### PR TITLE
fix: apply drive prefix in rename+move operation

### DIFF
--- a/DS3DriveProvider/FileProviderExtension.swift
+++ b/DS3DriveProvider/FileProviderExtension.swift
@@ -821,6 +821,11 @@ class FileProviderExtension: NSObject, @preconcurrency NSFileProviderReplicatedE
                         newKey += delimiter
                     }
 
+                    // Apply drive prefix if needed
+                    if let prefix = drive.syncAnchor.prefix, !newKey.starts(with: prefix) {
+                        newKey = prefix + newKey
+                    }
+
                     let movedS3Item = try await s3Lib.moveS3Item(s3Item, toKey: newKey, withProgress: progress)
 
                     try? await self.metadataStore?.deleteItem(byKey: oldKey, driveId: drive.id)


### PR DESCRIPTION
## Summary
- The rename+move code path in `modifyItem` was missing drive prefix logic, causing objects on prefixed drives to be written to the wrong S3 path when simultaneously renamed and moved
- The pure move path already had the fix — this adds the same prefix guard to the combined rename+move branch

Closes #18