### PR TITLE
Fix stalled rotation on tray footer status indicator

### DIFF
--- a/DS3Drive/Views/Tray/Views/TrayMenuFooterView.swift
+++ b/DS3Drive/Views/Tray/Views/TrayMenuFooterView.swift
@@ -97,7 +97,9 @@ struct TrayMenuFooterView: View {
     }
 
     private func stopRotation() {
-        withAnimation(.linear(duration: 0)) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
             rotationAngle = 0
         }
     }

--- a/DS3Drive/Views/Tray/Views/TrayMenuFooterView.swift
+++ b/DS3Drive/Views/Tray/Views/TrayMenuFooterView.swift
@@ -16,28 +16,29 @@ struct TrayMenuFooterView: View {
     /// the footer is the single live status surface (no redundant rows).
     var driveViewModels: [DS3DriveViewModel] = []
 
-    @State private var isRotating = false
+    @State private var rotationAngle: Double = 0
 
     var body: some View {
         HStack(spacing: DS3Spacing.xs) {
-            // Plan 05-18b Gap 30: replace `.symbolEffect(.pulse)` with a
-            // continuous rotation animation so the syncing state reads as
-            // real motion.
+            // Continuous rotation for the syncing/indexing state. Driving
+            // a Double angle via `withAnimation(...repeatForever)` inside
+            // onAppear/onChange is the reliable SwiftUI pattern — the
+            // previous Bool + `.animation(value:)` approach stalled when
+            // the MenuBarExtra window dismissed and reopened, because the
+            // flag was already `true` and nothing re-triggered the repeat.
             Image(systemName: statusIcon.name)
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(statusIcon.color)
-                .rotationEffect(.degrees(statusIcon.animated && isRotating ? 360 : 0))
-                .animation(
-                    statusIcon.animated
-                        ? .linear(duration: 1.5).repeatForever(autoreverses: false)
-                        : .default,
-                    value: isRotating
-                )
+                .rotationEffect(.degrees(rotationAngle))
                 .onAppear {
-                    if statusIcon.animated { isRotating = true }
+                    if statusIcon.animated { startContinuousRotation() }
                 }
                 .onChange(of: statusIcon.animated) { _, newValue in
-                    isRotating = newValue
+                    if newValue {
+                        startContinuousRotation()
+                    } else {
+                        stopRotation()
+                    }
                 }
 
             Text(status)
@@ -85,6 +86,19 @@ struct TrayMenuFooterView: View {
             Rectangle()
                 .fill(DS3Colors.brandBorder.opacity(0.4))
                 .frame(height: 1)
+        }
+    }
+
+    private func startContinuousRotation() {
+        rotationAngle = 0
+        withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+            rotationAngle = 360
+        }
+    }
+
+    private func stopRotation() {
+        withAnimation(.linear(duration: 0)) {
+            rotationAngle = 0
         }
     }
 


### PR DESCRIPTION
## Summary

The syncing/indexing arrow in the tray footer would freeze in place instead of rotating continuously. Reproducing it was easy once observed: open the tray menu while a drive was indexing, dismiss it, reopen — the arrow stayed at a fixed angle.

## Root cause

`TrayMenuFooterView` drove rotation with \`.animation(_, value: isRotating)\` on a \`Bool\`. The flag only transitions once (false → true on first appearance), which is enough to kick off a \`.repeatForever(autoreverses: false)\` animation — but SwiftUI ties the lifetime of that repeat to the bound value's ongoing transitions. Once \`isRotating\` settled at \`true\`, the repeat could be paused by window dismissal, a status flip, or a re-render, and nothing re-triggered it.

## Fix

- Replace \`@State isRotating: Bool\` with \`@State rotationAngle: Double\`.
- Drop the \`.animation(_, value:)\` modifier.
- Drive rotation explicitly from \`onAppear\` and \`onChange(of: statusIcon.animated)\` via \`withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false))\` inside private \`startContinuousRotation()\` / \`stopRotation()\` helpers.

This is the canonical SwiftUI pattern for continuous rotation and is robust to the view re-appearing inside a \`MenuBarExtra\` window.

## Test plan

- [ ] Open tray menu while a drive is indexing — arrow rotates continuously.
- [ ] Dismiss and reopen tray menu — arrow still rotates continuously (regression being fixed).
- [ ] Status transitions idle → indexing → syncing → idle — rotation starts, continues through icon changes, and stops cleanly on idle.
- [ ] Error / paused / offline states — icons are static (no jitter from a dangling animation).