### PR TITLE
feat: throttle auth failure recovery notifications

### DIFF
--- a/DS3Drive/DS3DriveApp.swift
+++ b/DS3Drive/DS3DriveApp.swift
@@ -19,6 +19,7 @@ struct DS3DriveApp: App {
     @State var ds3DriveManager: DS3DriveManager = .init(appStatusManager: AppStatusManager.default())
     private let conflictNotificationHandler = ConflictNotificationHandler()
     private var authFailureObserver: NSObjectProtocol?
+    private let recoveryTracker = AuthRecoveryTracker()
     @State private var refreshTask: Task<Void, Never>?
 
     @State var trayMenuVisible: Bool = true
@@ -163,7 +164,7 @@ struct DS3DriveApp: App {
             forName: NSNotification.Name(DefaultSettings.Notifications.authFailure),
             object: nil,
             queue: .main
-        ) { [weak ds3Authentication, ds3DriveManager, logger] notification in
+        ) { [weak ds3Authentication, ds3DriveManager, logger, recoveryTracker] notification in
             let domainId = notification.object as? String
             let reason = (notification.userInfo as? [String: String])?["reason"]
 
@@ -182,6 +183,15 @@ struct DS3DriveApp: App {
                     Self.showSessionExpiredNotification(logger: logger)
                     return
                 }
+
+                // Skip if recovery is already in progress for this domain
+                guard !recoveryTracker.activeRecoveries.contains(domainId) else {
+                    logger.info("Auth recovery already in progress for domain \(domainId, privacy: .public), skipping")
+                    return
+                }
+
+                recoveryTracker.activeRecoveries.insert(domainId)
+                defer { recoveryTracker.activeRecoveries.remove(domainId) }
 
                 do {
                     guard let drive = ds3DriveManager.drives.first(where: { $0.id.uuidString == domainId }) else {
@@ -238,4 +248,11 @@ struct DS3DriveApp: App {
             }
         }
     }
+}
+
+/// Tracks in-flight auth recovery operations per File Provider domain.
+/// Only accessed from @MainActor context (notification observer + Task).
+@MainActor
+private final class AuthRecoveryTracker: @unchecked Sendable {
+    var activeRecoveries: Set<String> = []
 }

--- a/DS3DriveProvider/NotificationsManager.swift
+++ b/DS3DriveProvider/NotificationsManager.swift
@@ -13,6 +13,7 @@ actor NotificationManager {
     private var lastTransferSpeedTime: ContinuousClock.Instant = .now - .seconds(999)
     private var pendingTransferStats: DriveTransferStats?
     private var transferThrottleTask: Task<Void, Never>?
+    private var lastAuthFailureTime: ContinuousClock.Instant = .now - .seconds(999)
 
     /// Tracks the number of in-flight file operations (fetch, create, modify, delete).
     /// Each immediate `.sync` increments; each debounced `.idle`/`.error` decrements.
@@ -144,6 +145,17 @@ actor NotificationManager {
     ///   - domainId: The File Provider domain identifier
     ///   - reason: A machine-readable reason string (e.g. "tokenRefreshFailed", "apiKeySelfHealingFailed")
     func sendAuthFailureNotification(domainId: String, reason: String) {
+        let now = ContinuousClock.now
+        let elapsed = now - lastAuthFailureTime
+        let elapsedSeconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
+
+        if elapsedSeconds < DefaultSettings.Extension.authFailureCooldownSeconds {
+            logger.info("Auth failure notification suppressed (cooldown): domain=\(domainId, privacy: .public), reason=\(reason, privacy: .public)")
+            return
+        }
+
+        lastAuthFailureTime = now
+
         Task { [ipcService] in
             await ipcService.postAuthFailure(domainId: domainId, reason: reason)
         }

--- a/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
@@ -109,6 +109,10 @@ public enum DefaultSettings {
         /// Limits how often the tray UI refreshes during streaming downloads/uploads.
         public static let transferSpeedThrottleInterval = 0.5
 
+        /// Minimum interval between auth failure notifications from the same drive (seconds).
+        /// Prevents repeated S3 auth failures within one extension from flooding the main app.
+        public static let authFailureCooldownSeconds = 30.0
+
         /// Interval in seconds between periodic remote change polling signals.
         public static let pollingIntervalSeconds: Int = 30
     }


### PR DESCRIPTION
## Summary

- Suppress duplicate auth failure notifications with configurable cooldown (`authFailureCooldownSeconds`) to prevent notification storms during token refresh failures

## Test plan

- [x] Trigger auth failure — verify notification appears once
- [x] Trigger multiple auth failures within cooldown — verify no duplicate notifications
- [x] Wait for cooldown to expire and trigger again — verify notification reappears