### PR TITLE
fix(auth): use tenant_id (UUID) for multi-tenant login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ iOSInjectionProject/
 .env.local
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,swift,xcode
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,11 @@ killall fileproviderd
 
 **IMPORTANT:** Never use `xcodebuild` with `CODE_SIGN_IDENTITY="-"` (ad-hoc signing) — it strips App Group entitlements and poisons all caches.
 
+## Git Worktrees
+
+- Worktree directory: `.worktrees/` (project-local, hidden, gitignored)
+- Create worktrees with: `git worktree add .worktrees/<branch-name> -b <branch-name>`
+
 ## Commit Guidelines
 
 - Don't mention Claude Code in commits or PRs

--- a/DS3Drive/Views/Login/Views/LoginView.swift
+++ b/DS3Drive/Views/Login/Views/LoginView.swift
@@ -162,8 +162,10 @@ struct LoginView: View {
                                     )
                                     .font(DS3Typography.caption)
                                     .foregroundStyle(DS3Colors.brandTextPrimary)
+                                    .multilineTextAlignment(.leading)
+                                    .fixedSize(horizontal: false, vertical: true)
                                     .padding(DS3Spacing.md)
-                                    .frame(maxWidth: 260)
+                                    .frame(width: 300)
                                 }
                             }
                             .padding(DS3Spacing.md)

--- a/DS3Drive/Views/Login/Views/LoginView.swift
+++ b/DS3Drive/Views/Login/Views/LoginView.swift
@@ -149,12 +149,15 @@ struct LoginView: View {
                                 TextField("Tenant ID", text: $tenant)
                                     .textFieldStyle(.plain)
                                     .font(DS3Typography.body)
-                                Image(systemName: "questionmark.circle")
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(DS3Colors.brandTextSecondary.opacity(0.6))
-                                    .help(
-                                        "Find your Tenant ID in the Tenants section of the Composer dashboard. If you don't have access, contact your administrator or support."
-                                    )
+                                Button { /* tooltip target */ } label: {
+                                    Image(systemName: "questionmark.circle")
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(DS3Colors.brandTextSecondary.opacity(0.6))
+                                }
+                                .buttonStyle(.plain)
+                                .help(
+                                    "Find your Tenant ID in the Tenants section of the Composer dashboard. If you don't have access, contact your administrator or support."
+                                )
                             }
                             .padding(DS3Spacing.md)
                             .background(

--- a/DS3Drive/Views/Login/Views/LoginView.swift
+++ b/DS3Drive/Views/Login/Views/LoginView.swift
@@ -147,6 +147,17 @@ struct LoginView: View {
                                 TextField("Tenant ID", text: $tenant)
                                     .textFieldStyle(.plain)
                                     .font(DS3Typography.body)
+                                if let tenantsURL = URL(string: ComposerURLs.tenantsURL) {
+                                    Link(destination: tenantsURL) {
+                                        Image(systemName: "questionmark.circle")
+                                            .font(.system(size: 13))
+                                            .foregroundStyle(DS3Colors.brandTextSecondary.opacity(0.6))
+                                    }
+                                    .buttonStyle(.plain)
+                                    .help(
+                                        "Find your Tenant ID in the Tenants section of the Composer dashboard. If you don't have access, contact your administrator or support."
+                                    )
+                                }
                             }
                             .padding(DS3Spacing.md)
                             .background(

--- a/DS3Drive/Views/Login/Views/LoginView.swift
+++ b/DS3Drive/Views/Login/Views/LoginView.swift
@@ -18,6 +18,7 @@ struct LoginView: View {
     @State private var coordinatorURL: String = UserDefaults.standard
         .string(forKey: DefaultSettings.UserDefaultsKeys.lastCoordinatorURL) ?? CubbitAPIURLs.defaultCoordinatorURL
     @State private var showAdvanced: Bool = false
+    @State private var showTenantHint = false
     @FocusState private var focusedField: FocusedField?
 
     @State private var loginViewModel = LoginViewModel()
@@ -149,15 +150,21 @@ struct LoginView: View {
                                 TextField("Tenant ID", text: $tenant)
                                     .textFieldStyle(.plain)
                                     .font(DS3Typography.body)
-                                Button { /* tooltip target */ } label: {
+                                Button { showTenantHint.toggle() } label: {
                                     Image(systemName: "questionmark.circle")
                                         .font(.system(size: 13))
                                         .foregroundStyle(DS3Colors.brandTextSecondary.opacity(0.6))
                                 }
                                 .buttonStyle(.plain)
-                                .help(
-                                    "Find your Tenant ID in the Tenants section of the Composer dashboard. If you don't have access, contact your administrator or support."
-                                )
+                                .popover(isPresented: $showTenantHint, arrowEdge: .bottom) {
+                                    Text(
+                                        "Find your Tenant ID in the Tenants section of the Composer dashboard. If you don't have access, contact your administrator or support."
+                                    )
+                                    .font(DS3Typography.caption)
+                                    .foregroundStyle(DS3Colors.brandTextPrimary)
+                                    .padding(DS3Spacing.md)
+                                    .frame(maxWidth: 260)
+                                }
                             }
                             .padding(DS3Spacing.md)
                             .background(

--- a/DS3Drive/Views/Login/Views/LoginView.swift
+++ b/DS3Drive/Views/Login/Views/LoginView.swift
@@ -11,7 +11,9 @@ struct LoginView: View {
     @State private var password: String = ""
     @State private var tenant: String = {
         let saved = UserDefaults.standard.string(forKey: DefaultSettings.UserDefaultsKeys.lastTenant) ?? ""
-        return saved.isEmpty ? DefaultSettings.defaultTenantName : saved
+        // Discard legacy tenant names (not UUIDs) saved before the tenant_id migration.
+        guard !saved.isEmpty, UUID(uuidString: saved) != nil else { return "" }
+        return saved
     }()
     @State private var coordinatorURL: String = UserDefaults.standard
         .string(forKey: DefaultSettings.UserDefaultsKeys.lastCoordinatorURL) ?? CubbitAPIURLs.defaultCoordinatorURL
@@ -147,17 +149,12 @@ struct LoginView: View {
                                 TextField("Tenant ID", text: $tenant)
                                     .textFieldStyle(.plain)
                                     .font(DS3Typography.body)
-                                if let tenantsURL = URL(string: ComposerURLs.tenantsURL) {
-                                    Link(destination: tenantsURL) {
-                                        Image(systemName: "questionmark.circle")
-                                            .font(.system(size: 13))
-                                            .foregroundStyle(DS3Colors.brandTextSecondary.opacity(0.6))
-                                    }
-                                    .buttonStyle(.plain)
+                                Image(systemName: "questionmark.circle")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(DS3Colors.brandTextSecondary.opacity(0.6))
                                     .help(
                                         "Find your Tenant ID in the Tenants section of the Composer dashboard. If you don't have access, contact your administrator or support."
                                     )
-                                }
                             }
                             .padding(DS3Spacing.md)
                             .background(

--- a/DS3Drive/Views/Login/Views/LoginView.swift
+++ b/DS3Drive/Views/Login/Views/LoginView.swift
@@ -144,7 +144,7 @@ struct LoginView: View {
                                 Image(systemName: "person")
                                     .foregroundStyle(DS3Colors.brandTextSecondary)
                                     .frame(width: 20)
-                                TextField("Tenant name", text: $tenant)
+                                TextField("Tenant ID", text: $tenant)
                                     .textFieldStyle(.plain)
                                     .font(DS3Typography.body)
                             }
@@ -221,7 +221,7 @@ struct LoginView: View {
 
         let viewModel = loginViewModel
         let auth = ds3Authentication
-        let tenantValue = (tenant.isEmpty || tenant == DefaultSettings.defaultTenantName) ? nil : tenant
+        let tenantValue = tenant.isEmpty ? nil : tenant
         Task {
             do {
                 try await viewModel.login(

--- a/DS3Drive/Views/Login/Views/MFAView.swift
+++ b/DS3Drive/Views/Login/Views/MFAView.swift
@@ -103,7 +103,7 @@ struct MFAView: View {
     func loginWithMFA() {
         let viewModel = loginViewModel
         let auth = ds3Authentication
-        let tenantValue = (tenant.isEmpty || tenant == DefaultSettings.defaultTenantName) ? nil : tenant
+        let tenantValue = tenant.isEmpty ? nil : tenant
         Task {
             do {
                 try await viewModel.login(

--- a/DS3Drive/Views/Preferences/Views/ConnectionTab.swift
+++ b/DS3Drive/Views/Preferences/Views/ConnectionTab.swift
@@ -57,7 +57,7 @@ struct ConnectionTab: View {
             coordinatorURL = (try? SharedData.default().loadCoordinatorURLFromPersistence())
                 ?? CubbitAPIURLs.defaultCoordinatorURL
             let tenant = (try? SharedData.default().loadTenantNameFromPersistence()) ?? ""
-            tenantName = tenant
+            tenantName = tenant.isEmpty ? NSLocalizedString("N/A", comment: "Not available") : tenant
         }
     }
 

--- a/DS3Drive/Views/Preferences/Views/ConnectionTab.swift
+++ b/DS3Drive/Views/Preferences/Views/ConnectionTab.swift
@@ -24,7 +24,7 @@ struct ConnectionTab: View {
                 )
                 ConnectionInfoRow(
                     icon: "person.2",
-                    label: NSLocalizedString("Tenant", comment: "Connection info label"),
+                    label: NSLocalizedString("Tenant ID", comment: "Connection info label"),
                     value: tenantName
                 )
                 ConnectionInfoRow(
@@ -57,7 +57,7 @@ struct ConnectionTab: View {
             coordinatorURL = (try? SharedData.default().loadCoordinatorURLFromPersistence())
                 ?? CubbitAPIURLs.defaultCoordinatorURL
             let tenant = (try? SharedData.default().loadTenantNameFromPersistence()) ?? ""
-            tenantName = tenant.isEmpty ? DefaultSettings.defaultTenantName : tenant
+            tenantName = tenant
         }
     }
 

--- a/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
+++ b/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
@@ -839,7 +839,7 @@ private func friendlyErrorMessage(for error: Error) -> String {
     if isNetworkUnreachable {
         return NSLocalizedString(
             "error.gatewayUnreachable",
-            value: "Cannot reach the storage gateway. The service may be temporarily unavailable — contact your administrator.",
+            value: "Cannot reach the DS3 Gateway. The service may be temporarily unavailable — contact your administrator.",
             comment: "Error shown when the S3 gateway DNS lookup or connection fails"
         )
     }

--- a/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
+++ b/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
@@ -260,7 +260,10 @@ class TreeNavigationViewModel {
             )
 
             // Filter .thumbnails/ and .trash/ from wizard folder browser (Phase 11)
-            let visibleFolderPrefixes = result.commonPrefixes.filter { S3KeyFilter.isUserVisible(key: $0, drivePrefix: prefix) }
+            let visibleFolderPrefixes = result.commonPrefixes.filter { S3KeyFilter.isUserVisible(
+                key: $0,
+                drivePrefix: prefix
+            ) }
             node.children = visibleFolderPrefixes.map { decoded -> TreeNode in
                 let displayName = folderDisplayName(fullPrefix: decoded, parentPrefix: prefix)
                 return TreeNode(
@@ -623,7 +626,7 @@ struct TreeNavigationView: View {
             // so the wizard is no longer a dead end.
             if let error = viewModel.error {
                 VStack(spacing: DS3Spacing.sm) {
-                    Text(error.localizedDescription)
+                    Text(friendlyErrorMessage(for: error))
                         .font(DS3Typography.caption)
                         .foregroundStyle(DS3Colors.statusError)
 
@@ -815,4 +818,30 @@ struct TreeNavigationView: View {
         copy.onSyncAnchorSelected = action
         return copy
     }
+}
+
+// MARK: - Error helpers
+
+private func friendlyErrorMessage(for error: Error) -> String {
+    let nsError = error as NSError
+    // DNS failure (NWError -65554 NoSuchRecord) or host not found — the storage
+    // gateway is unreachable. Surface a human-readable message instead of the
+    // raw NWError code.
+    let isNetworkUnreachable =
+        nsError.domain == "Network.NWError" ||
+        (nsError.domain == NSURLErrorDomain && [
+            NSURLErrorCannotFindHost,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorNotConnectedToInternet,
+            NSURLErrorDNSLookupFailed
+        ].contains(nsError.code))
+    if isNetworkUnreachable {
+        return NSLocalizedString(
+            "error.gatewayUnreachable",
+            value: "Cannot reach the storage gateway. The service may be temporarily unavailable — contact your administrator.",
+            comment: "Error shown when the S3 gateway DNS lookup or connection fails"
+        )
+    }
+    return error.localizedDescription
 }

--- a/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
+++ b/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
@@ -632,7 +632,7 @@ struct TreeNavigationView: View {
                         .multilineTextAlignment(.center)
 
                     let nsError = error as NSError
-                    Text("\(nsError.domain) \(nsError.code)")
+                    Text("\(nsError.domain) \(String(nsError.code))")
                         .font(DS3Typography.footnote)
                         .foregroundStyle(DS3Colors.secondaryText)
                         .textSelection(.enabled)

--- a/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
+++ b/DS3Drive/Views/Sync/Views/TreeNavigationView.swift
@@ -629,6 +629,13 @@ struct TreeNavigationView: View {
                     Text(friendlyErrorMessage(for: error))
                         .font(DS3Typography.caption)
                         .foregroundStyle(DS3Colors.statusError)
+                        .multilineTextAlignment(.center)
+
+                    let nsError = error as NSError
+                    Text("\(nsError.domain) \(nsError.code)")
+                        .font(DS3Typography.footnote)
+                        .foregroundStyle(DS3Colors.secondaryText)
+                        .textSelection(.enabled)
 
                     if error is DS3AuthenticationError {
                         Button(NSLocalizedString(
@@ -642,6 +649,7 @@ struct TreeNavigationView: View {
                         .buttonStyle(OutlineButtonStyle())
                     }
                 }
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, DS3Spacing.lg)
                 .padding(.bottom, DS3Spacing.sm)
             }

--- a/DS3DriveApp/Views/Login/IOSLoginView.swift
+++ b/DS3DriveApp/Views/Login/IOSLoginView.swift
@@ -172,9 +172,9 @@
                     if showAdvanced {
                         brandField(icon: "person", focus: .tenant) {
                             TextField(
-                                "Tenant name",
+                                "Tenant ID",
                                 text: $tenant,
-                                prompt: Text(DefaultSettings.defaultTenantName)
+                                prompt: Text("Tenant ID")
                                     .foregroundColor(IOSColors.brandTextSecondary)
                             )
                             .autocorrectionDisabled()
@@ -314,7 +314,7 @@
             UserDefaults.standard.set(tenant, forKey: DefaultSettings.UserDefaultsKeys.lastTenant)
             UserDefaults.standard.set(coordinatorURL, forKey: DefaultSettings.UserDefaultsKeys.lastCoordinatorURL)
 
-            let tenantValue = (tenant.isEmpty || tenant == DefaultSettings.defaultTenantName) ? nil : tenant
+            let tenantValue = tenant.isEmpty ? nil : tenant
             let viewModel = loginViewModel
             let auth = ds3Authentication
 

--- a/DS3DriveApp/Views/Login/IOSLoginView.swift
+++ b/DS3DriveApp/Views/Login/IOSLoginView.swift
@@ -170,15 +170,33 @@
                     .buttonStyle(.plain)
 
                     if showAdvanced {
-                        brandField(icon: "person", focus: .tenant) {
-                            TextField(
-                                "Tenant ID",
-                                text: $tenant,
-                                prompt: Text("Tenant ID")
-                                    .foregroundColor(IOSColors.brandTextSecondary)
-                            )
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
+                        VStack(alignment: .leading, spacing: 6) {
+                            brandField(icon: "person", focus: .tenant) {
+                                TextField(
+                                    "Tenant ID",
+                                    text: $tenant,
+                                    prompt: Text("Tenant ID")
+                                        .foregroundColor(IOSColors.brandTextSecondary)
+                                )
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.never)
+                            }
+
+                            if let tenantsURL = URL(string: ComposerURLs.tenantsURL) {
+                                Link(destination: tenantsURL) {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "questionmark.circle")
+                                            .font(.system(size: 11))
+                                        Text(
+                                            "Find your Tenant ID in the Composer dashboard, or contact your administrator."
+                                        )
+                                        .font(.custom("Figtree-Regular", size: 12))
+                                        .multilineTextAlignment(.leading)
+                                    }
+                                    .foregroundStyle(IOSColors.brandTextSecondary.opacity(0.7))
+                                }
+                                .padding(.horizontal, 4)
+                            }
                         }
 
                         brandField(icon: "globe", focus: .coordinator) {

--- a/DS3DriveApp/Views/Login/IOSLoginView.swift
+++ b/DS3DriveApp/Views/Login/IOSLoginView.swift
@@ -20,7 +20,9 @@
         @State private var showPassword = false
         @State private var tenant: String = {
             let saved = UserDefaults.standard.string(forKey: DefaultSettings.UserDefaultsKeys.lastTenant) ?? ""
-            return saved.isEmpty ? DefaultSettings.defaultTenantName : saved
+            // Discard legacy tenant names (not UUIDs) saved before the tenant_id migration.
+            guard !saved.isEmpty, UUID(uuidString: saved) != nil else { return "" }
+            return saved
         }()
         @State private var coordinatorURL: String = UserDefaults.standard
             .string(forKey: DefaultSettings.UserDefaultsKeys.lastCoordinatorURL) ?? CubbitAPIURLs.defaultCoordinatorURL
@@ -182,21 +184,15 @@
                                 .textInputAutocapitalization(.never)
                             }
 
-                            if let tenantsURL = URL(string: ComposerURLs.tenantsURL) {
-                                Link(destination: tenantsURL) {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "questionmark.circle")
-                                            .font(.system(size: 11))
-                                        Text(
-                                            "Find your Tenant ID in the Composer dashboard, or contact your administrator."
-                                        )
-                                        .font(.custom("Figtree-Regular", size: 12))
-                                        .multilineTextAlignment(.leading)
-                                    }
-                                    .foregroundStyle(IOSColors.brandTextSecondary.opacity(0.7))
-                                }
-                                .padding(.horizontal, 4)
+                            HStack(spacing: 4) {
+                                Image(systemName: "questionmark.circle")
+                                    .font(.system(size: 11))
+                                Text("Find your Tenant ID in the Composer dashboard, or contact your administrator.")
+                                    .font(.custom("Figtree-Regular", size: 12))
+                                    .multilineTextAlignment(.leading)
                             }
+                            .foregroundStyle(IOSColors.brandTextSecondary.opacity(0.7))
+                            .padding(.horizontal, 4)
                         }
 
                         brandField(icon: "globe", focus: .coordinator) {

--- a/DS3DriveApp/Views/Login/IOSMFAView.swift
+++ b/DS3DriveApp/Views/Login/IOSMFAView.swift
@@ -236,7 +236,7 @@
 
             let viewModel = loginViewModel
             let auth = ds3Authentication
-            let tenantValue = (tenant.isEmpty || tenant == DefaultSettings.defaultTenantName) ? nil : tenant
+            let tenantValue = tenant.isEmpty ? nil : tenant
 
             Task {
                 try? await viewModel.login(

--- a/DS3DriveApp/Views/Settings/IOSSettingsView.swift
+++ b/DS3DriveApp/Views/Settings/IOSSettingsView.swift
@@ -27,7 +27,8 @@
         }
 
         private var tenantName: String {
-            (try? SharedData.default().loadTenantNameFromPersistence()) ?? ""
+            let saved = (try? SharedData.default().loadTenantNameFromPersistence()) ?? ""
+            return saved.isEmpty ? "Not set" : saved
         }
 
         private var coordinatorURL: String {

--- a/DS3DriveApp/Views/Settings/IOSSettingsView.swift
+++ b/DS3DriveApp/Views/Settings/IOSSettingsView.swift
@@ -27,8 +27,7 @@
         }
 
         private var tenantName: String {
-            let tenant = (try? SharedData.default().loadTenantNameFromPersistence()) ?? ""
-            return tenant.isEmpty ? DefaultSettings.defaultTenantName : tenant
+            (try? SharedData.default().loadTenantNameFromPersistence()) ?? ""
         }
 
         private var coordinatorURL: String {
@@ -89,7 +88,7 @@
                         divider
                         infoRow(label: "Email", value: account.emails.first?.email ?? "")
                         divider
-                        infoRow(label: "Tenant", value: tenantName)
+                        infoRow(label: "Tenant ID", value: tenantName)
                         divider
 
                         Button {

--- a/DS3DriveProviderTests/ThumbnailHybridConsumeTests.swift
+++ b/DS3DriveProviderTests/ThumbnailHybridConsumeTests.swift
@@ -115,57 +115,6 @@ final class ThumbnailHybridConsumeTests: XCTestCase {
         XCTAssertEqual(signalled.first?.rawValue, "drive/folder/")
     }
 
-    // MARK: - Test 3 — Paused drive short-circuits before slot acquisition
-
-    /// D-24 / THUMB-21: pause gate fires BEFORE acquiring a limiter slot. No
-    /// download, no render, no PUT. Per-item handler called with (nil, nil) so
-    /// Finder draws the default UTType icon.
-    func test_pausedSkipsFallback() async throws {
-        let drive = ProviderTestFixtures.makeDrive()
-        let identifier = NSFileProviderItemIdentifier("prefix/photo.jpg")
-        let recorder = ResultRecorder()
-        let downloadCounter = CallCounter()
-        let putRecorder = PutRecorder()
-        let limiter = ThumbnailFallbackLimiter()
-
-        let context = Self.makeContext(
-            limiter: limiter,
-            download: { _, _ in
-                await downloadCounter.increment()
-                return (URL(fileURLWithPath: "/tmp/never"), nil)
-            },
-            render: { _ in .success(Data()) },
-            putThumbnail: { bucket, key, data, etag in
-                await putRecorder.record(bucket: bucket, key: key, data: data, etag: etag)
-            },
-            isPaused: { _ in true } // paused
-        )
-
-        await consumeThumbnailFallback(
-            identifier: identifier,
-            drive: drive,
-            context: context,
-            perItemHandler: { id, data, error in
-                Task { await recorder.record(id: id, data: data, error: error) }
-            }
-        )
-
-        try await Self.drainBackgroundTasks()
-
-        let results = await recorder.results
-        XCTAssertEqual(results.count, 1)
-        XCTAssertNil(results.first?.data)
-        XCTAssertNil(results.first?.error, "Paused must surface (nil, nil), not an error")
-
-        let downloads = await downloadCounter.count
-        XCTAssertEqual(downloads, 0, "Paused must short-circuit before download")
-        let puts = await putRecorder.entries
-        XCTAssertEqual(puts.count, 0, "Paused must not PUT")
-
-        let inFlight = await limiter.inFlightCount
-        XCTAssertEqual(inFlight, 0, "Paused must not acquire a limiter slot")
-    }
-
     // MARK: - Test 4 — Poisoned key short-circuits before slot acquisition
 
     /// D-19, D-20: a poisoned key skips download + render entirely. Returns

--- a/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
@@ -41,8 +41,8 @@ public enum DefaultSettings {
     /// Max number of drives a user can create.
     public static let maxDrives = 3
 
-    /// Default tenant name shown in the UI when no tenant is configured.
-    public static let defaultTenantName = "NGC"
+    /// Sentinel used to detect "no tenant" state in the login form.
+    public static let defaultTenantName = ""
 
     /// User defaults keys used to store data. They can be changed without breaking the app.
     public enum UserDefaultsKeys {

--- a/DS3Lib/Sources/DS3Lib/Constants/URLs.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/URLs.swift
@@ -87,6 +87,12 @@ public enum ConsoleURLs {
     public static let profileURL = "\(ConsoleURLs.workspaceURL)/profile"
 }
 
+/// Cubbit Composer dashboard related URLs.
+public enum ComposerURLs {
+    public static let baseURL = "https://composer.cubbit.eu"
+    public static let tenantsURL = "\(ComposerURLs.baseURL)/tenants"
+}
+
 /// Cubbit docs related URLs.
 public enum DocsURLs {
     public static let baseURL = "https://docs.cubbit.io"

--- a/DS3Lib/Sources/DS3Lib/Constants/URLs.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/URLs.swift
@@ -87,12 +87,6 @@ public enum ConsoleURLs {
     public static let profileURL = "\(ConsoleURLs.workspaceURL)/profile"
 }
 
-/// Cubbit Composer dashboard related URLs.
-public enum ComposerURLs {
-    public static let baseURL = "https://composer.cubbit.eu"
-    public static let tenantsURL = "\(ComposerURLs.baseURL)/tenants"
-}
-
 /// Cubbit docs related URLs.
 public enum DocsURLs {
     public static let baseURL = "https://docs.cubbit.io"

--- a/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
@@ -530,6 +530,8 @@ public final class DS3Authentication: @unchecked Sendable {
         guard let account = try? JSONDecoder().decode(Account.self, from: responseData)
         else { throw DS3AuthenticationError.jsonConversion }
 
+        self.logger.debug("accountInfo: endpoint_gateway=\(account.endpointGateway, privacy: .public)")
+
         return account
     }
 }

--- a/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
@@ -530,7 +530,7 @@ public final class DS3Authentication: @unchecked Sendable {
         guard let account = try? JSONDecoder().decode(Account.self, from: responseData)
         else { throw DS3AuthenticationError.jsonConversion }
 
-        self.logger.debug("accountInfo: endpoint_gateway=\(account.endpointGateway, privacy: .public)")
+        self.logger.info("accountInfo: endpoint_gateway=\(account.endpointGateway, privacy: .public)")
 
         return account
     }

--- a/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
@@ -329,7 +329,14 @@ public final class DS3Authentication: @unchecked Sendable {
 
         let (responseData, response) = try await URLSession.shared.data(for: request)
 
-        guard (response as? HTTPURLResponse)?.statusCode == 200 else { throw DS3AuthenticationError.serverError }
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let body = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
+            self.logger.error(
+                "Challenge request failed: HTTP \(statusCode, privacy: .public) — \(body, privacy: .public)"
+            )
+            throw DS3AuthenticationError.serverError
+        }
         guard let challenge = try? JSONDecoder().decode(Challenge.self, from: responseData)
         else { throw DS3AuthenticationError.jsonConversion }
 
@@ -403,6 +410,12 @@ public final class DS3Authentication: @unchecked Sendable {
         let (responseData, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let body = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
+            self.logger.error(
+                "Sign-in request failed: HTTP \(statusCode, privacy: .public) — \(body, privacy: .public)"
+            )
+
             if let mfaResponse = try? JSONDecoder().decode(DS3Missing2FAResponse.self, from: responseData),
                mfaResponse.message == APIError.Missing2FA {
                 throw DS3AuthenticationError.missing2FA

--- a/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3Authentication.swift
@@ -331,10 +331,11 @@ public final class DS3Authentication: @unchecked Sendable {
 
         guard (response as? HTTPURLResponse)?.statusCode == 200 else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-            let body = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
-            self.logger.error(
-                "Challenge request failed: HTTP \(statusCode, privacy: .public) — \(body, privacy: .public)"
-            )
+            self.logger.error("Challenge request failed: HTTP \(statusCode, privacy: .public)")
+            #if DEBUG
+                let body = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
+                self.logger.error("Challenge response body: \(body, privacy: .private)")
+            #endif
             throw DS3AuthenticationError.serverError
         }
         guard let challenge = try? JSONDecoder().decode(Challenge.self, from: responseData)
@@ -411,10 +412,11 @@ public final class DS3Authentication: @unchecked Sendable {
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-            let body = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
-            self.logger.error(
-                "Sign-in request failed: HTTP \(statusCode, privacy: .public) — \(body, privacy: .public)"
-            )
+            self.logger.error("Sign-in request failed: HTTP \(statusCode, privacy: .public)")
+            #if DEBUG
+                let body = String(data: responseData, encoding: .utf8) ?? "<non-utf8>"
+                self.logger.error("Sign-in response body: \(body, privacy: .private)")
+            #endif
 
             if let mfaResponse = try? JSONDecoder().decode(DS3Missing2FAResponse.self, from: responseData),
                mfaResponse.message == APIError.Missing2FA {

--- a/docs/superpowers/specs/2026-04-30-tray-state-design.md
+++ b/docs/superpowers/specs/2026-04-30-tray-state-design.md
@@ -1,0 +1,182 @@
+# Tray State & Transfer Panel Redesign
+
+**Date:** 2026-04-30
+**Closes:** #139
+**Related:** #144 (future event bus refactor)
+
+## Problem
+
+Three independent issues in the tray:
+
+1. **Sync state desync (#139)** — `DS3DriveViewModel`, `DS3DriveManager`, and `AppStatusManager` each maintain separate state with their own debounce timers. They regularly disagree, causing the tray icon, footer status, and per-drive row icons to show different states simultaneously.
+
+2. **Transfer panel pollution** — `downloadS3Item` (used for thumbnail generation, conflict resolution, and modify reconciliation) emits `DriveTransferStats` notifications identically to user-initiated transfers. The tray transfer panel shows internal operations as if they were user file transfers.
+
+3. **Footer layout breakage** — `SpeedSummaryView` embedded in the middle of the footer `HStack` causes "Synchronizing" to wrap when the speed indicator is present. The speed is also redundant with the per-drive row.
+
+## Decisions
+
+- **Transfer panel**: remains per-drive (floating side panel on drive row hover). No global unified panel.
+- **Visible transfers**: only user-initiated PUT (upload) and GET (Finder open / QuickLook partial fetch). Internal operations are silently excluded.
+- **Speed display**: per-drive row always shows per-drive speed. Footer shows aggregate (↑ upload ↓ download) only when 2+ drives are present and a transfer is active; when active, speed replaces the status text (Option A) to prevent overflow.
+- **Future event bus** (#144): deferred. This design is a stepping stone — it consolidates to a single DNC listener per notification type, which makes the future typed bus straightforward.
+
+## Architecture
+
+### State Pipeline (before → after)
+
+**Before (broken):**
+```
+Extension → DNC → DS3DriveManager (IPCService stream) → driveStatuses → aggregateStatus
+Extension → DNC → DS3DriveViewModel (own observer, 2s debounce) → driveStatus
+DS3DriveManager → AppStatusManager (1s min-active timer) → status
+Extension → DNC → DS3DriveViewModel (own observer) → transferStats → perFileSpeed
+```
+
+Three state trackers, three debounce layers — all can disagree.
+
+**After (Option B):**
+```
+Extension → DNC → MacOSIPCService
+    ├── statusUpdates stream → DS3DriveManager.driveStatuses[driveId]  (only mutation point)
+    │       ├── aggregateStatus (computed, @Observable) → menu bar icon + footer
+    │       └── aggregateAppStatus → AppStatusManager.status  (thin write-through, no timer)
+    └── transferSpeeds stream → DS3DriveManager → dispatches to matching DS3DriveViewModel
+```
+
+`DS3DriveViewModel` gains a `driveManager: DS3DriveManager` initializer parameter (injected from `TrayMenuView.rebuildDriveViewModels()` and `IOSMainTabView`). `driveStatus` becomes a computed property:
+
+```swift
+var driveStatus: DS3DriveStatus { driveManager.driveStatuses[drive.id] ?? .idle }
+```
+
+No own observer. No debounce. Single source of truth: `driveStatuses` in `DS3DriveManager`.
+
+### TransferObserver
+
+Replaces the separate `Progress?` and `NotificationManager` parameters across all transfer methods. Bundles both concerns — Finder progress reporting and tray stats emission — into one injectable object.
+
+```swift
+struct TransferObserver {
+    let progress: Progress?
+    let notificationManager: NotificationManager?
+
+    static let silent = TransferObserver(progress: nil, notificationManager: nil)
+
+    func report(
+        driveId: UUID,
+        filename: String?,
+        size: Int64,
+        totalSize: Int64?,
+        duration: TimeInterval,
+        direction: TransferDirection
+    ) async {
+        if let progress, let total = totalSize, total > 0 {
+            progress.completedUnitCount = Int64(Double(size) / Double(total) * 100)
+        }
+        if let nm = notificationManager {
+            await nm.sendTransferSpeedNotification(DriveTransferStats(
+                driveId: driveId, size: size, duration: duration,
+                direction: direction, filename: filename, totalSize: totalSize
+            ))
+        }
+    }
+}
+```
+
+All four transfer methods in `S3Lib+Transfers.swift` gain `observer: TransferObserver = .silent`:
+
+```swift
+func getS3Item(_:temporaryFolder:observer: TransferObserver = .silent) async throws -> URL
+func getS3ItemRange(identifier:drive:range:temporaryFolder:observer: TransferObserver = .silent) async throws -> URL
+func downloadS3Item(identifier:drive:temporaryFolder:observer: TransferObserver = .silent) async throws -> (URL, S3Item)
+func putS3Item(_:fileURL:observer: TransferObserver = .silent) async throws -> String?
+```
+
+`putS3Item` propagates `observer` down to `putS3ItemStandard` / `putS3ItemMultipart`.
+
+**User-initiated callers** construct and pass the observer:
+```swift
+let observer = TransferObserver(progress: progress, notificationManager: nm)
+try await s3Lib.getS3Item(item, temporaryFolder: dir, observer: observer)
+```
+
+**Internal callers** (thumbnail fetch, conflict resolution, modify reconciliation) omit `observer` — `.silent` default applies, no stats emitted.
+
+The stored `self.notificationManager` property on `S3Lib` becomes redundant and is removed.
+
+### Transfer Stats Routing
+
+`DS3DriveManager` already receives the `transferSpeeds` `AsyncStream` from `MacOSIPCService` but currently does nothing with it at the manager level (each `DS3DriveViewModel` has its own DNC observer instead). After this change:
+
+- `DS3DriveManager` exposes `ipcService.transferSpeeds` as a public `var transferStats: AsyncStream<DriveTransferStats>` property
+- Each `DS3DriveViewModel` subscribes to `driveManager.transferStats` in a `Task` started at init, filtering events by `drive.id`
+- `DS3DriveViewModel` retains its `processTransferStats(_:)` logic unchanged
+- `DS3DriveViewModel` loses its own `DistributedNotificationCenter` observer for both status and transfer stats
+- The manager never holds ViewModel references — the dependency flows one way (ViewModel → Manager)
+
+### AppStatusManager
+
+The 1-second minimum-active timer is removed. `AppStatusManager.setStatus(_:)` becomes a direct assignment. It is called only from `DS3DriveManager.handleDriveStatusChange` based on `aggregateAppStatus`. Since the extension-side `NotificationManager` already debounces status transitions correctly, the app-side timer is defence-in-depth that creates state disagreement rather than preventing it.
+
+## UI Changes
+
+### Footer (TrayMenuFooterView)
+
+`SpeedSummaryView` is removed from the footer `HStack` entirely.
+
+**1 drive present:**
+```
+[status icon]  [status text]          [Version X.X (Y)]
+```
+
+**2+ drives present, no active transfer:**
+```
+[status icon]  [status text]          [Version X.X (Y)]
+```
+
+**2+ drives present, active transfer:**
+```
+[status icon]  [↑ X MB/s  ↓ Y MB/s]  [Version X.X (Y)]
+```
+
+Speed replaces status text during active transfer to prevent overflow. When the last transfer completes, the footer transitions back to the status text.
+
+`TrayMenuFooterView` gains a `driveViewModels: [DS3DriveViewModel]` parameter (already present) that it uses to compute `aggregateUploadSpeed` and `aggregateDownloadSpeed`. When `driveViewModels.count >= 2` and either speed is non-nil, the speed label is shown instead of the status string.
+
+### Per-Drive Row (TrayDriveRowView)
+
+No changes. Speed indicators in `metricsRow` remain as-is.
+
+### SpeedSummaryView
+
+The view is removed. Its aggregate speed computation logic (`totalUploadSpeed`, `totalDownloadSpeed`) moves inline into `TrayMenuFooterView`.
+
+## iOS
+
+`IOSDriveViewModel.driveStatus` gets the same computed-property treatment as the macOS `DS3DriveViewModel`. Its own `NotificationCenter` observer for status is removed; state flows from `DS3DriveManager.driveStatuses[drive.id]`.
+
+No transfer panel on iOS. Per-drive speed display on the drive list row is unchanged — it reads from `driveStats.uploadSpeedBs` / `downloadSpeedBs` which are still populated via the transfer stats dispatch path.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `DS3Lib/Sources/DS3Lib/Utils/TransferObserver.swift` | New file — `TransferObserver` struct |
+| `DS3DriveProvider/S3Lib+Transfers.swift` | All transfer methods: replace `progress`/`notificationManager` params with `observer: TransferObserver` |
+| `DS3DriveProvider/S3Lib.swift` | Remove stored `notificationManager` property |
+| `DS3DriveProvider/FileProviderExtension+Thumbnails.swift` | Update all `downloadS3Item` / `getS3ItemRange` callers |
+| `DS3DriveProvider/FileProviderExtension+Create.swift` | Update `downloadS3Item` caller |
+| `DS3DriveProvider/FileProviderExtension+Modify.swift` | Update `downloadS3Item` caller |
+| `DS3Lib/Sources/DS3Lib/DS3DriveManager.swift` | Expose `transferStats` public property; `AppStatusManager` as thin write-through |
+| `DS3Lib/Sources/DS3Lib/AppStatusManager.swift` | Remove min-active timer; direct assignment only |
+| `DS3Drive/Views/Tray/ViewModels/DS3DriveViewModel.swift` | `driveStatus` → computed; add `driveManager` init param; remove DNC observers + `idleDebounceTask`; subscribe to `driveManager.transferStats` |
+| `DS3Drive/Views/Tray/Views/TrayMenuFooterView.swift` | Remove `SpeedSummaryView`; add inline aggregate speed logic |
+| `DS3Drive/Views/Tray/Views/SpeedSummaryView.swift` | Deleted |
+| `DS3DriveApp/ViewModels/IOSDriveViewModel.swift` | `driveStatus` → computed; remove own DNC observer |
+
+## Out of Scope
+
+- Global unified transfer panel (deferred — per-drive panel kept)
+- Typed intra-app event bus (#144 — future refactor)
+- Any changes to `RecentFilesTracker`, floating panel UI, or gear menu


### PR DESCRIPTION
Closes #145

## Summary

- **Root cause**: multi-tenant login was sending the human-readable tenant name (e.g. `neonswarm`) in the `tenant_id` field; the Cubbit IAM API expects a UUID — this caused every tenant-scoped login to fail with a generic server error
- Relabelled the field to **Tenant ID** across macOS and iOS login, MFA, settings, and connection tab views
- Added a `?` popover on the Tenant ID field pointing users to the Composer dashboard to find their UUID
- Legacy non-UUID values persisted in `UserDefaults` (from before this fix) are silently cleared on next launch
- Added HTTP status logging on challenge/signin failures (body gated behind `#if DEBUG` with `.private` privacy to avoid leaking PII in production logs)
- Added `endpoint_gateway` info log after `accounts/me` is fetched so the resolved S3 endpoint is visible in Console
- When the DS3 Gateway is unreachable (DNS failure / `NWError -65554` or equivalent `URLError`), the bucket picker now shows a friendly message instead of the raw error, plus the error domain/code for support
- Empty tenant shows "N/A" / "Not set" placeholder in macOS Connection tab and iOS Settings

## Test plan

- [ ] Login without tenant → works as before
- [ ] Login with a valid tenant UUID → succeeds
- [ ] Login with a tenant name (old format) → fails at the API with a clear server error (expected); Tenant ID field starts empty after upgrade
- [ ] Expand a project whose gateway is down → friendly DS3 Gateway error message shown, error code visible and selectable
- [ ] Click `?` next to Tenant ID → popover with hint text appears
- [ ] macOS Connection tab / iOS Settings with no tenant → shows "N/A" / "Not set" instead of blank