### PR TITLE
iOS Settings: thumbnails section (cellular, progress, generate-now)

### DIFF
--- a/DS3DriveApp/DS3DriveApp.swift
+++ b/DS3DriveApp/DS3DriveApp.swift
@@ -23,6 +23,9 @@ struct DS3DriveApp: App {
                 .environment(ds3DriveManager)
                 .environment(appStatusManager)
                 .environment(updateChecker)
+            #if os(iOS)
+                .environment(thumbnailBackfillDriver)
+            #endif
                 .font(IOSTypography.body)
                 .onChange(of: scenePhase, initial: true) { _, newPhase in
                     #if os(iOS)

--- a/DS3DriveApp/Views/Settings/IOSSettingsView.swift
+++ b/DS3DriveApp/Views/Settings/IOSSettingsView.swift
@@ -10,16 +10,21 @@
         @Environment(DS3Authentication.self) private var ds3Authentication
         @Environment(DS3DriveManager.self) private var ds3DriveManager
         @Environment(UpdateChecker.self) private var updateChecker
+        @Environment(ForegroundBackfillDriver.self) private var thumbnailBackfillDriver
         @Environment(\.openURL) private var openURL
 
         @State private var showLogoutAlert = false
         @State private var showClearCacheAlert = false
+        @State private var showGenerateNowAlert = false
         @State private var cacheSize: Int64 = 0
         @State private var isClearingCache = false
         @State private var isLoggingOut = false
+        @State private var cellularEnabled: Bool = ThumbnailNetworkPolicy.shared.cellularOptIn
         @AppStorage("syncNotificationsEnabled") private var syncNotificationsEnabled = false
         @AppStorage(DefaultSettings.UserDefaultsKeys.tutorial) private var tutorialShown: Bool = DefaultSettings
             .tutorialShown
+        @AppStorage("io.cubbit.DS3Drive.thumbnailGenerateNowWarningShown")
+        private var generateNowWarningShown: Bool = false
         @State private var copiedFieldId: String?
 
         private var account: Account? {
@@ -44,6 +49,7 @@
                     VStack(spacing: 24) {
                         accountSection
                         generalSection
+                        thumbnailsSection
                         updatesSection
                         onboardingSection
                         aboutSection
@@ -71,6 +77,18 @@
                 Button("Cancel", role: .cancel) { /* dismiss */ }
             } message: {
                 Text("This will remove all downloaded files. They will be re-downloaded when you open them.")
+            }
+            .alert("Generate Thumbnails", isPresented: $showGenerateNowAlert) {
+                Button("Generate") {
+                    generateNowWarningShown = true
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    DarwinNotificationCenter.shared.post(name: DarwinNotificationCenter.thumbnailRenderRequest)
+                }
+                Button("Cancel", role: .cancel) { /* dismiss */ }
+            } message: {
+                Text(
+                    "This will use data to generate thumbnails for all images. Thumbnails are small JPEG files (10–50 KB each)."
+                )
             }
             .task {
                 cacheSize = await CacheManager.calculateCacheSize()
@@ -215,6 +233,88 @@
                     .padding(.vertical, 14)
                 }
                 .background(cardBackground)
+            }
+        }
+
+        // MARK: - Thumbnails Section
+
+        private var thumbnailsSection: some View {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionHeader("THUMBNAILS", systemImage: "photo.on.rectangle.angled")
+
+                VStack(spacing: 0) {
+                    HStack(alignment: .center, spacing: 12) {
+                        Text(
+                            thumbnailBackfillDriver.pendingCount > 0
+                                ? "\(thumbnailBackfillDriver.pendingCount) thumbnails pending"
+                                : "All thumbnails up to date"
+                        )
+                        .font(.custom("Figtree-SemiBold", size: 15))
+                        .foregroundStyle(IOSColors.brandTextPrimary)
+
+                        Spacer(minLength: 8)
+
+                        if thumbnailBackfillDriver.isRunning {
+                            ProgressView().controlSize(.small)
+                        }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 16)
+
+                    divider
+
+                    HStack(alignment: .center, spacing: 12) {
+                        Text("Allow on Cellular")
+                            .font(.custom("Figtree-SemiBold", size: 15))
+                            .foregroundStyle(IOSColors.brandTextPrimary)
+
+                        Spacer(minLength: 8)
+
+                        Toggle("", isOn: $cellularEnabled)
+                            .labelsHidden()
+                            .tint(IOSColors.brandPrimary)
+                            .onChange(of: cellularEnabled) { _, newValue in
+                                ThumbnailNetworkPolicy.shared.cellularOptIn = newValue
+                            }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+
+                    divider
+
+                    Button {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        if generateNowWarningShown {
+                            DarwinNotificationCenter.shared.post(
+                                name: DarwinNotificationCenter.thumbnailRenderRequest
+                            )
+                        } else {
+                            showGenerateNowAlert = true
+                        }
+                    } label: {
+                        HStack(alignment: .center, spacing: 12) {
+                            Text("Generate Thumbnails Now")
+                                .font(.custom("Figtree-SemiBold", size: 15))
+                                .foregroundStyle(IOSColors.brandPrimary)
+                            Spacer(minLength: 8)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(IOSColors.brandPrimary)
+                        }
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 16)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+                .background(cardBackground)
+
+                Text(
+                    "Thumbnail generation runs while the app is open. Force-quitting the app stops background generation until next launch."
+                )
+                .font(.custom("Figtree-Regular", size: 12))
+                .foregroundStyle(IOSColors.brandTextSecondary)
+                .padding(.horizontal, 4)
             }
         }
 

--- a/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
@@ -56,6 +56,9 @@ public enum DefaultSettings {
         public static let lastUpdateCheck = "io.cubbit.DS3Drive.userDefaults.lastUpdateCheck"
         /// App Group UserDefaults key for the global cellular-download opt-in for thumbnail generation.
         public static let thumbnailCellularOptIn = "io.cubbit.DS3Drive.thumbnailCellularOptIn"
+        /// Standard (non-app-group) UserDefaults key tracking whether the generate-now bandwidth warning has been
+        /// shown. Intentionally stored per-device in the main app's standard suite — the extension never reads it.
+        public static let thumbnailGenerateNowWarningShown = "io.cubbit.DS3Drive.thumbnailGenerateNowWarningShown"
     }
 
     /// A unique identifier for the app. It is used to identify the specific app instance when creating API keys.


### PR DESCRIPTION
## Summary

iOS Settings → Thumbnails section. Rebased onto main after #148 merged.

- Progress row driven by `ForegroundBackfillDriver.pendingCount`
- Cellular opt-in toggle (`@AppStorage` on app group, key `thumbnailCellularOptIn`)
- "Generate Thumbnails Now" button: first tap shows bandwidth alert, subsequent taps post `DarwinNotificationCenter.thumbnailRenderRequest` silently
- Force-quit caveat text

Wave 4 (BGProcessingTask) and Waves 1–3 are NOT in this PR — they shipped via #148 (`ThumbnailBackfillTaskHandler` + memory-hardened drainer).

## Files changed

| File | Change |
|---|---|
| `DS3DriveApp/DS3DriveApp.swift` | Inject `ForegroundBackfillDriver` into iOS environment |
| `DS3DriveApp/Views/Settings/IOSSettingsView.swift` | Thumbnails section UI |
| `DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift` | `thumbnailGenerateNowWarningShown` key |

## Test plan

- [ ] Settings → Thumbnails section visible
- [ ] Progress row updates as queue drains
- [ ] Cellular toggle persists across launches; flip pauses/resumes drain on cellular
- [ ] First "Generate Now" tap shows alert; after Generate, alert no longer appears
- [ ] Subsequent taps trigger drain (visible in logs / pending count)