### PR TITLE
Add multipart upload resume support

### DIFF
--- a/DS3DriveProvider/S3Lib.swift
+++ b/DS3DriveProvider/S3Lib.swift
@@ -800,6 +800,12 @@ class S3Lib: @unchecked Sendable { // swiftlint:disable:this type_body_length
             return eTag
         } catch {
             self.logger.error("Multipart upload failed for key \(key, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            do {
+                try await self.abortS3MultipartUpload(for: s3Item, withUploadId: uploadId)
+            } catch {
+                self.logger.warning("Failed to abort multipart upload \(uploadId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+            await pendingUploadStore.remove(forKey: key)
             throw error
         }
     }

--- a/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
@@ -38,6 +38,9 @@ public actor PendingUploadStore {
         let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: DefaultSettings.appGroup
         )
+        if containerURL == nil {
+            logger.warning("App Group container unavailable, pending uploads will use temporary directory and won't survive restarts")
+        }
         self.fileURL = (containerURL ?? URL(fileURLWithPath: NSTemporaryDirectory()))
             .appendingPathComponent("pendingUploads.json")
         self.uploads = Self.loadFromDisk(url: self.fileURL)


### PR DESCRIPTION
## Summary
- Resume interrupted multipart uploads instead of restarting from scratch
- Track pending uploads via PendingUploadStore
- Filter already-completed parts when resuming
- Clean up pending state on success or failure

Continuation of #62 (parallel multipart uploads).