### PR TITLE
fix(sync): stop infinite reconciliation loop and debounce tray icon

### DIFF
--- a/DS3Lib/Sources/DS3Lib/AppStatusManager.swift
+++ b/DS3Lib/Sources/DS3Lib/AppStatusManager.swift
@@ -2,14 +2,31 @@ import SwiftUI
 import os.log
 
 /// Manages the global status of the app, displayed in the menu bar tray icon.
+///
+/// Enforces a minimum active duration: once the status becomes syncing/indexing,
+/// it must remain active for at least `minActiveDuration` seconds before
+/// transitioning to idle. This prevents the tray icon from flashing.
 @Observable public final class AppStatusManager: @unchecked Sendable {
     private static let instance = AppStatusManager()
 
     @ObservationIgnored
     private let logger = Logger(subsystem: LogSubsystem.app, category: LogCategory.app.rawValue)
 
+    /// Minimum time (seconds) the status must stay in syncing/indexing before
+    /// it can transition to idle. Prevents rapid icon flashing.
+    @ObservationIgnored
+    private let minActiveDuration: TimeInterval = 3.0
+
+    /// When the status last entered an active state (syncing/indexing).
+    @ObservationIgnored
+    private var lastActiveTime: Date?
+
+    /// Timer for deferred idle transitions.
+    @ObservationIgnored
+    private var pendingIdleTimer: Timer?
+
     /// The current app status (idle, syncing, error, offline, info)
-    public var status: AppStatus = .idle
+    public private(set) var status: AppStatus = .idle
 
     private init() {}
 
@@ -17,5 +34,42 @@ import os.log
     /// - Returns: the default instance of the AppStatusManager.
     public static func `default`() -> AppStatusManager {
         return instance
+    }
+
+    /// Updates the global app status.
+    ///
+    /// Active states (syncing/indexing) are applied immediately and reset the
+    /// minimum-active timer. Idle transitions are held until `minActiveDuration`
+    /// has elapsed since the last active state, preventing tray icon flicker.
+    public func setStatus(_ newStatus: AppStatus) {
+        pendingIdleTimer?.invalidate()
+        pendingIdleTimer = nil
+
+        switch newStatus {
+        case .syncing, .indexing:
+            lastActiveTime = Date()
+            status = newStatus
+        case .idle:
+            guard let activeTime = lastActiveTime else {
+                status = .idle
+                return
+            }
+            let elapsed = Date().timeIntervalSince(activeTime)
+            let remaining = minActiveDuration - elapsed
+            if remaining <= 0 {
+                status = .idle
+                lastActiveTime = nil
+            } else {
+                pendingIdleTimer = Timer.scheduledTimer(withTimeInterval: remaining, repeats: false) { [weak self] _ in
+                    guard let self else { return }
+                    self.status = .idle
+                    self.lastActiveTime = nil
+                }
+            }
+        default:
+            // error, offline, info, paused — apply immediately
+            lastActiveTime = nil
+            status = newStatus
+        }
     }
 }

--- a/DS3Lib/Sources/DS3Lib/DS3DriveManager.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3DriveManager.swift
@@ -75,10 +75,10 @@ public enum DS3DriveManagerError: Error {
         switch updateDriveStatusNotification.status {
         case .sync:
             self.syncingDrives.insert(driveId)
-            AppStatusManager.default().status = .syncing
+            AppStatusManager.default().setStatus(.syncing)
         case .indexing:
             self.syncingDrives.insert(driveId)
-            AppStatusManager.default().status = .indexing
+            AppStatusManager.default().setStatus(.indexing)
         default:
             // Debounce removal: wait 2s before marking this drive as idle
             self.idleDebounceTimers[driveId] = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
@@ -86,7 +86,7 @@ public enum DS3DriveManagerError: Error {
                 self.syncingDrives.remove(driveId)
                 self.idleDebounceTimers.removeValue(forKey: driveId)
                 if self.syncingDrives.isEmpty {
-                    AppStatusManager.default().status = .idle
+                    AppStatusManager.default().setStatus(.idle)
                 }
             }
         }

--- a/DS3Lib/Sources/DS3Lib/Sync/SyncEngine.swift
+++ b/DS3Lib/Sources/DS3Lib/Sync/SyncEngine.swift
@@ -196,7 +196,13 @@ public actor SyncEngine {
         remoteItems: [String: S3ObjectInfo],
         localEtags: [String: String?]
     ) -> Set<String> {
-        Set(commonKeys.filter { key in
+        let delimiter = String(DefaultSettings.S3.delimiter)
+        return Set(commonKeys.filter { key in
+            // Folders don't have meaningful ETags in S3 — skip them.
+            // The BFS indexer (non-recursive) and SyncEngine (recursive) store
+            // different ETags for folders, causing infinite reconciliation.
+            guard !key.hasSuffix(delimiter) else { return false }
+
             let remoteEtag = remoteItems[key]?.etag
             let localEtag = localEtags[key].flatMap { $0 }
             return remoteEtag != localEtag


### PR DESCRIPTION
## Summary
- **Skip folder keys in `SyncEngine.computeModifiedKeys`** — S3 folders have no meaningful ETags. The BFS indexer (non-recursive listing) and SyncEngine (recursive listing) stored different ETag values for the same folder keys, causing every reconciliation cycle to detect ~27 phantom "modified" items that never converge to 0.
- **Add minimum-active-duration debounce (3s) in `AppStatusManager`** — once the tray icon enters syncing/indexing, it stays there for at least 3 seconds before transitioning to idle, preventing rapid icon flashing/flickering.
- **Route all status updates through `AppStatusManager.setStatus(_:)`** instead of direct property assignment, so the debounce is enforced consistently.

## Test plan
- [x] All 136 DS3Lib tests pass (`swift test --package-path DS3Lib`)
- [x] `xcodebuild build -scheme DS3Drive` succeeds
- [ ] Run app → observe logs: reconciliation should converge to `0 new, 0 modified, 0 deleted` after first pass
- [ ] Tray icon should settle to idle without flickering