### PR TITLE
fix: improve startup sync and cache warm-up for File Provider extension

### DIFF
--- a/DS3DriveProvider/BreadthFirstIndexer.swift
+++ b/DS3DriveProvider/BreadthFirstIndexer.swift
@@ -110,8 +110,21 @@ final class BreadthFirstIndexer: @unchecked Sendable {
 
                 } while continuationToken != nil
 
-                if let metadataStore, !upsertBatch.isEmpty {
-                    try await metadataStore.batchUpsertItems(upsertBatch)
+                if let metadataStore {
+                    if !upsertBatch.isEmpty {
+                        try await metadataStore.batchUpsertItems(upsertBatch)
+                    }
+
+                    // Prune cached items no longer in S3 for this folder.
+                    // Runs even when upsertBatch is empty (folder fully emptied on S3).
+                    let keepKeys = Set(upsertBatch.map(\.s3Key))
+                    let drivePrefix = drive.syncAnchor.prefix ?? ""
+                    let parentKey: String? = (prefix == drivePrefix) ? nil : prefix
+                    try await metadataStore.pruneChildren(
+                        parentKey: parentKey,
+                        driveId: drive.id,
+                        keepKeys: keepKeys
+                    )
                 }
 
                 logger.debug("BFS indexed \(upsertBatch.count) items at prefix \(prefix.isEmpty ? "<root>" : prefix, privacy: .public)")

--- a/DS3DriveProvider/FileProviderExtension.swift
+++ b/DS3DriveProvider/FileProviderExtension.swift
@@ -159,7 +159,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
 
         super.init()
         self.startPolling()
-        self.startBFSIndexer()
+        self.warmCacheThenStartBFS()
 
         // If drive is paused, notify the main app so UI reflects the state
         if let driveId = self.drive?.id,
@@ -1175,6 +1175,79 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         }
     }
 
+    // MARK: - Cache Warm-up
+
+    /// Performs a single recursive S3 listing on startup to populate MetadataStore
+    /// before BFS starts. This turns all subsequent enumerateItems calls into
+    /// instant cache hits, avoiding the enumeration waterfall when the user
+    /// downloads a large folder tree.
+    private func warmCacheThenStartBFS() {
+        #if os(iOS)
+        // On iOS, skip warm-up — recursive listings spike memory and burn
+        // the networking grace period. Per-folder enumeration handles discovery.
+        return
+        #else
+        guard self.enabled,
+              let drive = self.drive,
+              let s3Lib = self.s3Lib,
+              let metadataStore = self.metadataStore else {
+            self.startBFSIndexer()
+            return
+        }
+
+        // Skip warm-up when drive is paused
+        if (try? SharedData.default().isDrivePaused(drive.id)) == true {
+            self.startBFSIndexer()
+            return
+        }
+
+        Task.detached(priority: .utility) { [weak self] in
+            let prefix = drive.syncAnchor.prefix
+            self?.logger.info("Cache warm-up: starting recursive listing for prefix \(prefix ?? "<root>", privacy: .public)")
+
+            do {
+                var continuationToken: String?
+                var allItems: [S3Item] = []
+
+                repeat {
+                    let (items, nextToken) = try await s3Lib.listS3Items(
+                        forDrive: drive,
+                        withPrefix: prefix,
+                        recursively: true,
+                        withContinuationToken: continuationToken
+                    )
+                    continuationToken = nextToken
+                    allItems.append(contentsOf: items)
+
+                    // Upsert each page incrementally so enumerateItems can
+                    // start serving partial results while we're still listing.
+                    let upsertData = items.map { MetadataStore.ItemUpsertData(from: $0) }
+                    try await metadataStore.batchUpsertItems(upsertData)
+                } while continuationToken != nil
+
+                // Synthesize virtual folders (recursive listing omits directory-only prefixes)
+                let virtualFolders = S3Enumerator.synthesizeVirtualFolders(
+                    from: allItems, drive: drive, prefix: prefix
+                )
+                if !virtualFolders.isEmpty {
+                    let folderData = virtualFolders.map { MetadataStore.ItemUpsertData(from: $0) }
+                    try await metadataStore.batchUpsertItems(folderData)
+                }
+
+                self?.logger.info("Cache warm-up complete: \(allItems.count) items + \(virtualFolders.count) virtual folders")
+
+                // Signal working set so fileproviderd picks up the warm cache
+                self?.signalChanges()
+            } catch {
+                self?.logger.error("Cache warm-up failed: \(error.localizedDescription, privacy: .public). Falling back to BFS.")
+            }
+
+            // Start BFS for ongoing cache maintenance after warm-up completes (or fails)
+            self?.startBFSIndexer()
+        }
+        #endif
+    }
+
     // MARK: - BFS Indexer
 
     private func startBFSIndexer() {
@@ -1217,6 +1290,10 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension, NSFile
         #endif
 
         let pollingInterval = DefaultSettings.Extension.pollingIntervalSeconds
+
+        // Signal immediately on startup so enumerateChanges/reconciliation
+        // runs right away — don't wait for the first polling interval.
+        self.signalChanges()
 
         self.pollingTask = Task { [weak self] in
             while !Task.isCancelled {

--- a/DS3DriveProvider/S3Enumerator.swift
+++ b/DS3DriveProvider/S3Enumerator.swift
@@ -353,6 +353,7 @@ class S3Enumerator: NSObject, NSFileProviderEnumerator, @unchecked Sendable {
 
             do {
                 var continuationToken: String?
+                var allKeys = Set<String>()
                 repeat {
                     let (items, nextToken) = try await s3Lib.listS3Items(
                         forDrive: drive,
@@ -363,8 +364,20 @@ class S3Enumerator: NSObject, NSFileProviderEnumerator, @unchecked Sendable {
                     continuationToken = nextToken
 
                     let upsertData = items.map { MetadataStore.ItemUpsertData(from: $0) }
+                    allKeys.formUnion(upsertData.lazy.map(\.s3Key))
                     try await metadataStore.batchUpsertItems(upsertData)
                 } while continuationToken != nil
+
+                // Remove cached items that are no longer in S3 (only synced items,
+                // preserving pending uploads and items in error/conflict state).
+                if !recursively {
+                    let parentKey: String? = parent == .rootContainer ? nil : parent.rawValue
+                    try await metadataStore.pruneChildren(
+                        parentKey: parentKey,
+                        driveId: drive.id,
+                        keepKeys: allKeys
+                    )
+                }
 
                 // On macOS, signal the specific folder container so Finder picks up
                 // the refreshed cache immediately. On iOS, skip the signal — it would

--- a/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore.swift
@@ -185,6 +185,34 @@ public actor MetadataStore {
         try context.save()
     }
 
+    /// Remove cached children of a folder that are no longer present in S3.
+    /// Only prunes items with `.synced` status — items being uploaded or in error are preserved.
+    public func pruneChildren(parentKey: String?, driveId: UUID, keepKeys: Set<String>) throws {
+        let context = modelExecutor.modelContext
+        let syncedStatus = SyncStatus.synced.rawValue
+        let items: [SyncedItem]
+
+        if let parentKey {
+            let predicate = #Predicate<SyncedItem> {
+                $0.driveId == driveId && $0.parentKey == parentKey && $0.syncStatus == syncedStatus
+            }
+            items = try context.fetch(FetchDescriptor<SyncedItem>(predicate: predicate))
+        } else {
+            let predicate = #Predicate<SyncedItem> {
+                $0.driveId == driveId && $0.parentKey == nil && $0.syncStatus == syncedStatus
+            }
+            items = try context.fetch(FetchDescriptor<SyncedItem>(predicate: predicate))
+        }
+
+        let staleItems = items.filter { !keepKeys.contains($0.s3Key) }
+        for item in staleItems {
+            context.delete(item)
+        }
+        if !staleItems.isEmpty {
+            try context.save()
+        }
+    }
+
     /// Delete a single SyncedItem by S3 key within a specific drive.
     public func deleteItem(byKey s3Key: String, driveId: UUID) throws {
         if let item = try findItem(byKey: s3Key, driveId: driveId) {


### PR DESCRIPTION
## Summary
- Signal `enumerateChanges` immediately on extension startup instead of waiting 30s
- Pre-warm MetadataStore cache with a single recursive S3 listing on startup, eliminating the per-folder enumeration waterfall when downloading large folder trees
- Prune stale MetadataStore entries in `refreshCacheInBackground` and BFS indexer so files deleted from S3 are removed from cache promptly
- Add `MetadataStore.pruneChildren` to remove cached items no longer present in S3 (only prunes `.synced` items, preserving pending uploads/errors)

Fixes #97

## Changes
- **FileProviderExtension.swift**: immediate `signalChanges()` on startup + `warmCacheThenStartBFS()` that does a recursive listing before starting BFS
- **S3Enumerator.swift**: `refreshCacheInBackground` now prunes stale children after upserting
- **BreadthFirstIndexer.swift**: prunes stale children after each folder pass, with correct `parentKey` alignment for prefixed drives
- **MetadataStore.swift**: new `pruneChildren(parentKey:driveId:keepKeys:)` method

## Test plan
- [x] Extension startup signals immediately — reconciliation runs without 30s delay
- [x] Cache warm-up populates MetadataStore (8308 items + 27 virtual folders in ~30s)
- [x] "Download" on a large folder starts faster with warm cache vs cold
- [x] Delete while app is off → fileproviderd replays delete on restart → propagates to S3
- [x] Periodic polling continues working for ongoing remote change detection