### PR TITLE
Add NSFileProviderThumbnailing support for image files

### DIFF
--- a/DS3DriveProvider/FileProviderExtension.swift
+++ b/DS3DriveProvider/FileProviderExtension.swift
@@ -1063,13 +1063,13 @@ extension FileProviderExtension {
                 progress.completedUnitCount += 1
             }
 
-            guard guard_.tryAcquire() else { return }
+            guard guard_.tryCall() else { return }
             cb.handler(nil)
         }
 
         progress.cancellationHandler = {
             task.cancel()
-            guard guard_.tryAcquire() else { return }
+            guard guard_.tryCall() else { return }
             cb.handler(NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError))
         }
 


### PR DESCRIPTION
## Summary
- Implement fetchThumbnails for common image types
- Use ImageIO for thread-safe thumbnail generation
- Register supported UTTypes for thumbnail requests