### PR TITLE
fix(tutorial): update onboarding slides to reflect current UI

### DIFF
--- a/DS3Drive/Views/Tutorial/ViewModels/TutorialViewModel.swift
+++ b/DS3Drive/Views/Tutorial/ViewModels/TutorialViewModel.swift
@@ -15,7 +15,7 @@ class TutorialViewModel: ObservableObject {
         }
     }
     
-    func isLastSlide() -> Bool {
-        return currentSlideIndex == slides.count - 1
+    var isLastSlide: Bool {
+        currentSlideIndex == slides.count - 1
     }
 }

--- a/DS3Drive/Views/Tutorial/Views/TutorialView.swift
+++ b/DS3Drive/Views/Tutorial/Views/TutorialView.swift
@@ -4,105 +4,97 @@ import DS3Lib
 struct TutorialProgress: View {
     var totalSlides: Int
 
-    @Binding var currentSlide: Int
-
-    @State var isHovering: Bool = false
+    @Binding var currentSlideIndex: Int
 
     var body: some View {
-        ForEach((0...totalSlides - 1), id: \.self) { index in
-            Circle()
-                .fill(index == currentSlide ? Color(nsColor: .separatorColor) : Color(nsColor: .controlBackgroundColor))
-                .frame(width: 8, height: 8)
-                .onHover { hovering in
-                    isHovering = hovering
-                }
-                .onChange(of: isHovering) {
-                    DispatchQueue.main.async {
-                        if isHovering {
+        HStack {
+            ForEach(0..<totalSlides, id: \.self) { index in
+                Circle()
+                    .fill(index == currentSlideIndex ? Color(nsColor: .separatorColor) : Color(nsColor: .controlBackgroundColor))
+                    .frame(width: 8, height: 8)
+                    .onHover { hovering in
+                        if hovering {
                             NSCursor.pointingHand.push()
                         } else {
                             NSCursor.pop()
                         }
                     }
-                }
-                .onTapGesture {
-                    currentSlide = index
-                }
+                    .onTapGesture {
+                        currentSlideIndex = index
+                    }
+            }
+
+            Spacer()
         }
     }
 }
 
 struct TutorialView: View {
-    @StateObject var vm: TutorialViewModel = TutorialViewModel(
+    // TODO: Replace tutorial images (Tutorial1, Tutorial2, Tutorial3) with new screenshots matching the current UI
+    // - Tutorial1: should show the new tree navigation view (Projects -> Buckets -> Folders sidebar + content panel)
+    // - Tutorial2: should show the new tray menu with status dots, speed metrics, and floating recent files panel
+    // - Tutorial3: should show drives in Finder sidebar with the current app icon
+    @StateObject private var vm = TutorialViewModel(
         slides: [
             Slide(
                 imageName: .tutorial1,
-                title: "Sync a DS3 bucket with a virtual drive in your Finder",
-                paragraph: "Select a DS3 Bucket from one of your projects and start syncing your files. You can also choose to sync only specific folders"
+                title: "Browse and sync your DS3 storage",
+                paragraph: "Navigate your projects, buckets, and folders in a single tree view. Pick exactly what you want to sync and create a virtual drive in your Finder"
             ),
             Slide(
                 imageName: .tutorial2,
-                title: "Manage up to 3 drives from the tray menu",
-                paragraph: "From the DS3 Drive tray menu you can manage up to 3 drives. You can add or remove drives and change their settings"
+                title: "Monitor your drives from the menu bar",
+                paragraph: "Keep track of sync status, transfer speed, and recent files at a glance. Manage up to 3 drives with pause, refresh, and reset controls"
             ),
             Slide(
                 imageName: .tutorial3,
                 title: "Access your files from the Finder",
-                paragraph: "Use the tool you are familiar with to access your files stored on Cubbit DS3. With DS3 Drive you can create a virtual drive to sync your files, without having to download them locally"
+                paragraph: "Your DS3 storage appears as a native drive in Finder. Open, edit, and organize your cloud files without downloading them first"
             )
         ]
     )
 
     @AppStorage(DefaultSettings.UserDefaultsKeys.tutorial) var tutorialShown: Bool = DefaultSettings.tutorialShown
 
+    private var currentSlide: Slide {
+        vm.slides[vm.currentSlideIndex]
+    }
+
     var body: some View {
         HStack {
-            Image(vm.slides[vm.currentSlideIndex].imageName)
+            Image(currentSlide.imageName)
                 .ignoresSafeArea()
 
-                VStack(alignment: .leading) {
-                    Text(vm.slides[vm.currentSlideIndex].title)
-                        .font(DS3Typography.headline)
-                        .fontWeight(.bold)
+            VStack(alignment: .leading) {
+                Text(currentSlide.title)
+                    .font(DS3Typography.headline)
+                    .fontWeight(.bold)
 
-                    Text(vm.slides[vm.currentSlideIndex].paragraph)
-                        .font(DS3Typography.body)
-                        .padding(.vertical)
-
-                    if vm.isLastSlide() {
-                        Button("Sync Projects") {
-                            tutorialShown = true
-                        }
-                        .padding(.vertical)
-                        .buttonStyle(PrimaryButtonStyle())
-                    } else {
-                        Button("Next") {
-                            vm.nextSlide()
-                        }
-                        .padding(.vertical)
-                        .buttonStyle(PrimaryButtonStyle())
-                    }
-
-                    HStack {
-                        TutorialProgress(
-                            totalSlides: vm.slides.count,
-                            currentSlide: $vm.currentSlideIndex
-                        )
-
-                        Spacer()
-                    }
+                Text(currentSlide.paragraph)
+                    .font(DS3Typography.body)
                     .padding(.vertical)
+
+                Button(vm.isLastSlide ? "Get Started" : "Next") {
+                    if vm.isLastSlide {
+                        tutorialShown = true
+                    } else {
+                        vm.nextSlide()
+                    }
                 }
-                .frame(minWidth: 272)
-                .padding()
-                .padding(.horizontal)
+                .padding(.vertical)
+                .buttonStyle(PrimaryButtonStyle())
+
+                TutorialProgress(
+                    totalSlides: vm.slides.count,
+                    currentSlideIndex: $vm.currentSlideIndex
+                )
+                .padding(.vertical)
+            }
+            .frame(minWidth: 272)
+            .padding()
+            .padding(.horizontal)
         }
-        .frame(
-            minWidth: 800,
-            maxWidth: 800,
-            minHeight: 450,
-            maxHeight: 450
-        )
+        .frame(width: 800, height: 450)
     }
 }
 


### PR DESCRIPTION
## Summary

- Update tutorial slide text to match the current UI: tree navigation setup flow (slide 1), menu bar monitoring with status dots and controls (slide 2), simplified Finder integration description (slide 3)
- Change CTA button label from "Sync Projects" to "Get Started"
- Refactor TutorialView: extract `currentSlide` computed property, consolidate button logic, simplify frame modifier, clean up `TutorialProgress` (remove unnecessary `@State`, move layout inside component, rename binding)
- Convert `isLastSlide()` method to computed property
- Add TODO placeholders for replacing the 3 tutorial screenshot assets

## Test plan

- [x] SwiftLint passes with 0 violations (strict mode)
- [x] `xcodebuild clean build analyze` succeeds
- [ ] Manually verify tutorial flow: slide navigation, dot indicators, "Next" / "Get Started" button behavior
- [ ] Verify Xcode preview renders correctly for `TutorialView`