### PR TITLE
Add TestFlight and Homebrew Cask release workflows

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -1,0 +1,211 @@
+name: Release — Homebrew Cask
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  homebrew:
+    name: Archive, Notarize & Publish
+    runs-on: macos-15
+    if: "!contains(github.ref_name, '-')"
+
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"           # e.g. v1.5.0
+          MARKETING="${TAG#v}"               # 1.5.0
+          DMG_NAME="Cubbit-DS3-Drive-${MARKETING}.dmg"
+          echo "marketing=$MARKETING" >> "$GITHUB_OUTPUT"
+          echo "build=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "dmg_name=$DMG_NAME" >> "$GITHUB_OUTPUT"
+          echo "Marketing version: $MARKETING"
+          echo "Build number: ${{ github.run_number }}"
+          echo "DMG name: $DMG_NAME"
+
+      - name: Create temporary keychain
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Import certificate
+        env:
+          DEVELOPER_ID_P12: ${{ secrets.DEVELOPER_ID_P12 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/developer_id.p12"
+          echo "$DEVELOPER_ID_P12" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$DEVELOPER_ID_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+      - name: Install provisioning profiles
+        env:
+          DEVID_PROFILE_APP: ${{ secrets.DEVID_PROFILE_APP }}
+          DEVID_PROFILE_EXTENSION: ${{ secrets.DEVID_PROFILE_EXTENSION }}
+        run: |
+          PROFILES_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILES_DIR"
+          echo "$DEVID_PROFILE_APP" | base64 --decode > "$PROFILES_DIR/DS3Drive_DeveloperID.mobileprovision"
+          echo "$DEVID_PROFILE_EXTENSION" | base64 --decode > "$PROFILES_DIR/DS3DriveProvider_DeveloperID.mobileprovision"
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project DS3Drive.xcodeproj \
+            -scheme DS3Drive
+
+      - name: Archive
+        run: |
+          xcodebuild archive \
+            -project DS3Drive.xcodeproj \
+            -scheme DS3Drive \
+            -destination 'platform=macOS' \
+            -archivePath "$RUNNER_TEMP/DS3Drive.xcarchive" \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            MARKETING_VERSION="${{ steps.version.outputs.marketing }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build }}"
+
+      - name: Export archive
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/DS3Drive.xcarchive" \
+            -exportOptionsPlist ExportOptions-developer-id.plist \
+            -exportPath "$RUNNER_TEMP/export"
+
+      - name: Write App Store Connect API key
+        env:
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          echo "$ASC_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+      - name: Notarize app
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          APP_PATH="$RUNNER_TEMP/export/Cubbit DS3 Drive.app"
+
+          ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/DS3Drive-notarize.zip"
+
+          xcrun notarytool submit "$RUNNER_TEMP/DS3Drive-notarize.zip" \
+            --key "$RUNNER_TEMP/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
+            --key-id "$ASC_KEY_ID" \
+            --issuer "$ASC_ISSUER_ID" \
+            --wait
+
+          xcrun stapler staple "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+
+          rm -f "$RUNNER_TEMP/DS3Drive-notarize.zip"
+
+      - name: Create DMG
+        run: |
+          brew install create-dmg
+          chmod +x scripts/create-dmg.sh
+          ./scripts/create-dmg.sh \
+            "$RUNNER_TEMP/export/Cubbit DS3 Drive.app" \
+            "$RUNNER_TEMP/${{ steps.version.outputs.dmg_name }}"
+
+      - name: Notarize DMG
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          xcrun notarytool submit "$RUNNER_TEMP/${{ steps.version.outputs.dmg_name }}" \
+            --key "$RUNNER_TEMP/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
+            --key-id "$ASC_KEY_ID" \
+            --issuer "$ASC_ISSUER_ID" \
+            --wait
+
+          xcrun stapler staple "$RUNNER_TEMP/${{ steps.version.outputs.dmg_name }}"
+          xcrun stapler validate "$RUNNER_TEMP/${{ steps.version.outputs.dmg_name }}"
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          SHA=$(shasum -a 256 "$RUNNER_TEMP/${{ steps.version.outputs.dmg_name }}" | awk '{print $1}')
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "SHA256: $SHA"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ runner.temp }}/${{ steps.version.outputs.dmg_name }}
+          generate_release_notes: true
+
+      - name: Update Homebrew tap
+        env:
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+        run: |
+          VERSION="${{ steps.version.outputs.marketing }}"
+          SHA256="${{ steps.sha.outputs.sha256 }}"
+          REPO_OWNER="${{ github.repository_owner }}"
+          REPO_NAME="${{ github.event.repository.name }}"
+
+          git clone "https://x-access-token:${HOMEBREW_TAP_PAT}@github.com/${REPO_OWNER}/homebrew-tap.git" "$RUNNER_TEMP/homebrew-tap"
+          cd "$RUNNER_TEMP/homebrew-tap"
+
+          mkdir -p Casks
+
+          cat > Casks/ds3-drive.rb <<CASK
+          cask "ds3-drive" do
+            version "$VERSION"
+            sha256 "$SHA256"
+
+            url "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v#{version}/Cubbit-DS3-Drive-#{version}.dmg"
+            name "Cubbit DS3 Drive"
+            desc "Sync local files with Cubbit DS3 cloud storage"
+            homepage "https://github.com/${REPO_OWNER}/${REPO_NAME}"
+
+            depends_on macos: ">= :sequoia"
+
+            app "Cubbit DS3 Drive.app"
+
+            zap trash: [
+              "~/Library/Group Containers/group.X889956QSM.io.cubbit.DS3Drive",
+              "~/Library/Containers/io.cubbit.DS3Drive",
+              "~/Library/Containers/io.cubbit.DS3Drive.provider",
+              "~/Library/Caches/io.cubbit.DS3Drive",
+              "~/Library/Preferences/io.cubbit.DS3Drive.plist",
+            ]
+          end
+          CASK
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/ds3-drive.rb
+          git diff --staged --quiet || git commit -m "ds3-drive $VERSION"
+          git push
+
+      - name: Cleanup
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -rf "$RUNNER_TEMP/private_keys"
+          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/DS3Drive_DeveloperID.mobileprovision"
+          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/DS3DriveProvider_DeveloperID.mobileprovision"

--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -1,0 +1,117 @@
+name: Release — TestFlight
+
+on:
+  push:
+    tags:
+      - 'v*-alpha.*'
+      - 'v*-beta.*'
+
+jobs:
+  testflight:
+    name: Archive & Upload to TestFlight
+    runs-on: macos-15
+
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"           # e.g. v1.5.0-beta.1
+          MARKETING="${TAG#v}"               # 1.5.0-beta.1
+          MARKETING="${MARKETING%%-*}"       # 1.5.0
+          echo "marketing=$MARKETING" >> "$GITHUB_OUTPUT"
+          echo "build=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "Marketing version: $MARKETING"
+          echo "Build number: ${{ github.run_number }}"
+
+      - name: Create temporary keychain
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Import certificate
+        env:
+          APPLE_DISTRIBUTION_P12: ${{ secrets.APPLE_DISTRIBUTION_P12 }}
+          APPLE_DISTRIBUTION_P12_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_P12_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/apple_distribution.p12"
+          echo "$APPLE_DISTRIBUTION_P12" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_DISTRIBUTION_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+      - name: Install provisioning profiles
+        env:
+          APPSTORE_PROFILE_APP: ${{ secrets.APPSTORE_PROFILE_APP }}
+          APPSTORE_PROFILE_EXTENSION: ${{ secrets.APPSTORE_PROFILE_EXTENSION }}
+        run: |
+          PROFILES_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILES_DIR"
+          echo "$APPSTORE_PROFILE_APP" | base64 --decode > "$PROFILES_DIR/DS3Drive_AppStore.mobileprovision"
+          echo "$APPSTORE_PROFILE_EXTENSION" | base64 --decode > "$PROFILES_DIR/DS3DriveProvider_AppStore.mobileprovision"
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project DS3Drive.xcodeproj \
+            -scheme DS3Drive
+
+      - name: Archive
+        run: |
+          xcodebuild archive \
+            -project DS3Drive.xcodeproj \
+            -scheme DS3Drive \
+            -destination 'platform=macOS' \
+            -archivePath "$RUNNER_TEMP/DS3Drive.xcarchive" \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            MARKETING_VERSION="${{ steps.version.outputs.marketing }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build }}"
+
+      - name: Write App Store Connect API key
+        env:
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          echo "$ASC_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+      - name: Export & Upload to TestFlight
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/DS3Drive.xcarchive" \
+            -exportOptionsPlist ExportOptions-appstore.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+            -allowProvisioningUpdates
+
+      - name: Cleanup
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -rf "$RUNNER_TEMP/private_keys"
+          rm -rf "$HOME/Library/MobileDevice/Provisioning Profiles/DS3Drive_AppStore.mobileprovision"
+          rm -rf "$HOME/Library/MobileDevice/Provisioning Profiles/DS3DriveProvider_AppStore.mobileprovision"

--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -990,7 +990,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DS3Drive/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "DS3 Drive";
+				INFOPLIST_KEY_CFBundleDisplayName = "Cubbit DS3 Drive";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_LSUIElement = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -1010,7 +1010,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.cubbit.DS3Drive;
-				PRODUCT_NAME = "DS3 Drive";
+				PRODUCT_NAME = "Cubbit DS3 Drive";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = macosx;
@@ -1039,7 +1039,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DS3Drive/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "DS3 Drive";
+				INFOPLIST_KEY_CFBundleDisplayName = "Cubbit DS3 Drive";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_LSUIElement = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -1059,7 +1059,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = io.cubbit.DS3Drive;
-				PRODUCT_NAME = "DS3 Drive";
+				PRODUCT_NAME = "Cubbit DS3 Drive";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = macosx;

--- a/DS3Drive/Assets/Localizable.xcstrings
+++ b/DS3Drive/Assets/Localizable.xcstrings
@@ -316,13 +316,13 @@
         }
       }
     },
-    "DS3 Drive" : {
+    "Cubbit DS3 Drive" : {
       "comment" : "Auth failure notification title",
       "localizations" : {
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DS3 Drive"
+            "value" : "Cubbit DS3 Drive"
           }
         }
       }

--- a/DS3Drive/DS3DriveApp.swift
+++ b/DS3Drive/DS3DriveApp.swift
@@ -247,7 +247,7 @@ struct DS3DriveApp: App {
 
     private static func showSessionExpiredNotification(logger: Logger) {
         let content = UNMutableNotificationContent()
-        content.title = NSLocalizedString("DS3 Drive", comment: "Auth failure notification title")
+        content.title = NSLocalizedString("Cubbit DS3 Drive", comment: "Auth failure notification title")
         content.body = NSLocalizedString("Session expired -- sign in to resume syncing", comment: "Auth failure notification body")
         content.sound = .default
 

--- a/DS3Drive/Views/Login/Views/LoginView.swift
+++ b/DS3Drive/Views/Login/Views/LoginView.swift
@@ -35,7 +35,7 @@ struct LoginView: View {
                         .resizable()
                         .frame(width: 120, height: 44)
 
-                    Text("DS3 Drive")
+                    Text("Cubbit DS3 Drive")
                         .font(DS3Typography.caption)
                         .foregroundStyle(DS3Colors.secondaryText)
 

--- a/DS3DriveProvider/Info.plist
+++ b/DS3DriveProvider/Info.plist
@@ -98,7 +98,7 @@
 	<key>NSFileProviderDomain</key>
 	<dict>
 		<key>NSFileProviderDomainDisplayName</key>
-		<string>DS3 Drive</string>
+		<string>Cubbit DS3 Drive</string>
 	</dict>
 	<key>CFBundleIcons</key>
 	<dict>

--- a/ExportOptions-appstore.plist
+++ b/ExportOptions-appstore.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>destination</key>
+	<string>upload</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>io.cubbit.DS3Drive</key>
+		<string>DS3Drive AppStore</string>
+		<key>io.cubbit.DS3Drive.provider</key>
+		<string>DS3DriveProvider AppStore</string>
+	</dict>
+</dict>
+</plist>

--- a/ExportOptions-developer-id.plist
+++ b/ExportOptions-developer-id.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>io.cubbit.DS3Drive</key>
+		<string>DS3Drive Developer ID</string>
+		<key>io.cubbit.DS3Drive.provider</key>
+		<string>DS3DriveProvider Developer ID</string>
+	</dict>
+</dict>
+</plist>

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: create-dmg.sh <app-path> <output-dmg-path> [volume-name]
+# Example: create-dmg.sh "build/Cubbit DS3 Drive.app" "build/Cubbit-DS3-Drive-1.5.0.dmg" "Cubbit DS3 Drive"
+
+APP_PATH="${1:?Usage: create-dmg.sh <app-path> <output-dmg-path> [volume-name]}"
+OUTPUT_DMG="${2:?Usage: create-dmg.sh <app-path> <output-dmg-path> [volume-name]}"
+VOLUME_NAME="${3:-Cubbit DS3 Drive}"
+
+if [ ! -d "$APP_PATH" ]; then
+    echo "Error: App not found at $APP_PATH" >&2
+    exit 1
+fi
+
+command -v create-dmg >/dev/null 2>&1 || {
+    echo "Error: create-dmg not found. Install with: brew install create-dmg" >&2
+    exit 1
+}
+
+rm -f "$OUTPUT_DMG"
+
+APP_NAME=$(basename "$APP_PATH")
+
+create-dmg \
+    --volname "$VOLUME_NAME" \
+    --window-pos 200 120 \
+    --window-size 660 400 \
+    --icon-size 160 \
+    --icon "$APP_NAME" 160 185 \
+    --hide-extension "$APP_NAME" \
+    --app-drop-link 500 185 \
+    "$OUTPUT_DMG" \
+    "$APP_PATH"


### PR DESCRIPTION
## Summary
- Add `release-testflight.yml` workflow: archive + upload to TestFlight on pre-release tags (`v*-alpha.*`, `v*-beta.*`)
- Add `release-homebrew.yml` workflow: archive + notarize + DMG + GitHub Release + homebrew-tap update on stable tags (`v*`)
- Add `ExportOptions-appstore.plist` and `ExportOptions-developer-id.plist` for manual signing
- Add `scripts/create-dmg.sh` helper for DMG creation

## Test plan
- [ ] Push `v1.5.0-beta.1` tag → verify TestFlight workflow succeeds and build appears in App Store Connect
- [ ] Push `v1.5.0` tag → verify Homebrew workflow: GitHub Release has DMG, `ds3-drive.rb` updated in tap
- [ ] Verify existing `build.yml` (lint + unsigned build) still runs on push to main