### PR TITLE
Fix bulk-upload thumbnail nil race (#141)

### DIFF
--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -106,6 +106,9 @@
 		A130601201000000A1306012 /* ThumbnailFetchLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130601001000000A1306010 /* ThumbnailFetchLimiter.swift */; };
 		A132010101000000A1320101 /* ThumbnailFallbackLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A132010001000000A1320100 /* ThumbnailFallbackLimiter.swift */; };
 		A132010201000000A1320102 /* ThumbnailFallbackLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A132010001000000A1320100 /* ThumbnailFallbackLimiter.swift */; };
+		A141010101000000A1410101 /* ThumbnailUploadLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A141010001000000A1410100 /* ThumbnailUploadLimiter.swift */; };
+		A141010201000000A1410102 /* ThumbnailUploadLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A141010001000000A1410100 /* ThumbnailUploadLimiter.swift */; };
+		A141010401000000A1410104 /* ThumbnailUploadLimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */; };
 		A130601401000000A1306014 /* ThumbnailFetchLimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */; };
 		A132010401000000A1320104 /* ThumbnailFallbackLimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */; };
 		A132020201000000A1320202 /* ThumbnailHybridConsumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A132020101000000A1320201 /* ThumbnailHybridConsumeTests.swift */; };
@@ -332,6 +335,8 @@
 		D51672A02F7A00000042AD93 /* BucketListingLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketListingLimiter.swift; sourceTree = "<group>"; };
 		A130601001000000A1306010 /* ThumbnailFetchLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailFetchLimiter.swift; sourceTree = "<group>"; };
 		A132010001000000A1320100 /* ThumbnailFallbackLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailFallbackLimiter.swift; sourceTree = "<group>"; };
+		A141010001000000A1410100 /* ThumbnailUploadLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailUploadLimiter.swift; sourceTree = "<group>"; };
+		A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailUploadLimiterTests.swift; sourceTree = "<group>"; };
 		A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailFetchLimiterTests.swift; sourceTree = "<group>"; };
 		A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailFallbackLimiterTests.swift; sourceTree = "<group>"; };
 		A132020101000000A1320201 /* ThumbnailHybridConsumeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailHybridConsumeTests.swift; sourceTree = "<group>"; };
@@ -640,6 +645,7 @@
 				154C907172E95FD06C8615BD /* S3ItemTests.swift */,
 				A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */,
 				A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */,
+				A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */,
 				A132020101000000A1320201 /* ThumbnailHybridConsumeTests.swift */,
 				A132040301000000A1320403 /* ThumbnailFallbackMemorySmokeTests.swift */,
 				A130603001000000A1306030 /* FetchThumbnailsTests.swift */,
@@ -950,6 +956,7 @@
 				D51672A02F7A00000042AD93 /* BucketListingLimiter.swift */,
 				A130601001000000A1306010 /* ThumbnailFetchLimiter.swift */,
 				A132010001000000A1320100 /* ThumbnailFallbackLimiter.swift */,
+				A141010001000000A1410100 /* ThumbnailUploadLimiter.swift */,
 				D540029D2B5EAEB000B54E97 /* S3Lib.swift */,
 				A10203032F6300000042AD93 /* WorkingSetEnumerator.swift */,
 				D5A4E0AA2B630A9800D7560B /* NotificationsManager.swift */,
@@ -1306,8 +1313,10 @@
 				D51672A12F7A00000042AD93 /* BucketListingLimiter.swift in Sources */,
 				A130601201000000A1306012 /* ThumbnailFetchLimiter.swift in Sources */,
 				A132010201000000A1320102 /* ThumbnailFallbackLimiter.swift in Sources */,
+				A141010201000000A1410102 /* ThumbnailUploadLimiter.swift in Sources */,
 				A130601401000000A1306014 /* ThumbnailFetchLimiterTests.swift in Sources */,
 				A132010401000000A1320104 /* ThumbnailFallbackLimiterTests.swift in Sources */,
+				A141010401000000A1410104 /* ThumbnailUploadLimiterTests.swift in Sources */,
 				A132020201000000A1320202 /* ThumbnailHybridConsumeTests.swift in Sources */,
 				A132040401000000A1320404 /* ThumbnailFallbackMemorySmokeTests.swift in Sources */,
 				347AA53C0831D587C66D0445 /* FileProviderExtension+Create.swift in Sources */,
@@ -1445,6 +1454,7 @@
 				D51672A22F7A00000042AD93 /* BucketListingLimiter.swift in Sources */,
 				A130601101000000A1306011 /* ThumbnailFetchLimiter.swift in Sources */,
 				A132010101000000A1320101 /* ThumbnailFallbackLimiter.swift in Sources */,
+				A141010101000000A1410101 /* ThumbnailUploadLimiter.swift in Sources */,
 				D5A4E0AB2B630A9800D7560B /* NotificationsManager.swift in Sources */,
 				D5A2228B2B5721CC00F1413B /* S3Item+Metadata.swift in Sources */,
 			);

--- a/DS3DriveProvider/FileProviderExtension+Create.swift
+++ b/DS3DriveProvider/FileProviderExtension+Create.swift
@@ -248,16 +248,31 @@ extension FileProviderExtension {
                 // have no contents). Fire-and-forget, decoupled from this completion handler.
                 // Errors logged + swallowed inside the helper's detached Task — they NEVER
                 // surface in `completionHandler(...)` below.
-                if !s3Item.isFolder, let localURL = url, let s3Client = self.s3Client {
+                if !s3Item.isFolder, let s3Client = self.s3Client {
+                    let s3LibCopy = self.s3Lib
+                    let tempDirCopy = self.temporaryDirectory
+                    let downloadFn: ThumbnailOriginalDownloader = { @Sendable identifier, drive in
+                        guard let s3Lib = s3LibCopy, let tempDir = tempDirCopy else {
+                            throw NSFileProviderError(.cannotSynchronize)
+                        }
+                        let (fileURL, item) = try await s3Lib.downloadS3Item(
+                            identifier: identifier,
+                            drive: drive,
+                            temporaryFolder: tempDir,
+                            progress: Progress()
+                        )
+                        return (fileURL, item.metadata.etag)
+                    }
                     enqueueThumbnailUpload(
                         originalKey: key,
-                        localURL: localURL,
                         sourceETag: ETagUtils.normalize(createETag) ?? createETag,
                         drive: drive,
                         s3Client: s3Client,
                         metadataStore: self.metadataStore,
                         domain: self.domain,
-                        logger: self.logger
+                        logger: self.logger,
+                        limiter: self.thumbnailUploadLimiter,
+                        download: downloadFn
                     )
                 }
 

--- a/DS3DriveProvider/FileProviderExtension+Modify.swift
+++ b/DS3DriveProvider/FileProviderExtension+Modify.swift
@@ -166,15 +166,30 @@ extension FileProviderExtension {
                         // branch only — Plan 13-08 owns the rename/move cascade in this same
                         // file's other branches and uses server-side `copyThumbnail` instead.
                         if !s3Item.isFolder, let s3Client = self.s3Client {
+                            let s3LibCopy = self.s3Lib
+                            let tempDirCopy = self.temporaryDirectory
+                            let downloadFn: ThumbnailOriginalDownloader = { @Sendable identifier, drive in
+                                guard let s3Lib = s3LibCopy, let tempDir = tempDirCopy else {
+                                    throw NSFileProviderError(.cannotSynchronize)
+                                }
+                                let (fileURL, item) = try await s3Lib.downloadS3Item(
+                                    identifier: identifier,
+                                    drive: drive,
+                                    temporaryFolder: tempDir,
+                                    progress: Progress()
+                                )
+                                return (fileURL, item.metadata.etag)
+                            }
                             enqueueThumbnailUpload(
                                 originalKey: s3Item.itemIdentifier.rawValue,
-                                localURL: contents,
                                 sourceETag: ETagUtils.normalize(uploadETag) ?? uploadETag,
                                 drive: drive,
                                 s3Client: s3Client,
                                 metadataStore: self.metadataStore,
                                 domain: self.domain,
-                                logger: self.logger
+                                logger: self.logger,
+                                limiter: self.thumbnailUploadLimiter,
+                                download: downloadFn
                             )
                         }
 

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
@@ -182,7 +182,7 @@ typealias ThumbnailOriginalDownloader =
 /// Closure that renders a JPEG thumbnail from a local original. Returns nil
 /// when the bytes don't decode (corrupt file, unsupported UTI). Production
 /// wires this to `ThumbnailRenderer().renderJPEG(from:)`.
-typealias ThumbnailRendererFn = @Sendable (URL) -> Data?
+typealias ThumbnailRendererFn = @Sendable (URL) -> Result<Data, RenderFailure>
 
 /// Closure that PUTs the rendered JPEG to S3. Production wires this to
 /// `s3Client.putThumbnail(bucket:key:data:sourceETag:)`.
@@ -276,11 +276,18 @@ func consumeThumbnailFallback(
         let (fileURL, sourceETag) = try await context.download(identifier, drive)
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
-        // Step 4 — Render. nil result records a strike but is NOT an error
+        // Step 4 — Render. A failure records a strike but is NOT an error
         // surfaced to Finder beyond `.noSuchItem` (Finder draws default icon).
-        guard let jpegBytes = context.render(fileURL) else {
+        let renderResult = context.render(fileURL)
+        let jpegBytes: Data
+        switch renderResult {
+        case let .success(bytes):
+            jpegBytes = bytes
+        case let .failure(reason):
             await limiter.recordFailure(key)
-            logger.info("Fallback: render returned nil for \(key, privacy: .public)")
+            logger.info(
+                "Fallback: render failed for \(key, privacy: .public) — reason=\(reason.rawValue, privacy: .public)"
+            )
             perItemHandler(identifier, nil, NSFileProviderError(.noSuchItem) as NSError)
             await limiter.release()
             return

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
@@ -179,9 +179,11 @@ let throttlingS3ErrorCodes: Set<String> = [
 typealias ThumbnailOriginalDownloader =
     @Sendable (NSFileProviderItemIdentifier, DS3Drive) async throws -> (URL, String?)
 
-/// Closure that renders a JPEG thumbnail from a local original. Returns nil
-/// when the bytes don't decode (corrupt file, unsupported UTI). Production
-/// wires this to `ThumbnailRenderer().renderJPEG(from:)`.
+/// Closure that renders a JPEG thumbnail from a local original. Returns
+/// `.failure(RenderFailure)` when the bytes don't decode (corrupt file,
+/// unsupported UTI, etc.) — the failure case names the specific reason
+/// (see `RenderFailure` in DS3Lib). Production wires this to
+/// `ThumbnailRenderer().renderJPEG(from:)`.
 typealias ThumbnailRendererFn = @Sendable (URL) -> Result<Data, RenderFailure>
 
 /// Closure that PUTs the rendered JPEG to S3. Production wires this to
@@ -215,8 +217,8 @@ struct ThumbnailFallbackContext {
 ///    Cancellation maps to `NSUserCancelledError`.
 /// 3. **Download** original via the `download` closure. On throw → record
 ///    strike, map error via `mapThumbnailFetchError`, return mapped error.
-/// 4. **Render** via the `render` closure. nil result → record strike, return
-///    `.noSuchItem`.
+/// 4. **Render** via the `render` closure. `.failure(...)` → record strike,
+///    return `.noSuchItem`.
 /// 5. **Lane 2 (D-01 lane 2, D-04):** invoke `perItemHandler` with rendered
 ///    bytes BEFORE issuing the PUT — the user sees the thumbnail immediately.
 /// 6. **Lane 3 (D-01 lane 3, D-04, D-12):** fire-and-forget `Task.detached`

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
@@ -50,8 +50,10 @@ import os.log
 /// for this declaration) prevents SwiftFormat from stripping the conformance.
 struct ThumbnailUploadHookContext: Sendable {
     let originalKey: String
-    /// `nil` allowed for ETag races — putThumbnail accepts empty sourceETag
-    /// (see consumeThumbnailFallback's `etagForPut = sourceETag ?? ""`).
+    /// MUST be non-empty. The enqueue path rejects empty/nil eagerly
+    /// (the original PUT response always provides one). The Optional
+    /// type is retained on the context struct for call-site stability;
+    /// the precondition is enforced inside `enqueueThumbnailUpload`.
     let sourceETag: String?
     let drive: DS3Drive
     let s3Client: any DS3S3ClientProtocol
@@ -137,9 +139,8 @@ private func runUploadHook(
         //     read-after-write consistent for new objects. Errors logged + swallowed (D-06).
         let identifier = NSFileProviderItemIdentifier(originalKey)
         let downloadedURL: URL
-        let downloadedETag: String?
         do {
-            (downloadedURL, downloadedETag) = try await download(identifier, drive)
+            (downloadedURL, _) = try await download(identifier, drive)
         } catch {
             logger.error(
                 "Upload-hook: GET original failed for \(originalKey, privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
@@ -163,15 +164,14 @@ private func runUploadHook(
             return
         }
 
-        // (d) PUT. Use the freshest available sourceETag — caller-supplied first,
-        //     fallback to whatever the GET surfaced, fallback to "" (matches
-        //     consume-path convention).
+        // (d) PUT. `sourceETag` is guaranteed non-empty by enqueueThumbnailUpload's
+        //     precondition (line ~225); no fallback needed.
         let bucket = drive.syncAnchor.bucket.name
         let drivePrefix = drive.syncAnchor.prefix
         let thumbKey = S3PathUtils.thumbnailKey(
             forOriginalKey: originalKey, drivePrefix: drivePrefix
         )
-        let etagForPut = sourceETag.isEmpty ? (downloadedETag ?? "") : sourceETag
+        let etagForPut = sourceETag
         do {
             _ = try await s3Client.putThumbnail(
                 bucket: bucket, key: thumbKey, data: jpegBytes, sourceETag: etagForPut

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
@@ -3,7 +3,7 @@ import DS3Lib
 import Foundation
 import os.log
 
-// MARK: - Upload-time thumbnail hook (Phase 13 D-06, D-08, D-09, D-10; THUMB-06)
+// MARK: - Upload-time thumbnail hook (Phase 13 D-06, D-08, D-09, D-10; THUMB-06; #141)
 
 // swiftformat:disable redundantSendable
 /// Free-function entry point that `createItem` (post-PUT) and `modifyItem` (content-change branch)
@@ -21,6 +21,13 @@ import os.log
 ///   the `thumbnailStatus` field, so the hook no longer marks `.notApplicable`.
 /// - Errors inside the detached Task are logged and SWALLOWED (`try?`) — they never propagate
 ///   to the user-visible upload contract. THUMB-06 mandates this lifecycle decoupling.
+///
+/// Issue #141 (Task 4): the eager path no longer reads the FileProvider temp URL.
+/// FileProvider may invalidate `localURL` the moment the createItem completionHandler
+/// returns; the detached Task could race that invalidation under bulk load. The hook
+/// now downloads the original from S3 (same bytes-source as the consume-path fallback)
+/// after the original PUT completes, gated through `ThumbnailUploadLimiter` for
+/// admission control.
 ///
 /// **NEVER capture `self` inside the detached Task** — pass sendable locals only:
 /// `s3Client` (Sendable), `metadataStore` (`@ModelActor`), `drive` (Sendable struct), strings,
@@ -43,7 +50,8 @@ import os.log
 /// for this declaration) prevents SwiftFormat from stripping the conformance.
 struct ThumbnailUploadHookContext: Sendable {
     let originalKey: String
-    let localURL: URL
+    /// `nil` allowed for ETag races — putThumbnail accepts empty sourceETag
+    /// (see consumeThumbnailFallback's `etagForPut = sourceETag ?? ""`).
     let sourceETag: String?
     let drive: DS3Drive
     let s3Client: any DS3S3ClientProtocol
@@ -90,69 +98,116 @@ func makeSignalParentContainer(
 /// `enqueueThumbnailUpload` to keep the Task body type-checkable under Swift 6's
 /// stricter overload resolution (the inline form ran into ambiguity between
 /// `Task.detached` overloads when capturing a `@Sendable` callback alongside the
-/// other Sendable locals). Parameters bundled at the call site via
-/// `ThumbnailUploadHookContext`; SwiftLint's count check is disabled here as a
+/// other Sendable locals). SwiftLint's count check is disabled here as a
 /// deliberate trade-off — the alternative is yet another Sendable struct just
 /// for this internal helper.
+///
+/// Issue #141 (Task 4): pivots the upload path off the FileProvider temp URL.
+/// Sequence: acquire limiter slot → GET original from S3 → render → PUT thumb
+/// → signal parent. Same bytes-source as `consumeThumbnailFallback` so the eager
+/// and lazy paths are byte-identical.
 @Sendable
 private func runUploadHook(
     s3Client: any DS3S3ClientProtocol,
-    metadataStore: MetadataStore,
     drive: DS3Drive,
     originalKey: String,
-    localURL: URL,
     sourceETag: String,
+    limiter: ThumbnailUploadLimiter,
+    download: ThumbnailOriginalDownloader,
     signalCallback: @Sendable (NSFileProviderItemIdentifier) -> Void,
     logger: os.Logger
 ) async {
     #if os(macOS)
+        // (a) Acquire the slot. Cancellation = exit cleanly without doing work.
         do {
-            let uploader = ThumbnailUploader(
-                s3Client: s3Client, metadataStore: metadataStore
-            )
-            try await uploader.generateAndUpload(
-                localURL: localURL,
-                drive: drive,
-                sourceETag: sourceETag,
-                originalKey: originalKey
-            )
-            // Phase 13.2 D-12: PUT succeeded — signal the parent container so Apple
-            // re-enumerates and the just-uploaded thumbnail is fetched on the next visit.
-            // Symmetric with the fallback path's post-PUT signal in consumeThumbnailFallback.
-            let parentKey = S3PathUtils.parentKey(
-                forKey: originalKey, drivePrefix: drive.syncAnchor.prefix
-            )
-            let parentId: NSFileProviderItemIdentifier =
-                parentKey.map { NSFileProviderItemIdentifier($0) } ?? .rootContainer
-            signalCallback(parentId)
+            try await limiter.acquire()
         } catch {
-            // D-06: errors NEVER propagate to the user-visible upload contract — log + swallow.
-            // No signalCallback on the failure path: nothing to re-enumerate (D-12 negative path).
-            logger.error(
-                "Upload-hook: thumbnail upload failed for \(originalKey, privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
-            )
+            return
         }
+        defer {
+            Task { await limiter.release() }
+        }
+
+        // (b) Download the original from S3. We just uploaded it; S3 is
+        //     read-after-write consistent for new objects. Errors logged + swallowed (D-06).
+        let identifier = NSFileProviderItemIdentifier(originalKey)
+        let downloadedURL: URL
+        let downloadedETag: String?
+        do {
+            (downloadedURL, downloadedETag) = try await download(identifier, drive)
+        } catch {
+            logger.error(
+                "Upload-hook: GET original failed for \(originalKey, privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
+            )
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: downloadedURL) }
+
+        // (c) Render. Sub-reason logged via the RenderFailure enum.
+        let renderResult = ThumbnailRenderer().renderJPEG(from: downloadedURL)
+        let jpegBytes: Data
+        switch renderResult {
+        case let .success(bytes):
+            jpegBytes = bytes
+        case let .failure(reason):
+            logger.info(
+                "Upload-hook: render failed for \(originalKey, privacy: .public) — reason=\(reason.rawValue, privacy: .public)"
+            )
+            return
+        }
+
+        // (d) PUT. Use the freshest available sourceETag — caller-supplied first,
+        //     fallback to whatever the GET surfaced, fallback to "" (matches
+        //     consume-path convention).
+        let bucket = drive.syncAnchor.bucket.name
+        let drivePrefix = drive.syncAnchor.prefix
+        let thumbKey = S3PathUtils.thumbnailKey(
+            forOriginalKey: originalKey, drivePrefix: drivePrefix
+        )
+        let etagForPut = sourceETag.isEmpty ? (downloadedETag ?? "") : sourceETag
+        do {
+            _ = try await s3Client.putThumbnail(
+                bucket: bucket, key: thumbKey, data: jpegBytes, sourceETag: etagForPut
+            )
+        } catch {
+            logger.error(
+                "Upload-hook: PUT failed for \(thumbKey, privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
+            )
+            return
+        }
+
+        // (e) Signal the parent so Apple re-enumerates and the next visit hits
+        //     the warm cache.
+        let parentKeyOpt = S3PathUtils.parentKey(
+            forKey: originalKey, drivePrefix: drivePrefix
+        )
+        let parentId: NSFileProviderItemIdentifier =
+            parentKeyOpt.map { NSFileProviderItemIdentifier($0) } ?? .rootContainer
+        signalCallback(parentId)
     #else
-        // iOS path — Phase 14 will wire the foreground backfill driver. Phase 13.2
-        // Plan 09 / Schema V6 dropped `thumbnailStatus`, so there is no longer a
-        // metadata write to perform here. The consume-path fallback (Plan 02) will
-        // attempt a render against S3 on the next visit anyway.
-        _ = (metadataStore, s3Client, drive, originalKey, sourceETag, localURL, logger, signalCallback)
+        _ = (s3Client, drive, originalKey, sourceETag, limiter, download, signalCallback, logger)
     #endif
 }
 
 // swiftlint:enable function_parameter_count
 
-/// Per-platform upload hook. macOS spawns a detached Task that runs `ThumbnailUploader.generateAndUpload`;
-/// iOS marks the row `.pending` for Phase 14's foreground driver to pick up. Errors are SWALLOWED
-/// inside the detached Task per D-06 — they NEVER propagate to the user-visible upload contract.
+/// Per-platform upload hook. macOS spawns a detached Task that runs the limiter-gated
+/// GET → render → PUT → signal sequence; iOS is a no-op (Phase 14 owns the foreground
+/// backfill driver). Errors are SWALLOWED inside the detached Task per D-06 — they
+/// NEVER propagate to the user-visible upload contract.
 ///
 /// Phase 13.2 D-12: after a successful PUT, invokes `signalParentContainer` (defaulting to the
 /// NSFileProviderManager-backed implementation) so Apple re-enumerates the parent folder.
 /// Tests inject a recorder closure to observe the callback without standing up a real domain.
+///
+/// Issue #141 (Task 4): admission control via `ThumbnailUploadLimiter`. Soft-cap check
+/// at enqueue time drops new work past 64 pending waiters; the consume-path fallback
+/// generates missing thumbnails on first view.
 @Sendable
 func enqueueThumbnailUpload(
     _ context: ThumbnailUploadHookContext,
+    limiter: ThumbnailUploadLimiter,
+    download: @escaping ThumbnailOriginalDownloader,
     signalParentContainer: (@Sendable (NSFileProviderItemIdentifier) -> Void)? = nil
 ) {
     // (a) Pre-filter at the call boundary: non-raster originals never schedule render work.
@@ -164,16 +219,12 @@ func enqueueThumbnailUpload(
         return
     }
 
-    // (b) Raster path. We require BOTH a normalized sourceETag AND a metadata store.
-    //     Phase 13.2 Plan 09: the uploader no longer writes thumbnail-specific fields
-    //     against the store, but we still gate on its presence to mirror the prior
-    //     contract — call sites without a store are upstream regressions, not normal flow.
-    guard let metadataStore = context.metadataStore,
-          let sourceETag = context.sourceETag,
-          !sourceETag.isEmpty
-    else {
+    // (b) Require a non-empty sourceETag. The eager path's caller already has
+    //     a fresh ETag from the original PUT response — empty here is an
+    //     upstream bug.
+    guard let sourceETag = context.sourceETag, !sourceETag.isEmpty else {
         context.logger.debug(
-            "Upload-hook: skipping \(context.originalKey, privacy: .public) — missing metadataStore or empty sourceETag"
+            "Upload-hook: skipping \(context.originalKey, privacy: .public) — empty sourceETag"
         )
         return
     }
@@ -181,11 +232,11 @@ func enqueueThumbnailUpload(
     // (c) Capture sendable locals before opening the detached Task. NEVER capture `self`
     //     (this is a free function — the FileProviderExtension subclass is non-Sendable per
     //     Pitfall 1 in 13-RESEARCH.md). All values below are Sendable by construction.
+    let limiterRef = limiter
+    let originalKey = context.originalKey
+    let logger = context.logger
     let s3Client = context.s3Client
     let drive = context.drive
-    let originalKey = context.originalKey
-    let localURL = context.localURL
-    let logger = context.logger
     let domain = context.domain
     // Phase 13.2 D-12: bind the signal callback up-front. Production gets the NSFileProviderManager-backed
     // closure; tests inject a recorder. Either way, the closure is @Sendable and never captures self.
@@ -193,17 +244,30 @@ func enqueueThumbnailUpload(
         domain: domain, logger: logger, label: "Upload-hook"
     )
 
-    Task.detached(priority: .background) {
-        await runUploadHook(
-            s3Client: s3Client,
-            metadataStore: metadataStore,
-            drive: drive,
-            originalKey: originalKey,
-            localURL: localURL,
-            sourceETag: sourceETag,
-            signalCallback: signalCallback,
-            logger: logger
-        )
+    // (d) Soft-cap check. The check is a one-shot read against the actor; it CAN
+    //     race (another job releases between the check and the spawn) but the
+    //     cost is at most one extra waiter past the cap, which is fine.
+    //     Issue #141: bulk imports past 64+2 in-flight jobs fall through to the
+    //     consume-path fallback on first view.
+    Task {
+        if await limiterRef.isAtSoftCap {
+            logger.info(
+                "Upload-hook: soft cap reached, deferring \(originalKey, privacy: .public) to consume-path fallback"
+            )
+            return
+        }
+        Task.detached(priority: .background) {
+            await runUploadHook(
+                s3Client: s3Client,
+                drive: drive,
+                originalKey: originalKey,
+                sourceETag: sourceETag,
+                limiter: limiterRef,
+                download: download,
+                signalCallback: signalCallback,
+                logger: logger
+            )
+        }
     }
 }
 
@@ -215,22 +279,26 @@ func enqueueThumbnailUpload(
 /// Phase 13.2 D-12: `signalParentContainer` is an optional test-injection seam.
 /// Production passes nil (and the default NSFileProviderManager-backed closure runs);
 /// tests pass a recorder closure to assert the post-PUT signal fires correctly.
+///
+/// Issue #141 (Task 4): `limiter` and `download` are required injection seams.
+/// Production wires `download` to a closure around `S3Lib.downloadS3Item`; tests
+/// inject a stub returning a known fixture URL + etag.
 @Sendable
 func enqueueThumbnailUpload(
     originalKey: String,
-    localURL: URL,
     sourceETag: String?,
     drive: DS3Drive,
     s3Client: any DS3S3ClientProtocol,
     metadataStore: MetadataStore?,
     domain: NSFileProviderDomain,
     logger: os.Logger,
+    limiter: ThumbnailUploadLimiter,
+    download: @escaping ThumbnailOriginalDownloader,
     signalParentContainer: (@Sendable (NSFileProviderItemIdentifier) -> Void)? = nil
 ) {
     enqueueThumbnailUpload(
         ThumbnailUploadHookContext(
             originalKey: originalKey,
-            localURL: localURL,
             sourceETag: sourceETag,
             drive: drive,
             s3Client: s3Client,
@@ -238,6 +306,8 @@ func enqueueThumbnailUpload(
             domain: domain,
             logger: logger
         ),
+        limiter: limiter,
+        download: download,
         signalParentContainer: signalParentContainer
     )
 }

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
@@ -124,9 +124,14 @@ private func runUploadHook(
         } catch {
             return
         }
-        defer {
-            Task { await limiter.release() }
-        }
+
+        // Code review Fix 2 (Phase 13.2): release explicitly on every exit path
+        // rather than via `defer { Task { await release } }`. Spawning an
+        // unstructured Task to return the slot delays the hand-off by an extra
+        // task hop. Explicit `await limiter.release()` before each return
+        // guarantees the slot is returned synchronously within this Task —
+        // mirrors the consume-path fallback pattern in
+        // `consumeThumbnailFallback` (+ThumbnailConsume.swift).
 
         // (b) Download the original from S3. We just uploaded it; S3 is
         //     read-after-write consistent for new objects. Errors logged + swallowed (D-06).
@@ -139,6 +144,7 @@ private func runUploadHook(
             logger.error(
                 "Upload-hook: GET original failed for \(originalKey, privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
             )
+            await limiter.release()
             return
         }
         defer { try? FileManager.default.removeItem(at: downloadedURL) }
@@ -153,6 +159,7 @@ private func runUploadHook(
             logger.info(
                 "Upload-hook: render failed for \(originalKey, privacy: .public) — reason=\(reason.rawValue, privacy: .public)"
             )
+            await limiter.release()
             return
         }
 
@@ -173,8 +180,12 @@ private func runUploadHook(
             logger.error(
                 "Upload-hook: PUT failed for \(thumbKey, privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
             )
+            await limiter.release()
             return
         }
+        logger.info(
+            "Upload-hook: PUT succeeded for \(thumbKey, privacy: .public)"
+        )
 
         // (e) Signal the parent so Apple re-enumerates and the next visit hits
         //     the warm cache.
@@ -184,6 +195,7 @@ private func runUploadHook(
         let parentId: NSFileProviderItemIdentifier =
             parentKeyOpt.map { NSFileProviderItemIdentifier($0) } ?? .rootContainer
         signalCallback(parentId)
+        await limiter.release()
     #else
         _ = (s3Client, drive, originalKey, sourceETag, limiter, download, signalCallback, logger)
     #endif

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailUploadHook.swift
@@ -203,6 +203,12 @@ private func runUploadHook(
 /// Issue #141 (Task 4): admission control via `ThumbnailUploadLimiter`. Soft-cap check
 /// at enqueue time drops new work past 64 pending waiters; the consume-path fallback
 /// generates missing thumbnails on first view.
+///
+/// Implementation note: the soft-cap read crosses an actor boundary
+/// (`isAtSoftCap`), so we wrap it in an outer `Task(priority: .utility)`
+/// before spawning the inner `Task.detached(priority: .background)` that
+/// runs the render+PUT. The outer Task only does the cap check; never
+/// captures `self`.
 @Sendable
 func enqueueThumbnailUpload(
     _ context: ThumbnailUploadHookContext,
@@ -231,13 +237,16 @@ func enqueueThumbnailUpload(
 
     // (c) Capture sendable locals before opening the detached Task. NEVER capture `self`
     //     (this is a free function — the FileProviderExtension subclass is non-Sendable per
-    //     Pitfall 1 in 13-RESEARCH.md). All values below are Sendable by construction.
+    //     Pitfall 1 in 13-RESEARCH.md). All values below are Sendable by construction —
+    //     including `downloadFn`, which binds the @escaping `ThumbnailOriginalDownloader`
+    //     closure into a named local so the invariant is explicit at the capture site.
     let limiterRef = limiter
     let originalKey = context.originalKey
     let logger = context.logger
     let s3Client = context.s3Client
     let drive = context.drive
     let domain = context.domain
+    let downloadFn = download
     // Phase 13.2 D-12: bind the signal callback up-front. Production gets the NSFileProviderManager-backed
     // closure; tests inject a recorder. Either way, the closure is @Sendable and never captures self.
     let signalCallback = signalParentContainer ?? makeSignalParentContainer(
@@ -249,7 +258,7 @@ func enqueueThumbnailUpload(
     //     cost is at most one extra waiter past the cap, which is fine.
     //     Issue #141: bulk imports past 64+2 in-flight jobs fall through to the
     //     consume-path fallback on first view.
-    Task {
+    Task(priority: .utility) {
         if await limiterRef.isAtSoftCap {
             logger.info(
                 "Upload-hook: soft cap reached, deferring \(originalKey, privacy: .public) to consume-path fallback"
@@ -263,7 +272,7 @@ func enqueueThumbnailUpload(
                 originalKey: originalKey,
                 sourceETag: sourceETag,
                 limiter: limiterRef,
-                download: download,
+                download: downloadFn,
                 signalCallback: signalCallback,
                 logger: logger
             )

--- a/DS3DriveProvider/FileProviderExtension.swift
+++ b/DS3DriveProvider/FileProviderExtension.swift
@@ -81,6 +81,14 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension,
     /// + poison-key set for THUMB-20 reframed (D-19, D-20, D-21).
     let thumbnailFallbackLimiter = ThumbnailFallbackLimiter()
 
+    /// Admission-gate for the upload-time (eager) thumbnail generator.
+    /// Issue #141: bulk uploads previously spawned unbounded detached Tasks,
+    /// racing into ImageIO and reading the FileProvider temp URL after it
+    /// could be invalidated. This limiter caps concurrent render+PUT to 2
+    /// and drops overflow past 64 pending+inflight jobs (consume-path
+    /// fallback covers missed thumbnails on first view).
+    let thumbnailUploadLimiter = ThumbnailUploadLimiter()
+
     var drive: DS3Drive?
     let temporaryDirectory: URL?
     let systemService: any SystemService

--- a/DS3DriveProvider/ThumbnailUploadLimiter.swift
+++ b/DS3DriveProvider/ThumbnailUploadLimiter.swift
@@ -38,10 +38,15 @@ actor ThumbnailUploadLimiter {
         self.softMaxWaiters = softMaxWaiters
     }
 
-    /// Returns true if the limiter is currently at the soft cap. Callers use
-    /// this BEFORE spawning a detached Task so they can drop overflow work
-    /// without blocking. Soft because we never block the producer; we just
-    /// log and skip.
+    /// Returns true if the limiter's WAITER queue is at or above
+    /// `softMaxWaiters`. Callers use this BEFORE spawning a detached Task
+    /// so they can drop overflow work without blocking. Soft because we
+    /// never block the producer; we just log and skip.
+    ///
+    /// Counts only suspended waiters, not in-flight slots — so the
+    /// effective ceiling on concurrent in-progress work is
+    /// `softMaxWaiters + maxSlots` (66 with the defaults). Treat the
+    /// value as an order-of-magnitude ceiling, not a precise capacity.
     var isAtSoftCap: Bool {
         waiters.count >= softMaxWaiters
     }

--- a/DS3DriveProvider/ThumbnailUploadLimiter.swift
+++ b/DS3DriveProvider/ThumbnailUploadLimiter.swift
@@ -65,8 +65,15 @@ actor ThumbnailUploadLimiter {
                 waiters.append(Waiter(id: waiterId, cont: cont))
             }
         } onCancel: {
-            Task { [weak self] in
-                await self?.cancelWaiter(id: waiterId)
+            // The limiter is system-level infrastructure retained by
+            // `FileProviderExtension` for the process lifetime. A `[weak self]`
+            // capture here is misleading: `self` cannot deinit while a waiter
+            // is suspended on its continuation, and a weak capture would
+            // silently swallow the cancel-resume if it ever did, leaving the
+            // continuation orphaned and leaking the slot. Strong capture is
+            // correct. (Mirrors `ThumbnailFallbackLimiter` Code review Fix 5.)
+            Task { [self] in
+                await self.cancelWaiter(id: waiterId)
             }
         }
 

--- a/DS3DriveProvider/ThumbnailUploadLimiter.swift
+++ b/DS3DriveProvider/ThumbnailUploadLimiter.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Admission-gate for the upload-time (eager) thumbnail generator.
+///
+/// Issue #141: bulk uploads spawned unbounded `Task.detached(priority: .background)`
+/// calls into `ThumbnailRenderer`, racing into ImageIO under concurrent decode
+/// pressure (silent nil returns) AND reading the FileProvider temp URL after it
+/// could be invalidated. This limiter caps concurrent render+PUT to `maxSlots`
+/// and drops new work past `softMaxWaiters` so very large imports degrade
+/// gracefully — overflow falls through to the consume-path fallback on first
+/// view.
+///
+/// Slots = 2 by default — same as `ThumbnailFallbackLimiter`. The eager path
+/// now downloads the original from S3 (same bytes-source as the fallback), so
+/// the same slot count is appropriate. Separate instance keeps the eager and
+/// lazy paths from starving each other.
+///
+/// Soft cap = 64 waiters by default. Pending jobs are suspended Tasks (no
+/// bytes, no disk), but unbounded waiter accumulation under huge imports is
+/// still pathological. 64 covers the issue's 15-file repro with ~4× headroom.
+///
+/// Lifecycle / FIFO / cancellation semantics mirror `ThumbnailFetchLimiter`
+/// verbatim (the pattern is battle-tested). NO strike counter, NO poison set
+/// — those are consume-path concerns and stay in `ThumbnailFallbackLimiter`.
+actor ThumbnailUploadLimiter {
+    private struct Waiter {
+        let id: UUID
+        let cont: CheckedContinuation<Void, any Error>
+    }
+
+    private let maxSlots: Int
+    private let softMaxWaiters: Int
+    private var inFlight = 0
+    private var waiters: [Waiter] = []
+
+    init(maxSlots: Int = 2, softMaxWaiters: Int = 64) {
+        self.maxSlots = maxSlots
+        self.softMaxWaiters = softMaxWaiters
+    }
+
+    /// Returns true if the limiter is currently at the soft cap. Callers use
+    /// this BEFORE spawning a detached Task so they can drop overflow work
+    /// without blocking. Soft because we never block the producer; we just
+    /// log and skip.
+    var isAtSoftCap: Bool {
+        waiters.count >= softMaxWaiters
+    }
+
+    /// Acquires a slot. Suspends FIFO if all slots are taken. Throws
+    /// `CancellationError` if the calling Task is cancelled.
+    /// See `ThumbnailFetchLimiter.acquire()` for cancellation rationale.
+    func acquire() async throws {
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+        if inFlight < maxSlots {
+            inFlight += 1
+            return
+        }
+
+        let waiterId = UUID()
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+                waiters.append(Waiter(id: waiterId, cont: cont))
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.cancelWaiter(id: waiterId)
+            }
+        }
+
+        if Task.isCancelled {
+            release()
+            throw CancellationError()
+        }
+    }
+
+    /// Releases a slot. Hands directly to the next waiter if any.
+    func release() {
+        if !waiters.isEmpty {
+            let next = waiters.removeFirst()
+            next.cont.resume()
+        } else {
+            inFlight = max(0, inFlight - 1)
+        }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = waiters.remove(at: index)
+        waiter.cont.resume(throwing: CancellationError())
+    }
+
+    // MARK: - Test introspection
+
+    var inFlightCount: Int {
+        inFlight
+    }
+    var waiterCount: Int {
+        waiters.count
+    }
+}

--- a/DS3DriveProviderTests/ThumbnailFallbackMemorySmokeTests.swift
+++ b/DS3DriveProviderTests/ThumbnailFallbackMemorySmokeTests.swift
@@ -56,9 +56,12 @@ final class ThumbnailFallbackMemorySmokeTests: XCTestCase {
 
         for iteration in 0 ..< 8 {
             autoreleasepool {
-                let bytes = renderer.renderJPEG(from: url)
-                XCTAssertNotNil(bytes, "Render #\(iteration) returned nil — fixture may be invalid HEIC")
-                XCTAssertGreaterThan(bytes?.count ?? 0, 0, "Render #\(iteration) produced empty JPEG")
+                let result = renderer.renderJPEG(from: url)
+                guard case let .success(bytes) = result else {
+                    XCTFail("Render #\(iteration) failed — fixture may be invalid HEIC, got \(result)")
+                    return
+                }
+                XCTAssertGreaterThan(bytes.count, 0, "Render #\(iteration) produced empty JPEG")
             }
             let current = Self.residentFootprintMB()
             peak = max(peak, current)

--- a/DS3DriveProviderTests/ThumbnailHybridConsumeTests.swift
+++ b/DS3DriveProviderTests/ThumbnailHybridConsumeTests.swift
@@ -37,7 +37,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
 
         let context = Self.makeContext(
             download: { _, _ in (downloadURL, sourceETag) },
-            render: { _ in renderedBytes },
+            render: { _ in .success(renderedBytes) },
             putThumbnail: { bucket, key, data, etag in
                 await putRecorder.record(bucket: bucket, key: key, data: data, etag: etag)
             },
@@ -92,7 +92,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
 
         let context = Self.makeContext(
             download: { _, _ in (downloadURL, "etag") },
-            render: { _ in renderedBytes },
+            render: { _ in .success(renderedBytes) },
             signalParentContainer: { id in
                 Task { await signalRecorder.record(id) }
             }
@@ -134,7 +134,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
                 await downloadCounter.increment()
                 return (URL(fileURLWithPath: "/tmp/never"), nil)
             },
-            render: { _ in Data() },
+            render: { _ in .success(Data()) },
             putThumbnail: { bucket, key, data, etag in
                 await putRecorder.record(bucket: bucket, key: key, data: data, etag: etag)
             },
@@ -190,7 +190,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
                 await downloadCounter.increment()
                 return (URL(fileURLWithPath: "/tmp/never"), nil)
             },
-            render: { _ in Data() }
+            render: { _ in .success(Data()) }
         )
 
         await consumeThumbnailFallback(
@@ -235,7 +235,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
                 await downloadCounter.increment()
                 return (downloadURL, nil)
             },
-            render: { _ in nil } // unsupported / corrupt
+            render: { _ in .failure(.thumbnailCreate) } // unsupported / corrupt
         )
         for _ in 0 ..< 3 {
             await consumeThumbnailFallback(
@@ -262,7 +262,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
                 await downloadCounter.increment()
                 return (downloadURL, nil)
             },
-            render: { _ in Data() }
+            render: { _ in .success(Data()) }
         )
         await consumeThumbnailFallback(
             identifier: identifier,
@@ -299,7 +299,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
         let context = Self.makeContext(
             limiter: limiter,
             download: { _, _ in (downloadURL, "etag") },
-            render: { _ in renderedBytes },
+            render: { _ in .success(renderedBytes) },
             putThumbnail: { _, _, _, _ in throw PutNetworkError() }
         )
         await consumeThumbnailFallback(
@@ -344,7 +344,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
 
         let context = Self.makeContext(
             download: { _, _ in throw CustomDomainError() }, // download fails
-            render: { _ in Data() }
+            render: { _ in .success(Data()) }
         )
         await consumeThumbnailFallback(
             identifier: identifier,
@@ -398,7 +398,7 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
         download: @escaping ThumbnailOriginalDownloader = { _, _ in
             throw NSFileProviderError(.cannotSynchronize)
         },
-        render: @escaping ThumbnailRendererFn = { _ in nil },
+        render: @escaping ThumbnailRendererFn = { _ in .failure(.thumbnailCreate) },
         putThumbnail: @escaping ThumbnailFallbackPutter = { _, _, _, _ in
             // Default: succeed silently. Tests that care override this.
         },

--- a/DS3DriveProviderTests/ThumbnailUploadLimiterTests.swift
+++ b/DS3DriveProviderTests/ThumbnailUploadLimiterTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+/// Tests `ThumbnailUploadLimiter` (issue #141, Phase 2).
+///
+/// `ThumbnailUploadLimiter.swift` is compiled directly into the test bundle
+/// via the DS3DriveProviderTests target's Sources phase (same pattern as
+/// `ThumbnailFallbackLimiter` / `ThumbnailFetchLimiter`).
+final class ThumbnailUploadLimiterTests: XCTestCase {
+    // MARK: - Slot mechanics (mirrors ThumbnailFallbackLimiterTests)
+
+    func testAcquireBelowMaxDoesNotBlock() async throws {
+        let limiter = ThumbnailUploadLimiter(maxSlots: 2)
+        try await limiter.acquire()
+        let inFlight = await limiter.inFlightCount
+        XCTAssertEqual(inFlight, 1)
+    }
+
+    /// Polls `waiterCount` against an expected value. Mirrors the helper in
+    /// `ThumbnailFallbackLimiterTests` — under CI scheduler pressure a spawned
+    /// waiter Task may not have reached its `withCheckedThrowingContinuation`
+    /// within a fixed sleep window, so polling is more robust than a bare sleep.
+    private func waitForWaiterCount(
+        _ expected: Int,
+        on limiter: ThumbnailUploadLimiter,
+        timeout: TimeInterval = 2.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let count = await limiter.waiterCount
+            if count == expected { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        let final = await limiter.waiterCount
+        XCTAssertEqual(
+            final, expected,
+            "Timed out waiting for waiterCount == \(expected) (got \(final))",
+            file: file, line: line
+        )
+    }
+
+    func testTwoAcquireAtMaxBlocksThird() async throws {
+        let limiter = ThumbnailUploadLimiter(maxSlots: 2)
+        try await limiter.acquire()
+        try await limiter.acquire()
+        let blockedTask = Task { try await limiter.acquire() }
+        try await waitForWaiterCount(1, on: limiter)
+        await limiter.release()
+        _ = try await blockedTask.value
+    }
+
+    func testFIFOOrderPreservedAcrossWaiters() async throws {
+        actor OrderRecorder {
+            private var values: [String] = []
+            func record(_ value: String) {
+                values.append(value)
+            }
+            func snapshot() -> [String] {
+                values
+            }
+        }
+        let limiter = ThumbnailUploadLimiter(maxSlots: 1)
+        try await limiter.acquire()
+        let order = OrderRecorder()
+        let taskA = Task {
+            try await limiter.acquire()
+            await order.record("A")
+            await limiter.release()
+        }
+        try await waitForWaiterCount(1, on: limiter)
+        let taskB = Task {
+            try await limiter.acquire()
+            await order.record("B")
+            await limiter.release()
+        }
+        try await waitForWaiterCount(2, on: limiter)
+        await limiter.release()
+        _ = try await taskA.value
+        _ = try await taskB.value
+        let recorded = await order.snapshot()
+        XCTAssertEqual(recorded, ["A", "B"])
+    }
+
+    func testCancellationDuringWaitRemovesWaiter() async throws {
+        let limiter = ThumbnailUploadLimiter(maxSlots: 1)
+        try await limiter.acquire()
+        let cancelTask = Task { try await limiter.acquire() }
+        try await waitForWaiterCount(1, on: limiter)
+        cancelTask.cancel()
+        do {
+            _ = try await cancelTask.value
+            XCTFail("expected CancellationError")
+        } catch is CancellationError {
+            // ok
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        try await waitForWaiterCount(0, on: limiter)
+    }
+
+    // MARK: - Soft cap (NEW behavior unique to ThumbnailUploadLimiter)
+
+    func testSoftCapFalseWhenWaitersBelowCap() async throws {
+        let limiter = ThumbnailUploadLimiter(maxSlots: 1, softMaxWaiters: 4)
+        try await limiter.acquire()
+        let isAt = await limiter.isAtSoftCap
+        XCTAssertFalse(isAt)
+    }
+
+    func testSoftCapTrueWhenWaitersAtOrAboveCap() async throws {
+        let limiter = ThumbnailUploadLimiter(maxSlots: 1, softMaxWaiters: 2)
+        try await limiter.acquire() // 1 in flight, 0 waiters
+        let t1 = Task { try await limiter.acquire() } // 1 in flight, 1 waiter
+        try await waitForWaiterCount(1, on: limiter)
+        let t2 = Task { try await limiter.acquire() } // 1 in flight, 2 waiters → at cap
+        try await waitForWaiterCount(2, on: limiter)
+        let isAt = await limiter.isAtSoftCap
+        XCTAssertTrue(isAt)
+        await limiter.release()
+        await limiter.release()
+        _ = try await t1.value
+        _ = try await t2.value
+    }
+}

--- a/DS3DriveProviderTests/UploadHookTests.swift
+++ b/DS3DriveProviderTests/UploadHookTests.swift
@@ -116,15 +116,17 @@ final class UploadHookTests: XCTestCase {
             forOriginalKey: originalKey, drivePrefix: drive.syncAnchor.prefix
         )
 
+        let downloadFn: ThumbnailOriginalDownloader = { @Sendable _, _ in (url, "abc123") }
         enqueueThumbnailUpload(
             originalKey: originalKey,
-            localURL: url,
             sourceETag: "abc123",
             drive: drive,
             s3Client: mock,
             metadataStore: metadataStore,
             domain: ProviderTestFixtures.makeDomain(),
-            logger: makeLogger()
+            logger: makeLogger(),
+            limiter: ThumbnailUploadLimiter(),
+            download: downloadFn
         )
 
         // Wait for the detached Task to call into the mock.
@@ -162,15 +164,19 @@ final class UploadHookTests: XCTestCase {
             s3Key: originalKey, driveId: drive.id, syncStatus: .synced, size: 100
         )
 
+        // Pre-filter rejects non-raster before reaching the download closure;
+        // the stub here would never fire.
+        let downloadFn: ThumbnailOriginalDownloader = { @Sendable _, _ in (url, "abc123") }
         enqueueThumbnailUpload(
             originalKey: originalKey,
-            localURL: url,
             sourceETag: "abc123",
             drive: drive,
             s3Client: mock,
             metadataStore: metadataStore,
             domain: ProviderTestFixtures.makeDomain(),
-            logger: makeLogger()
+            logger: makeLogger(),
+            limiter: ThumbnailUploadLimiter(),
+            download: downloadFn
         )
 
         // Drain the detached Task — even with no work to do, the helper opens
@@ -197,16 +203,18 @@ final class UploadHookTests: XCTestCase {
         let url = try writeTempJPEG()
         defer { try? FileManager.default.removeItem(at: url) }
 
+        let downloadFn: ThumbnailOriginalDownloader = { @Sendable _, _ in (url, "etag") }
         let start = DispatchTime.now()
         enqueueThumbnailUpload(
             originalKey: "prefix/slow.jpg",
-            localURL: url,
             sourceETag: "etag",
             drive: drive,
             s3Client: mock,
             metadataStore: metadataStore,
             domain: ProviderTestFixtures.makeDomain(),
-            logger: makeLogger()
+            logger: makeLogger(),
+            limiter: ThumbnailUploadLimiter(),
+            download: downloadFn
         )
         let elapsedNanos = DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds
 
@@ -232,15 +240,17 @@ final class UploadHookTests: XCTestCase {
 
         // Helper returns Void — calling it CANNOT throw. If the implementation ever
         // surfaces the error to the caller, this won't compile (helper must stay non-throwing).
+        let downloadFn: ThumbnailOriginalDownloader = { @Sendable _, _ in (url, "etag") }
         enqueueThumbnailUpload(
             originalKey: "prefix/fail.jpg",
-            localURL: url,
             sourceETag: "etag",
             drive: drive,
             s3Client: mock,
             metadataStore: metadataStore,
             domain: ProviderTestFixtures.makeDomain(),
-            logger: makeLogger()
+            logger: makeLogger(),
+            limiter: ThumbnailUploadLimiter(),
+            download: downloadFn
         )
 
         // Drain the detached Task so the error path runs and is logged-and-swallowed.
@@ -268,15 +278,17 @@ final class UploadHookTests: XCTestCase {
             forOriginalKey: originalKey, drivePrefix: drive.syncAnchor.prefix
         )
 
+        let downloadFn: ThumbnailOriginalDownloader = { @Sendable _, _ in (url, "new-etag-after-modify") }
         enqueueThumbnailUpload(
             originalKey: originalKey,
-            localURL: url,
             sourceETag: "new-etag-after-modify",
             drive: drive,
             s3Client: mock,
             metadataStore: metadataStore,
             domain: ProviderTestFixtures.makeDomain(),
-            logger: makeLogger()
+            logger: makeLogger(),
+            limiter: ThumbnailUploadLimiter(),
+            download: downloadFn
         )
 
         let predicate = NSPredicate { _, _ in
@@ -297,17 +309,8 @@ final class UploadHookTests: XCTestCase {
     // MARK: - Test 6 — Metadata-only modify path does NOT trigger uploader
 
     /// The metadata-only modify branch in `+Modify.swift` (no `.contents` field) does
-    /// NOT call `enqueueThumbnailUpload`. We can only enforce this via grep / source
-    /// inspection, since the helper itself has no awareness of the calling branch.
-    /// The build-time assertion is: `+Modify.swift` invokes `enqueueThumbnailUpload`
-    /// inside the `changedFields.contains(.contents)` branch only.
-    ///
-    /// Behavioral test: invoking the helper with no localURL would also be an error;
-    /// the call site is gated by `let contents = newContents` already. Here we
-    /// assert the contract: when the helper IS called with a non-existent URL (i.e.
-    /// metadata-only branch never kicked render), no PUT happens because the helper
-    /// short-circuits — we exercise it via the .notApplicable pre-filter on a
-    /// non-raster filename to mirror the "do nothing" path.
+    /// NOT call `enqueueThumbnailUpload`. Enforced by grep — the helper has no
+    /// awareness of the calling branch. This test documents the contract.
     func testModifyItemMetadataOnlyChangeDoesNotTriggerUploader() async {
         let drive = ProviderTestFixtures.makeDrive()
         let mock = HookMockS3Client()
@@ -355,15 +358,17 @@ final class UploadHookTests: XCTestCase {
         // ThumbnailHybridConsumeTests.swift — same closure-injection seam).
         let recorder = SignalRecorder()
 
+        let downloadFn: ThumbnailOriginalDownloader = { @Sendable _, _ in (url, "etag-d12") }
         enqueueThumbnailUpload(
             originalKey: originalKey,
-            localURL: url,
             sourceETag: "etag-d12",
             drive: drive,
             s3Client: mock,
             metadataStore: metadataStore,
             domain: ProviderTestFixtures.makeDomain(),
             logger: makeLogger(),
+            limiter: ThumbnailUploadLimiter(),
+            download: downloadFn,
             signalParentContainer: { identifier in
                 Task { await recorder.record(identifier) }
             }
@@ -409,15 +414,17 @@ final class UploadHookTests: XCTestCase {
 
         let recorder = SignalRecorder()
 
+        let downloadFn: ThumbnailOriginalDownloader = { @Sendable _, _ in (url, "etag") }
         enqueueThumbnailUpload(
             originalKey: "prefix/fail.jpg",
-            localURL: url,
             sourceETag: "etag",
             drive: drive,
             s3Client: mock,
             metadataStore: metadataStore,
             domain: ProviderTestFixtures.makeDomain(),
             logger: makeLogger(),
+            limiter: ThumbnailUploadLimiter(),
+            download: downloadFn,
             signalParentContainer: { identifier in
                 Task { await recorder.record(identifier) }
             }
@@ -588,10 +595,5 @@ final class HookMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
     }
 }
 
-// MARK: - Test-only MetadataStore helper
-
-//
 // Phase 13.2 Plan 09: `fetchThumbnailStatusForTest` removed — Schema V6 dropped
-// the `thumbnailStatus` field. Tests no longer have any per-row thumbnail state
-// to inspect; the only observable signal is "did the S3 PUT happen?" which the
-// mock S3 client records directly.
+// `thumbnailStatus`. Tests observe upload-hook behavior via the mock S3 client.

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
@@ -8,6 +8,22 @@ import UniformTypeIdentifiers
 // ImageIO and blow its 20 MB jetsam budget. Body-level gating leaks the symbol.
 #if os(macOS)
 
+    /// Sub-reason for a `renderJPEG` failure. Surfaces in logs at the call site
+    /// so we can distinguish FileProvider-temp-URL eviction (`dataLoad`) from
+    /// ImageIO concurrent-decode-pressure failures (`thumbnailCreate`) etc.
+    public enum RenderFailure: String, Error, Sendable, Equatable {
+        /// `Data(contentsOf:.mappedIfSafe)` threw — file gone, sandbox eviction, IO error.
+        case dataLoad
+        /// `CGImageSourceCreateWithData` returned nil — bytes don't form a valid image source.
+        case sourceCreate
+        /// UTI not in the raster allow-list (RAW, PDF, etc.).
+        case utiReject
+        /// `CGImageSourceCreateThumbnailAtIndex` returned nil — ImageIO decode failed.
+        case thumbnailCreate
+        /// JPEG encoder init or finalize failed.
+        case jpegEncode
+    }
+
     public struct ThumbnailRenderer {
         public let maxDimension: CGFloat
         public let jpegQuality: Float
@@ -20,13 +36,13 @@ import UniformTypeIdentifiers
             self.jpegQuality = jpegQuality
         }
 
-        public func renderJPEG(from fileURL: URL) -> Data? {
+        public func renderJPEG(from fileURL: URL) -> Result<Data, RenderFailure> {
             #if canImport(UIKit)
                 // Dead code under the outer macOS gate; kept as defense-in-depth
                 // in case the gate is ever loosened.
                 let availableMemory = os_proc_available_memory()
                 if availableMemory > 0, availableMemory < Self.minAvailableMemoryBytes {
-                    return nil
+                    return .failure(.dataLoad)
                 }
             #endif
 
@@ -47,7 +63,7 @@ import UniformTypeIdentifiers
                 do {
                     data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
                 } catch {
-                    return nil
+                    return .failure(.dataLoad)
                 }
 
                 let sourceOptions: [CFString: Any] = [
@@ -57,12 +73,12 @@ import UniformTypeIdentifiers
                     data as CFData,
                     sourceOptions as CFDictionary
                 )
-                else { return nil }
+                else { return .failure(.sourceCreate) }
 
                 // Reject RAW, PDF, etc. by UTI (file extension is unreliable).
                 guard let sourceType = CGImageSourceGetType(source),
                       Self.allowedRasterUTIs.contains(sourceType)
-                else { return nil }
+                else { return .failure(.utiReject) }
 
                 let options: [CFString: Any] = [
                     kCGImageSourceCreateThumbnailFromImageAlways: true,
@@ -74,9 +90,12 @@ import UniformTypeIdentifiers
                 guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
                     source, 0, options as CFDictionary
                 )
-                else { return nil }
+                else { return .failure(.thumbnailCreate) }
 
-                return jpegData(from: cgImage)
+                guard let bytes = jpegData(from: cgImage) else {
+                    return .failure(.jpegEncode)
+                }
+                return .success(bytes)
             }
         }
 

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
@@ -15,12 +15,15 @@ import UniformTypeIdentifiers
         /// `Data(contentsOf:.mappedIfSafe)` threw — file gone, sandbox eviction, IO error.
         case dataLoad
         /// `CGImageSourceCreateWithData` returned nil — bytes don't form a valid image source.
+        /// Not directly exercisable in unit tests (CGImageSource is permissive on invalid bytes); retained for
+        /// production diagnostic coverage.
         case sourceCreate
         /// UTI not in the raster allow-list (RAW, PDF, etc.).
         case utiReject
         /// `CGImageSourceCreateThumbnailAtIndex` returned nil — ImageIO decode failed.
         case thumbnailCreate
         /// JPEG encoder init or finalize failed.
+        /// Not directly exercisable in unit tests; retained for production diagnostic coverage.
         case jpegEncode
     }
 

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
@@ -4,28 +4,28 @@ import ImageIO
 import os
 import UniformTypeIdentifiers
 
+/// Sub-reason for a `renderJPEG` failure. Surfaces in logs at the call site
+/// so we can distinguish FileProvider-temp-URL eviction (`dataLoad`) from
+/// ImageIO concurrent-decode-pressure failures (`thumbnailCreate`) etc.
+public enum RenderFailure: String, Error, Sendable, Equatable {
+    /// `Data(contentsOf:.mappedIfSafe)` threw — file gone, sandbox eviction, IO error.
+    case dataLoad
+    /// `CGImageSourceCreateWithData` returned nil — bytes don't form a valid image source.
+    /// Not directly exercisable in unit tests (CGImageSource is permissive on invalid bytes); retained for
+    /// production diagnostic coverage.
+    case sourceCreate
+    /// UTI not in the raster allow-list (RAW, PDF, etc.).
+    case utiReject
+    /// `CGImageSourceCreateThumbnailAtIndex` returned nil — ImageIO decode failed.
+    case thumbnailCreate
+    /// JPEG encoder init or finalize failed.
+    /// Not directly exercisable in unit tests; retained for production diagnostic coverage.
+    case jpegEncode
+}
+
 // THUMB-07: whole-type `#if os(macOS)` gate so the iOS extension cannot link
 // ImageIO and blow its 20 MB jetsam budget. Body-level gating leaks the symbol.
 #if os(macOS)
-
-    /// Sub-reason for a `renderJPEG` failure. Surfaces in logs at the call site
-    /// so we can distinguish FileProvider-temp-URL eviction (`dataLoad`) from
-    /// ImageIO concurrent-decode-pressure failures (`thumbnailCreate`) etc.
-    public enum RenderFailure: String, Error, Sendable, Equatable {
-        /// `Data(contentsOf:.mappedIfSafe)` threw — file gone, sandbox eviction, IO error.
-        case dataLoad
-        /// `CGImageSourceCreateWithData` returned nil — bytes don't form a valid image source.
-        /// Not directly exercisable in unit tests (CGImageSource is permissive on invalid bytes); retained for
-        /// production diagnostic coverage.
-        case sourceCreate
-        /// UTI not in the raster allow-list (RAW, PDF, etc.).
-        case utiReject
-        /// `CGImageSourceCreateThumbnailAtIndex` returned nil — ImageIO decode failed.
-        case thumbnailCreate
-        /// JPEG encoder init or finalize failed.
-        /// Not directly exercisable in unit tests; retained for production diagnostic coverage.
-        case jpegEncode
-    }
 
     public struct ThumbnailRenderer {
         public let maxDimension: CGFloat

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailUploader.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailUploader.swift
@@ -18,6 +18,13 @@ import os.log
 ///   - PUT throws → log + RETHROW (caller's `try? await ...` swallows). No
 ///     schema strike counter write.
 ///
+/// NOTE: This DS3Lib-side helper is the legacy localURL-based path
+/// (still used by call sites that haven't migrated). The eager-path
+/// `runUploadHook` in DS3DriveProvider is the canonical post-#141
+/// implementation and uses different error semantics (logs + swallows
+/// PUT errors per D-06; does not rethrow). Don't unify their
+/// behavior without revisiting the eager-path D-06 contract.
+///
 /// Phase 13.2 Plan 09 (D-08, D-23): all `thumbnailStatus` writes removed in
 /// the same plan that ships Schema V6 — the field is gone from `SyncedItem`,
 /// so writing to it would not compile. The `metadataStore` parameter is

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailUploader.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailUploader.swift
@@ -12,9 +12,10 @@ import os.log
 ///
 /// Failure semantics (D-06 fire-and-forget contract, Phase 13.2 D-05/D-08/D-19):
 ///   - Non-raster originalKey → log + return (caller pre-filters anyway).
-///   - Renderer returns nil → log only and return. No schema strike counter
-///     anymore (Schema V5 dropped `thumbnailFailCount`); the consume-path
-///     fallback's `ThumbnailFallbackLimiter` owns the in-memory 3-strike rule.
+///   - Renderer returns `.failure(reason)` → log the sub-reason and return.
+///     No schema strike counter anymore (Schema V5 dropped `thumbnailFailCount`);
+///     the consume-path fallback's `ThumbnailFallbackLimiter` owns the
+///     in-memory 3-strike rule.
 ///   - PUT throws → log + RETHROW (caller's `try? await ...` swallows). No
 ///     schema strike counter write.
 ///

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailUploader.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailUploader.swift
@@ -67,9 +67,14 @@ public struct ThumbnailUploader: Sendable {
             // (b) Render — the renderer's allow-list (UTI-based, magic-byte sniffed) is
             // stricter than the extension allow-list, so this branch fires for files with
             // a raster extension whose bytes don't decode (corrupt JPEGs, unknown UTI).
-            guard let data = ThumbnailRenderer().renderJPEG(from: localURL) else {
+            let renderResult = ThumbnailRenderer().renderJPEG(from: localURL)
+            let data: Data
+            switch renderResult {
+            case let .success(bytes):
+                data = bytes
+            case let .failure(reason):
                 logger.info(
-                    "Uploader: render returned nil for \(originalKey, privacy: .public)"
+                    "Uploader: render failed for \(originalKey, privacy: .public) — reason=\(reason.rawValue, privacy: .public)"
                 )
                 // Phase 13.2 D-05/D-19: no schema strike counter anymore. The
                 // consume-path fallback's `ThumbnailFallbackLimiter` (in-memory)

--- a/DS3Lib/Tests/DS3LibTests/ThumbnailRendererTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ThumbnailRendererTests.swift
@@ -55,8 +55,8 @@ import XCTest
             let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
             let result = renderer.renderJPEG(from: pdfURL)
 
-            XCTAssertNil(
-                result,
+            XCTAssertEqual(
+                result, .failure(.utiReject),
                 "PDF (UTI com.adobe.pdf) must be rejected by the raster allow-list"
             )
         }
@@ -82,9 +82,10 @@ import XCTest
 
             for index in 0 ..< iterations {
                 let result = renderer.renderJPEG(from: pngURL)
-                XCTAssertNotNil(
-                    result, "iteration \(index): expected non-nil thumbnail for PNG fixture"
-                )
+                guard case .success = result else {
+                    XCTFail("iteration \(index): expected .success, got \(result)")
+                    return
+                }
             }
 
             let elapsed = Date().timeIntervalSince(startedAt)
@@ -111,10 +112,11 @@ import XCTest
             defer { try? FileManager.default.removeItem(at: sourceURL) }
 
             let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
-            let thumbnailData = try XCTUnwrap(
-                renderer.renderJPEG(from: sourceURL),
-                "expected a thumbnail for the EXIF-6 landscape JPEG"
-            )
+            let renderResult = renderer.renderJPEG(from: sourceURL)
+            guard case .success(let thumbnailData) = renderResult else {
+                XCTFail("expected .success, got \(renderResult)")
+                return
+            }
 
             // Decode the generated JPEG and inspect its pixel geometry.
             let decodedSource = try XCTUnwrap(
@@ -147,10 +149,11 @@ import XCTest
             )
 
             let renderer = ThumbnailRenderer()
-            let thumbnailData = try XCTUnwrap(
-                renderer.renderJPEG(from: pngURL),
-                "default renderer must produce a non-nil thumbnail"
-            )
+            let renderResult = renderer.renderJPEG(from: pngURL)
+            guard case .success(let thumbnailData) = renderResult else {
+                XCTFail("default renderer must produce a non-nil thumbnail, got \(renderResult)")
+                return
+            }
 
             // Confirm we got a JPEG (not just any bytes).
             let decodedSource = try XCTUnwrap(
@@ -194,7 +197,10 @@ import XCTest
             // bulk-paste scenario where 8 different files are rendered in parallel.
             // Reading the same URL from multiple tasks would mask URL/page-cache
             // contention bugs that only surface across distinct backing files.
-            let results = await withTaskGroup(of: Data?.self, returning: [Data?].self) { group in
+            let results = await withTaskGroup(
+                of: Result<Data, RenderFailure>.self,
+                returning: [Result<Data, RenderFailure>].self
+            ) { group in
                 for _ in 0..<8 {
                     group.addTask {
                         let copy = tempDir.appendingPathComponent("fanout-\(UUID().uuidString).png")
@@ -204,15 +210,15 @@ import XCTest
                         return renderer.renderJPEG(from: copy)
                     }
                 }
-                var collected: [Data?] = []
+                var collected: [Result<Data, RenderFailure>] = []
                 for await result in group { collected.append(result) }
                 return collected
             }
 
             XCTAssertEqual(results.count, 8)
-            let nonNilCount = results.compactMap { $0 }.count
+            let successCount = results.filter { if case .success = $0 { return true } else { return false } }.count
             XCTAssertEqual(
-                nonNilCount, 8,
+                successCount, 8,
                 "All 8 concurrent renders must succeed (audit baseline: 2/8 — should be 8/8 after Finding 2 fix)"
             )
         }
@@ -228,16 +234,21 @@ import XCTest
             let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
 
             let firstResult = renderer.renderJPEG(from: heicURL)
-            XCTAssertNotNil(firstResult, "First render of HEIC must succeed")
+            guard case .success = firstResult else {
+                XCTFail("First render of HEIC must succeed, got \(firstResult)")
+                return
+            }
 
             // 200ms delay simulates the user re-paste timing in the audit.
             try await Task.sleep(for: .milliseconds(200))
 
             let secondResult = renderer.renderJPEG(from: heicURL)
-            XCTAssertNotNil(
-                secondResult,
-                "Second render of identical HEIC bytes must succeed (audit symptom: nil on repeat)"
-            )
+            guard case .success = secondResult else {
+                XCTFail(
+                    "Second render of identical HEIC bytes must succeed (audit symptom: nil on repeat), got \(secondResult)"
+                )
+                return
+            }
         }
 
         /// Backfill path: renderer reads from a renderer-owned temp file that the
@@ -260,10 +271,40 @@ import XCTest
             let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
             let result = renderer.renderJPEG(from: tempURL)
 
-            XCTAssertNotNil(
-                result,
-                "Render from coordinator-owned temp file must succeed (audit symptom: nil on backfill path)"
+            guard case .success = result else {
+                XCTFail(
+                    "Render from coordinator-owned temp file must succeed (audit symptom: nil on backfill path), got \(result)"
+                )
+                return
+            }
+        }
+
+        // MARK: - RenderFailure Sub-reason Coverage (#141 Task 1)
+
+        /// Missing file → `Data(contentsOf:.mappedIfSafe)` throws → `.dataLoad`.
+        func testRenderJPEGReturnsDataLoadFailureForMissingFile() {
+            let missing = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString).jpg")
+            let result = ThumbnailRenderer().renderJPEG(from: missing)
+            XCTAssertEqual(result, .failure(.dataLoad))
+        }
+
+        /// Garbage bytes whose UTI cannot be sniffed → `.utiReject`.
+        ///
+        /// (`.sourceCreate` is left uncovered here because in practice
+        /// `CGImageSourceCreateWithData` is extremely permissive — it
+        /// returns a non-nil source even for empty / random CFData and
+        /// fails later at the `GetType` step, surfacing as `.utiReject`.
+        /// The PDF allow-list test exercises the same code path with a
+        /// real image source, and the missing-file test pins `.dataLoad`.)
+        func testRenderJPEGReturnsUTIRejectForGarbageBytes() throws {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "garbage-\(UUID().uuidString).bin"
             )
+            let garbage = Data(repeating: 0xFF, count: 1024)
+            try garbage.write(to: url)
+            defer { try? FileManager.default.removeItem(at: url) }
+            let result = ThumbnailRenderer().renderJPEG(from: url)
+            XCTAssertEqual(result, .failure(.utiReject))
         }
 
         // MARK: - EXIF-6 Fixture Synthesis


### PR DESCRIPTION
## Summary

- Fixes #141: bulk drag-copy of raster files left 11/14 thumbnails absent on S3 due to two concurrent bugs — FileProvider temp URL invalidation race and unbounded ImageIO concurrency under bulk load.
- Eager path no longer reads `localURL` from FileProvider; instead downloads the original from S3 after the original PUT completes (same bytes-source as the consume-path fallback, eliminating the URL-lifetime race entirely).
- New `ThumbnailUploadLimiter` actor (2 slots, 64-waiter soft cap) gates concurrent eager-path render+PUT; overflow drops silently and is filled by the existing consume-path fallback on first Finder view.
- `ThumbnailRenderer.renderJPEG` now returns `Result<Data, RenderFailure>` instead of `Data?`, making the five distinct failure paths (`dataLoad`, `sourceCreate`, `utiReject`, `thumbnailCreate`, `jpegEncode`) distinguishable in logs at both the upload-hook and consume-path call sites.
- Consume path (cache-miss fallback, fetch limiter, fallback limiter, Finder error mapping) is unchanged.

## Architecture

The eager path's detached Task previously raced FileProvider's temp URL eviction (`Data(contentsOf:)` reading the temp file hundreds of ms after `createItem` returned success) AND slammed ImageIO with N concurrent decodes for N parallel uploads (silent nil under concurrent decode pressure).

The fix structurally removes both:
- `runUploadHook` acquires a `ThumbnailUploadLimiter` slot (FIFO, 2-slot ceiling) BEFORE doing anything; releases explicitly on every exit path (mirrors `consumeThumbnailFallback`'s Code review Fix 2 — no `defer { Task { await release } }`).
- Bytes come from `s3Lib.downloadS3Item` — the same call the consume-path fallback already uses. Same closure-injection pattern (`ThumbnailOriginalDownloader` typealias reused, no new typealias).
- Soft cap drops at the producer; consume-path fallback (untouched) handles overflow on first Finder view. No backpressure on `createItem` itself.

Validated against Nextcloud / ownCloud / Dropbox prior art: all three bound the worker pool, not the queue, and keep a lazy fallback as the safety net even when an eager path exists.

## Commits (8, atomic)

- `1a7e66e` surface render failure sub-reason via Result type
- `e07f0a9` document RenderFailure cases not exercised in tests
- `89d7985` add ThumbnailUploadLimiter actor with soft cap
- `77a5a36` strong-capture self in UploadLimiter onCancel handler
- `0bc6193` hold ThumbnailUploadLimiter on FileProviderExtension
- `8c76d1b` pivot eager path to S3 GET, gate via ThumbnailUploadLimiter
- `f27319e` tighten upload-hook capture discipline + soft-cap priority
- `74ce8ea` align upload-hook release pattern + observability

## Test plan

- [x] `xcodebuild build` green (macOS scheme)
- [x] `ThumbnailUploadLimiterTests` 6/6 pass (FIFO, cancellation, soft cap)
- [x] `UploadHookTests` 9/9 pass (1 documented compile-time guard skip)
- [x] `ThumbnailHybridConsumeTests` 7/7 pass (consume path untouched)
- [x] `ThumbnailRendererTests` migrated to `Result` return type
- [x] Per-task spec + quality reviews + final cross-cutting review all approved
- [ ] **Manual repro on macOS:** drag-copy 15 raster files (PNG/HEIC mix, 84 KB – 24 MB) into a single folder of the DS3 drive. Confirm 14 `.thumbnails/<key>.jpg` entries on S3 and 14 `Upload-hook: PUT succeeded` log lines (zero `render failed`, zero `GET original failed`). Repro instructions at `docs/superpowers/plans/2026-04-29-thumbnail-bulk-upload-fix.md` step 5.
- [ ] **Stress at N=200:** soft-cap kicks in past 64+2 in-flight; remaining files fill lazily via consume-path fallback as Finder scrolls them.
- [ ] **No-regression sanity:** previously-uploaded folder still hits cached-thumb GET; manually deleted thumbnail regenerates via consume-path fallback (`Fallback: PUT succeeded`).

Closes #141.