### PR TITLE
fix(ci): replace deprecated altool with xcodebuild upload

### DIFF
--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -131,31 +131,19 @@ jobs:
           mkdir -p ~/private_keys
           echo "$ASC_API_KEY_P8" | base64 --decode > ~/private_keys/AuthKey_${ASC_KEY_ID}.p8
 
-      - name: Export archive
-        run: |
-          # Export locally without uploading
-          EXPORT_PLIST="$RUNNER_TEMP/ExportOptions.plist"
-          cp ExportOptions-appstore.plist "$EXPORT_PLIST"
-          /usr/libexec/PlistBuddy -c "Set :destination export" "$EXPORT_PLIST"
-
-          xcodebuild -exportArchive \
-            -archivePath "$RUNNER_TEMP/DS3Drive.xcarchive" \
-            -exportOptionsPlist "$EXPORT_PLIST" \
-            -exportPath "$RUNNER_TEMP/export"
-
-          echo "Exported artifacts:"
-          ls -lh "$RUNNER_TEMP/export/"
-
-      - name: Upload to TestFlight
+      - name: Export & upload to TestFlight
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
-          xcrun altool --upload-app \
-            -f "$RUNNER_TEMP/export/"*.pkg \
-            -t macos \
-            --apiKey "$ASC_KEY_ID" \
-            --apiIssuer "$ASC_ISSUER_ID"
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/DS3Drive.xcarchive" \
+            -exportOptionsPlist ExportOptions-appstore.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/private_keys/AuthKey_${ASC_KEY_ID}.p8 \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Summary
- **Replace `xcrun altool --upload-app`** with `xcodebuild -exportArchive` using API key auth flags — `altool` is deprecated since Xcode 14 and hangs/times out on Xcode 16.2 CI runners
- **Remove the `destination = export` override** — `ExportOptions-appstore.plist` already has `destination = upload`, so `xcodebuild` handles both export and upload in a single step
- **Merge "Export" and "Upload" steps** into one, simplifying the workflow

## Root cause
The previous workflow overrode the plist destination to `export` (local only), then used the deprecated `altool` for a separate upload step. On macOS 15 / Xcode 16.2, `altool` hangs indefinitely, causing the 30-minute timeout.

## Test plan
- [ ] Push a tag matching `v*-beta.*` and verify the workflow completes without timeout
- [ ] Verify the build appears in App Store Connect / TestFlight