### PR TITLE
Move launch-at-login consent into tutorial (fixes #131)

### DIFF
--- a/DS3Drive/Assets/Localizable.xcstrings
+++ b/DS3Drive/Assets/Localizable.xcstrings
@@ -1424,6 +1424,60 @@
         }
       }
     },
+    "tutorial.loginItem.description" : {
+      "comment" : "Tutorial login-item slide description — consent copy",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DS3 Drive only syncs while it's running. Turn this on to have it start automatically when you log in. You can change this anytime in Preferences."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DS3 Drive sincronizza i file solo mentre è in esecuzione. Attiva questa opzione per avviarlo automaticamente all'accesso. Puoi cambiarla in qualsiasi momento nelle Preferenze."
+          }
+        }
+      }
+    },
+    "tutorial.loginItem.title" : {
+      "comment" : "Tutorial login-item slide title — consent prompt",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch DS3 Drive at login?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avviare DS3 Drive all'accesso?"
+          }
+        }
+      }
+    },
+    "tutorial.loginItem.toggle" : {
+      "comment" : "Tutorial login-item slide toggle label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start DS3 Drive at login"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avvia DS3 Drive all'accesso"
+          }
+        }
+      }
+    },
     "tutorial.slide7.description" : {
       "comment" : "Tutorial slide 7 description — Drive limit (UX-07)",
       "extractionState" : "manual",

--- a/DS3Drive/DS3DriveApp.swift
+++ b/DS3Drive/DS3DriveApp.swift
@@ -14,7 +14,6 @@ struct DS3DriveApp: App {
     private let metadataContainer: ModelContainer?
 
     @AppStorage(DefaultSettings.UserDefaultsKeys.tutorial) var tutorialShown: Bool = DefaultSettings.tutorialShown
-    @AppStorage(DefaultSettings.UserDefaultsKeys.loginItemSet) var loginItemSet: Bool = DefaultSettings.loginItemSet
 
     @State private var ds3Authentication: DS3Authentication
     @State private var appStatusManager: AppStatusManager = .default()
@@ -200,14 +199,6 @@ struct DS3DriveApp: App {
         } catch {
             self.metadataContainer = nil
             logger.error("Failed to initialize MetadataStore container: \(error.localizedDescription)")
-        }
-
-        if !loginItemSet {
-            do {
-                try setLoginItem(true)
-            } catch {
-                self.logger.error("An error occurred while setting the app as login item: \(error)")
-            }
         }
 
         // Request notification permission for conflict alerts (best-effort)

--- a/DS3Drive/Views/Tutorial/Models/SlideModel.swift
+++ b/DS3Drive/Views/Tutorial/Models/SlideModel.swift
@@ -14,7 +14,10 @@ import SwiftUI
 /// human reviewer at the human-verify checkpoint.
 struct Slide: Identifiable {
     let id: String
-    let imageName: String
+    /// Asset-catalog name for the hero screenshot. `nil` for slides
+    /// that render a different hero (e.g. the login-item consent slide
+    /// uses an SF Symbol instead of a screenshot).
+    let imageName: String?
     let titleKey: LocalizedStringKey
     let descriptionKey: LocalizedStringKey
 }

--- a/DS3Drive/Views/Tutorial/ViewModels/TutorialViewModel.swift
+++ b/DS3Drive/Views/Tutorial/ViewModels/TutorialViewModel.swift
@@ -45,7 +45,7 @@ class TutorialViewModel: ObservableObject {
         ),
         Slide(
             id: TutorialViewModel.loginItemSlideID,
-            imageName: "",
+            imageName: nil,
             titleKey: "tutorial.loginItem.title",
             descriptionKey: "tutorial.loginItem.description"
         )

--- a/DS3Drive/Views/Tutorial/ViewModels/TutorialViewModel.swift
+++ b/DS3Drive/Views/Tutorial/ViewModels/TutorialViewModel.swift
@@ -5,10 +5,12 @@ class TutorialViewModel: ObservableObject {
     @Published var currentSlideIndex: Int
     @Published var slides: [Slide]
 
-    /// Five-slide tutorial, one slide per distinct feature. IDs are
-    /// non-sequential (`slide-1`, `-2`, `-3`, `-5`, `-7`) because they
-    /// key into `Localizable.xcstrings` entries preserved from an earlier
-    /// seven-slide revision — do not renumber. Images live under
+    static let loginItemSlideID = "slide-login-item"
+
+    /// Five feature slides plus one trailing consent slide. Feature IDs
+    /// are non-sequential (`slide-1`, `-2`, `-3`, `-5`, `-7`) because
+    /// they key into `Localizable.xcstrings` entries preserved from an
+    /// earlier seven-slide revision — do not renumber. Images live under
     /// `DS3Drive/Assets/Assets.xcassets/tutorial/`.
     static let defaultSlides: [Slide] = [
         Slide(
@@ -40,6 +42,12 @@ class TutorialViewModel: ObservableObject {
             imageName: "tutorial-slide-7",
             titleKey: "tutorial.slide7.title",
             descriptionKey: "tutorial.slide7.description"
+        ),
+        Slide(
+            id: TutorialViewModel.loginItemSlideID,
+            imageName: "",
+            titleKey: "tutorial.loginItem.title",
+            descriptionKey: "tutorial.loginItem.description"
         )
     ]
 

--- a/DS3Drive/Views/Tutorial/Views/TutorialView.swift
+++ b/DS3Drive/Views/Tutorial/Views/TutorialView.swift
@@ -147,9 +147,10 @@ struct TutorialView: View {
     }
 
     /// Explicit consent gate for App Store Guideline 2.4.5(iii): the app
-    /// must not register as a login item without a user action. This is
-    /// the only place the tutorial updates the login item via `setLoginItem`.
-    /// The Preferences toggle is the other intentional entry point.
+    /// must not register as a login item at startup or without an explicit
+    /// user action. This is the tutorial's entry point; the Preferences
+    /// toggle is the other intentional, user-initiated entry point. No
+    /// other call site in the app invokes `setLoginItem`.
     private func applyLoginItemPreference() {
         let alreadyRegistered = DefaultSettings.appIsLoginItem
         guard startAtLoginEnabled != alreadyRegistered else { return }

--- a/DS3Drive/Views/Tutorial/Views/TutorialView.swift
+++ b/DS3Drive/Views/Tutorial/Views/TutorialView.swift
@@ -1,4 +1,5 @@
 import DS3Lib
+import os.log
 import SwiftUI
 
 struct TutorialProgress: View {
@@ -37,8 +38,39 @@ struct TutorialView: View {
 
     @AppStorage(DefaultSettings.UserDefaultsKeys.tutorial) var tutorialShown: Bool = DefaultSettings.tutorialShown
 
+    @State private var startAtLoginEnabled: Bool = DefaultSettings.appIsLoginItem
+
+    private let logger = Logger(subsystem: LogSubsystem.app, category: LogCategory.app.rawValue)
+
     private var currentSlide: Slide {
         vm.slides[vm.currentSlideIndex]
+    }
+
+    private var isLoginItemSlide: Bool {
+        currentSlide.id == TutorialViewModel.loginItemSlideID
+    }
+
+    @ViewBuilder private var slideHero: some View {
+        if isLoginItemSlide {
+            Image(systemName: "power.circle.fill")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 120, height: 120)
+                .foregroundStyle(DS3Colors.brandPrimary)
+        } else {
+            Image(currentSlide.imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: 560, maxHeight: 280)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(
+                            DS3Colors.brandPrimary.opacity(0.2),
+                            lineWidth: 1
+                        )
+                )
+        }
     }
 
     var body: some View {
@@ -53,19 +85,7 @@ struct TutorialView: View {
                 Spacer(minLength: DS3Spacing.lg)
 
                 VStack(alignment: .center, spacing: DS3Spacing.lg) {
-                    // Hero screenshot, bordered with the brand primary tint.
-                    Image(currentSlide.imageName)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxWidth: 560, maxHeight: 280)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .strokeBorder(
-                                    DS3Colors.brandPrimary.opacity(0.2),
-                                    lineWidth: 1
-                                )
-                        )
+                    slideHero
                         .shadow(color: .black.opacity(0.18), radius: 10, x: 0, y: 4)
                         .id(vm.currentSlideIndex)
                         .transition(.opacity.combined(with: .scale(scale: 0.98)))
@@ -85,8 +105,20 @@ struct TutorialView: View {
                             .frame(maxWidth: 520)
                     }
 
+                    if isLoginItemSlide {
+                        Toggle(isOn: $startAtLoginEnabled) {
+                            Text("tutorial.loginItem.toggle")
+                                .font(DS3Typography.body)
+                                .foregroundStyle(DS3Colors.brandTextPrimary)
+                        }
+                        .toggleStyle(.switch)
+                        .tint(DS3Colors.brandPrimary)
+                        .frame(maxWidth: 360)
+                    }
+
                     Button(vm.isLastSlide ? "Get Started" : "Next") {
                         if vm.isLastSlide {
+                            applyLoginItemPreference()
                             tutorialShown = true
                         } else {
                             withAnimation(.easeInOut(duration: 0.3)) {
@@ -110,6 +142,19 @@ struct TutorialView: View {
         }
         .frame(width: 720, height: 580)
         .animation(.easeInOut(duration: 0.3), value: vm.currentSlideIndex)
+    }
+
+    /// Explicit consent gate for App Store Guideline 2.4.5(iii): the app
+    /// must not register as a login item without a user action. This is
+    /// the only path that calls `setLoginItem`.
+    private func applyLoginItemPreference() {
+        let alreadyRegistered = DefaultSettings.appIsLoginItem
+        guard startAtLoginEnabled != alreadyRegistered else { return }
+        do {
+            try setLoginItem(startAtLoginEnabled)
+        } catch {
+            logger.error("Failed to update login item from tutorial: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/DS3Drive/Views/Tutorial/Views/TutorialView.swift
+++ b/DS3Drive/Views/Tutorial/Views/TutorialView.swift
@@ -57,8 +57,8 @@ struct TutorialView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 120, height: 120)
                 .foregroundStyle(DS3Colors.brandPrimary)
-        } else {
-            Image(currentSlide.imageName)
+        } else if let imageName = currentSlide.imageName {
+            Image(imageName)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(maxWidth: 560, maxHeight: 280)
@@ -146,7 +146,8 @@ struct TutorialView: View {
 
     /// Explicit consent gate for App Store Guideline 2.4.5(iii): the app
     /// must not register as a login item without a user action. This is
-    /// the only path that calls `setLoginItem`.
+    /// the only place the tutorial updates the login item via `setLoginItem`.
+    /// The Preferences toggle is the other intentional entry point.
     private func applyLoginItemPreference() {
         let alreadyRegistered = DefaultSettings.appIsLoginItem
         guard startAtLoginEnabled != alreadyRegistered else { return }

--- a/DS3Drive/Views/Tutorial/Views/TutorialView.swift
+++ b/DS3Drive/Views/Tutorial/Views/TutorialView.swift
@@ -114,6 +114,8 @@ struct TutorialView: View {
                         .toggleStyle(.switch)
                         .tint(DS3Colors.brandPrimary)
                         .frame(maxWidth: 360)
+                        .padding(.top, DS3Spacing.md)
+                        .padding(.bottom, DS3Spacing.xs)
                     }
 
                     Button(vm.isLastSlide ? "Get Started" : "Next") {

--- a/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
@@ -84,14 +84,17 @@ public enum DefaultSettings {
     /// The application build number as string. It is retrieved from the app bundle.
     public static let appBuild: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
 
-    /// Whether the app is set to start at login or not.
-    public static let appIsLoginItem: Bool = {
+    /// Whether the app is currently registered as a login item. Evaluated
+    /// on each access so Preferences and tutorial replay reflect changes
+    /// made within the same process (e.g. the user enables launch-at-login
+    /// from the tutorial and immediately opens Preferences).
+    public static var appIsLoginItem: Bool {
         #if os(macOS)
             return SMAppService().status == .enabled
         #else
             return false
         #endif
-    }()
+    }
 
     /// Settings related to the tray menu.
     public enum Tray {

--- a/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
@@ -84,13 +84,20 @@ public enum DefaultSettings {
     /// The application build number as string. It is retrieved from the app bundle.
     public static let appBuild: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
 
-    /// Whether the app is currently registered as a login item. Evaluated
+    /// Whether the user has opted the app into launch-at-login. Evaluated
     /// on each access so Preferences and tutorial replay reflect changes
-    /// made within the same process (e.g. the user enables launch-at-login
-    /// from the tutorial and immediately opens Preferences).
+    /// made within the same process. Returns true for both `.enabled`
+    /// and `.requiresApproval` — the latter means the user registered
+    /// but still needs to confirm in System Settings → Login Items. In
+    /// both cases the user has consented and the UI should reflect that.
     public static var appIsLoginItem: Bool {
         #if os(macOS)
-            return SMAppService().status == .enabled
+            switch SMAppService().status {
+            case .enabled, .requiresApproval:
+                return true
+            default:
+                return false
+            }
         #else
             return false
         #endif


### PR DESCRIPTION
## Summary

Apple rejected build 1.7.0 (28) under **Guideline 2.4.5(iii) – Performance** because the app auto-registered itself as a login item on first launch without explicit user consent.

This PR fixes the rejection:

- Removes the auto-register block from `DS3DriveApp.init` — nothing at startup, in background tasks, or in notification handlers calls `setLoginItem` anymore.
- Adds a new final tutorial slide with an explicit "Start DS3 Drive at login" toggle (defaults **off**). `setLoginItem` is invoked only when the user taps **Get Started** on that slide.
- Makes `DefaultSettings.appIsLoginItem` a computed property instead of a `static let`, so the Preferences toggle and the tutorial (on replay) reflect the live `SMAppService` state rather than a value cached at process start.
- Adds EN + IT strings for the new slide.
- `Slide.imageName` is now optional so the consent slide doesn't have to carry an empty asset name (addresses Copilot review).

Existing users who previously had the app registered as a login item are unaffected — the old registration persists in the OS; this PR only changes how *new* consent is obtained.

Closes #131

## Manual verification (passing)

- [x] Fresh install, toggle **off**, Get Started → login item remains unregistered.
- [x] Fresh install, toggle **on**, Get Started → login item registered.
- [x] Existing install upgrade path: previously registered login items remain enabled after update.
- [x] Preferences "Show Tutorial Again": enabling login item in the replayed tutorial reflects immediately in the Preferences toggle (no stale cache).
- [x] Preferences toggle off → on → off still works end-to-end.
- [x] No `setLoginItem` call at startup (verified via `log show ... category == 'app'`).
- [x] Italian locale tutorial copy renders correctly.
- [x] Login-item slide spacing tuned so the toggle breathes between the description and the Get Started button.