### PR TITLE
iOS upload death-loop fix + thumbnail memory hardening

### DIFF
--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		A150020201000000A1500202 /* IOSUploadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150020001000000A1500200 /* IOSUploadCoordinator.swift */; };
 		A150030101000000A1500301 /* FileProviderExtension+IOSUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */; };
 		A150030201000000A1500302 /* FileProviderExtension+IOSUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */; };
+		A150040101000000A1500401 /* UploadOrphanCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150040001000000A1500400 /* UploadOrphanCleaner.swift */; };
+		A150040201000000A1500402 /* UploadOrphanCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150040001000000A1500400 /* UploadOrphanCleaner.swift */; };
 		A130608401000000A1306084 /* CascadeDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130608301000000A1306083 /* CascadeDeleteTests.swift */; };
 		A130608601000000A1306086 /* CascadeRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130608501000000A1306085 /* CascadeRenameTests.swift */; };
 		A131006001000000A1310060 /* ProgressFinalizationOnErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A131006001000000A1310061 /* ProgressFinalizationOnErrorTests.swift */; };
@@ -361,6 +363,7 @@
 		A130608001000000A1306080 /* FileProviderExtension+ThumbnailCascade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+ThumbnailCascade.swift"; sourceTree = "<group>"; };
 		A150010001000000A1500100 /* BackgroundUploadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BackgroundUploadSession.swift; path = "iOS/BackgroundUploadSession.swift"; sourceTree = "<group>"; };
 		A150020001000000A1500200 /* IOSUploadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IOSUploadCoordinator.swift; path = "iOS/IOSUploadCoordinator.swift"; sourceTree = "<group>"; };
+		A150040001000000A1500400 /* UploadOrphanCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UploadOrphanCleaner.swift; path = "iOS/UploadOrphanCleaner.swift"; sourceTree = "<group>"; };
 		A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+IOSUpload.swift"; sourceTree = "<group>"; };
 		A130608301000000A1306083 /* CascadeDeleteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CascadeDeleteTests.swift; sourceTree = "<group>"; };
 		A130608501000000A1306085 /* CascadeRenameTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CascadeRenameTests.swift; sourceTree = "<group>"; };
@@ -973,6 +976,7 @@
 				A130608001000000A1306080 /* FileProviderExtension+ThumbnailCascade.swift */,
 				A150010001000000A1500100 /* BackgroundUploadSession.swift */,
 				A150020001000000A1500200 /* IOSUploadCoordinator.swift */,
+				A150040001000000A1500400 /* UploadOrphanCleaner.swift */,
 				A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */,
 				593F2D8CD4BF43B084F95A95 /* S3Lib+Transfers.swift */,
 				AD84A687F1EB4A8F9C45AEAA /* S3Lib+Trash.swift */,
@@ -1366,6 +1370,7 @@
 				A150010201000000A1500102 /* BackgroundUploadSession.swift in Sources */,
 				A150030201000000A1500302 /* FileProviderExtension+IOSUpload.swift in Sources */,
 				A150020201000000A1500202 /* IOSUploadCoordinator.swift in Sources */,
+				A150040201000000A1500402 /* UploadOrphanCleaner.swift in Sources */,
 				A130603101000000A1306031 /* FetchThumbnailsTests.swift in Sources */,
 				A130604101000000A1306041 /* FetchThumbnailsErrorMappingTests.swift in Sources */,
 				A130607401000000A1306074 /* UploadHookTests.swift in Sources */,
@@ -1482,6 +1487,7 @@
 				A150010101000000A1500101 /* BackgroundUploadSession.swift in Sources */,
 				A150030101000000A1500301 /* FileProviderExtension+IOSUpload.swift in Sources */,
 				A150020101000000A1500201 /* IOSUploadCoordinator.swift in Sources */,
+				A150040101000000A1500401 /* UploadOrphanCleaner.swift in Sources */,
 				016234D433404D56AD1E6417 /* S3Lib+Transfers.swift in Sources */,
 				CBC4B9775BD14315A22AA731 /* S3Lib+Trash.swift in Sources */,
 				D11103010000000000000001 /* S3Lib+Thumbnails.swift in Sources */,

--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -125,6 +125,12 @@
 		A130607401000000A1306074 /* UploadHookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130607301000000A1306073 /* UploadHookTests.swift */; };
 		A130608101000000A1306081 /* FileProviderExtension+ThumbnailCascade.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130608001000000A1306080 /* FileProviderExtension+ThumbnailCascade.swift */; };
 		A130608201000000A1306082 /* FileProviderExtension+ThumbnailCascade.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130608001000000A1306080 /* FileProviderExtension+ThumbnailCascade.swift */; };
+		A150010101000000A1500101 /* BackgroundUploadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150010001000000A1500100 /* BackgroundUploadSession.swift */; };
+		A150010201000000A1500102 /* BackgroundUploadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150010001000000A1500100 /* BackgroundUploadSession.swift */; };
+		A150020101000000A1500201 /* IOSUploadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150020001000000A1500200 /* IOSUploadCoordinator.swift */; };
+		A150020201000000A1500202 /* IOSUploadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150020001000000A1500200 /* IOSUploadCoordinator.swift */; };
+		A150030101000000A1500301 /* FileProviderExtension+IOSUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */; };
+		A150030201000000A1500302 /* FileProviderExtension+IOSUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */; };
 		A130608401000000A1306084 /* CascadeDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130608301000000A1306083 /* CascadeDeleteTests.swift */; };
 		A130608601000000A1306086 /* CascadeRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A130608501000000A1306085 /* CascadeRenameTests.swift */; };
 		A131006001000000A1310060 /* ProgressFinalizationOnErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A131006001000000A1310061 /* ProgressFinalizationOnErrorTests.swift */; };
@@ -353,6 +359,9 @@
 		A130607001000000A1306070 /* FileProviderExtension+ThumbnailUploadHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+ThumbnailUploadHook.swift"; sourceTree = "<group>"; };
 		A130607301000000A1306073 /* UploadHookTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UploadHookTests.swift; sourceTree = "<group>"; };
 		A130608001000000A1306080 /* FileProviderExtension+ThumbnailCascade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+ThumbnailCascade.swift"; sourceTree = "<group>"; };
+		A150010001000000A1500100 /* BackgroundUploadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BackgroundUploadSession.swift; path = "iOS/BackgroundUploadSession.swift"; sourceTree = "<group>"; };
+		A150020001000000A1500200 /* IOSUploadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IOSUploadCoordinator.swift; path = "iOS/IOSUploadCoordinator.swift"; sourceTree = "<group>"; };
+		A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+IOSUpload.swift"; sourceTree = "<group>"; };
 		A130608301000000A1306083 /* CascadeDeleteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CascadeDeleteTests.swift; sourceTree = "<group>"; };
 		A130608501000000A1306085 /* CascadeRenameTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CascadeRenameTests.swift; sourceTree = "<group>"; };
 		A131006001000000A1310061 /* ProgressFinalizationOnErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressFinalizationOnErrorTests.swift; sourceTree = "<group>"; };
@@ -962,6 +971,9 @@
 				A130602001000000A1306020 /* FileProviderExtension+ThumbnailConsume.swift */,
 				A130607001000000A1306070 /* FileProviderExtension+ThumbnailUploadHook.swift */,
 				A130608001000000A1306080 /* FileProviderExtension+ThumbnailCascade.swift */,
+				A150010001000000A1500100 /* BackgroundUploadSession.swift */,
+				A150020001000000A1500200 /* IOSUploadCoordinator.swift */,
+				A150030001000000A1500300 /* FileProviderExtension+IOSUpload.swift */,
 				593F2D8CD4BF43B084F95A95 /* S3Lib+Transfers.swift */,
 				AD84A687F1EB4A8F9C45AEAA /* S3Lib+Trash.swift */,
 				D11103000000000000000001 /* S3Lib+Thumbnails.swift */,
@@ -1351,6 +1363,9 @@
 				A130602201000000A1306022 /* FileProviderExtension+ThumbnailConsume.swift in Sources */,
 				A130607201000000A1306072 /* FileProviderExtension+ThumbnailUploadHook.swift in Sources */,
 				A130608201000000A1306082 /* FileProviderExtension+ThumbnailCascade.swift in Sources */,
+				A150010201000000A1500102 /* BackgroundUploadSession.swift in Sources */,
+				A150030201000000A1500302 /* FileProviderExtension+IOSUpload.swift in Sources */,
+				A150020201000000A1500202 /* IOSUploadCoordinator.swift in Sources */,
 				A130603101000000A1306031 /* FetchThumbnailsTests.swift in Sources */,
 				A130604101000000A1306041 /* FetchThumbnailsErrorMappingTests.swift in Sources */,
 				A130607401000000A1306074 /* UploadHookTests.swift in Sources */,
@@ -1464,6 +1479,9 @@
 				A130602101000000A1306021 /* FileProviderExtension+ThumbnailConsume.swift in Sources */,
 				A130607101000000A1306071 /* FileProviderExtension+ThumbnailUploadHook.swift in Sources */,
 				A130608101000000A1306081 /* FileProviderExtension+ThumbnailCascade.swift in Sources */,
+				A150010101000000A1500101 /* BackgroundUploadSession.swift in Sources */,
+				A150030101000000A1500301 /* FileProviderExtension+IOSUpload.swift in Sources */,
+				A150020101000000A1500201 /* IOSUploadCoordinator.swift in Sources */,
 				016234D433404D56AD1E6417 /* S3Lib+Transfers.swift in Sources */,
 				CBC4B9775BD14315A22AA731 /* S3Lib+Trash.swift in Sources */,
 				D11103010000000000000001 /* S3Lib+Thumbnails.swift in Sources */,

--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		9659EB9202B95BD6A9520860 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63DAE38129B73666BC61012E /* Assets.xcassets */; };
 		9783D898595F0FCD77B116E6 /* IOSDriveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AFAE49D6C5787515C65EE4 /* IOSDriveViewModel.swift */; };
 		13F7A1F20E98472D947978BB /* ForegroundBackfillDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423AAB1887E54807AF0FBD77 /* ForegroundBackfillDriver.swift */; };
+		1FF9FB927E2A4928A486A64E /* ThumbnailBackfillTaskHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F291137750247769947C80E /* ThumbnailBackfillTaskHandler.swift */; };
 		98DDAFC1510A4C63AD7FCDBE /* S3Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A222802B5721CC00F1413B /* S3Item.swift */; };
 		9CEA174F0E2844919898555F /* FileProviderExtension+Modify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93BEB14CBD064F639C861742 /* FileProviderExtension+Modify.swift */; };
 		A10203042F6300000042AD93 /* WorkingSetEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10203032F6300000042AD93 /* WorkingSetEnumerator.swift */; };
@@ -287,6 +288,7 @@
 		830D73D29DDAA6E68151FC62 /* DriveDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DriveDetailView.swift; sourceTree = "<group>"; };
 		83AFAE49D6C5787515C65EE4 /* IOSDriveViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSDriveViewModel.swift; sourceTree = "<group>"; };
 		423AAB1887E54807AF0FBD77 /* ForegroundBackfillDriver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForegroundBackfillDriver.swift; sourceTree = "<group>"; };
+		0F291137750247769947C80E /* ThumbnailBackfillTaskHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailBackfillTaskHandler.swift; sourceTree = "<group>"; };
 		909BB02752B9D019AB353BDB /* IOSDriveViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSDriveViewModelTests.swift; sourceTree = "<group>"; };
 		92782ABCB6F9964E5FC56C71 /* DriveListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DriveListView.swift; sourceTree = "<group>"; };
 		93BEB14CBD064F639C861742 /* FileProviderExtension+Modify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+Modify.swift"; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 				44A645B8D9BDD9E87A9C55A6 /* Views */,
 				96811E45DB40205283CCB6CB /* ViewModels */,
 				58D7B11E3167F877F313A3AD /* Helpers */,
+				67CD2995203C4817A1EC3744 /* BackgroundTasks */,
 			);
 			path = DS3DriveApp;
 			sourceTree = "<group>";
@@ -585,6 +588,14 @@
 				423AAB1887E54807AF0FBD77 /* ForegroundBackfillDriver.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		67CD2995203C4817A1EC3744 /* BackgroundTasks */ = {
+			isa = PBXGroup;
+			children = (
+				0F291137750247769947C80E /* ThumbnailBackfillTaskHandler.swift */,
+			);
+			path = BackgroundTasks;
 			sourceTree = "<group>";
 		};
 		9F1D3B4136D4DDC8626ECCBC /* Settings */ = {
@@ -1302,6 +1313,7 @@
 				BCEEF72CA17699E9AE656942 /* IOSSettingsView.swift in Sources */,
 				9783D898595F0FCD77B116E6 /* IOSDriveViewModel.swift in Sources */,
 				13F7A1F20E98472D947978BB /* ForegroundBackfillDriver.swift in Sources */,
+				1FF9FB927E2A4928A486A64E /* ThumbnailBackfillTaskHandler.swift in Sources */,
 				4A20FD708E0B4A54CD5FCC70 /* OrientationLock.swift in Sources */,
 				8865FDA6BC93E8AC9A1462CC /* BackgroundRefreshManager.swift in Sources */,
 				AED31D6C586582649FEA832B /* CacheManager.swift in Sources */,

--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		942302CC0AD97A60450DA1B7 /* SyncSetupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C71C4FFADB8DDE9EC58F5E2 /* SyncSetupViewModelTests.swift */; };
 		9659EB9202B95BD6A9520860 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63DAE38129B73666BC61012E /* Assets.xcassets */; };
 		9783D898595F0FCD77B116E6 /* IOSDriveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AFAE49D6C5787515C65EE4 /* IOSDriveViewModel.swift */; };
+		13F7A1F20E98472D947978BB /* ForegroundBackfillDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423AAB1887E54807AF0FBD77 /* ForegroundBackfillDriver.swift */; };
 		98DDAFC1510A4C63AD7FCDBE /* S3Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A222802B5721CC00F1413B /* S3Item.swift */; };
 		9CEA174F0E2844919898555F /* FileProviderExtension+Modify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93BEB14CBD064F639C861742 /* FileProviderExtension+Modify.swift */; };
 		A10203042F6300000042AD93 /* WorkingSetEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10203032F6300000042AD93 /* WorkingSetEnumerator.swift */; };
@@ -91,6 +92,7 @@
 		B0A1F2E3C4D5678901234567 /* PresignNotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F809ABCDEF /* PresignNotificationHelper.swift */; };
 		B0A1F2E3C4D5678901234568 /* PresignNotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F809ABCDEF /* PresignNotificationHelper.swift */; };
 		AED31D6C586582649FEA832B /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBD730F5BCDD36A139A43B6 /* CacheManager.swift */; };
+		ACC64A9E50274304A36364D8 /* ThumbnailNetworkPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C538A90188042DD9DC63CA3 /* ThumbnailNetworkPolicy.swift */; };
 		B511A0010511A00100000511 /* DS3Gradients.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511A0000511A00000000511 /* DS3Gradients.swift */; };
 		BC79CBA66DC892F716F27F12 /* IOSDriveViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909BB02752B9D019AB353BDB /* IOSDriveViewModelTests.swift */; };
 		BCEEF72CA17699E9AE656942 /* IOSSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1823D7B17115B90E2FD9181D /* IOSSettingsView.swift */; };
@@ -284,6 +286,7 @@
 		80F8E8B79FD49D0216AD0815 /* IOSMFAView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSMFAView.swift; sourceTree = "<group>"; };
 		830D73D29DDAA6E68151FC62 /* DriveDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DriveDetailView.swift; sourceTree = "<group>"; };
 		83AFAE49D6C5787515C65EE4 /* IOSDriveViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSDriveViewModel.swift; sourceTree = "<group>"; };
+		423AAB1887E54807AF0FBD77 /* ForegroundBackfillDriver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForegroundBackfillDriver.swift; sourceTree = "<group>"; };
 		909BB02752B9D019AB353BDB /* IOSDriveViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSDriveViewModelTests.swift; sourceTree = "<group>"; };
 		92782ABCB6F9964E5FC56C71 /* DriveListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DriveListView.swift; sourceTree = "<group>"; };
 		93BEB14CBD064F639C861742 /* FileProviderExtension+Modify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+Modify.swift"; sourceTree = "<group>"; };
@@ -318,6 +321,7 @@
 		AD84A687F1EB4A8F9C45AEAA /* S3Lib+Trash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "S3Lib+Trash.swift"; sourceTree = "<group>"; };
 		D11103000000000000000001 /* S3Lib+Thumbnails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "S3Lib+Thumbnails.swift"; sourceTree = "<group>"; };
 		AFBD730F5BCDD36A139A43B6 /* CacheManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
+		8C538A90188042DD9DC63CA3 /* ThumbnailNetworkPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailNetworkPolicy.swift; sourceTree = "<group>"; };
 		B200454116D3DE5033A9FC01 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		B5113DDDA0BF251D4D70D3D0 /* DriveConfirmView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DriveConfirmView.swift; sourceTree = "<group>"; };
 		B511A0000511A00000000511 /* DS3Gradients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DS3Gradients.swift; sourceTree = "<group>"; };
@@ -540,6 +544,7 @@
 				4CA9016467657EB5B6B0F187 /* OrientationLock.swift */,
 				4E28C5D8656BE4652D84BD2D /* BackgroundRefreshManager.swift */,
 				AFBD730F5BCDD36A139A43B6 /* CacheManager.swift */,
+				8C538A90188042DD9DC63CA3 /* ThumbnailNetworkPolicy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -577,6 +582,7 @@
 			isa = PBXGroup;
 			children = (
 				83AFAE49D6C5787515C65EE4 /* IOSDriveViewModel.swift */,
+				423AAB1887E54807AF0FBD77 /* ForegroundBackfillDriver.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1295,9 +1301,11 @@
 				B11104001100040000000003 /* IOSThumbnailConflictWarningView.swift in Sources */,
 				BCEEF72CA17699E9AE656942 /* IOSSettingsView.swift in Sources */,
 				9783D898595F0FCD77B116E6 /* IOSDriveViewModel.swift in Sources */,
+				13F7A1F20E98472D947978BB /* ForegroundBackfillDriver.swift in Sources */,
 				4A20FD708E0B4A54CD5FCC70 /* OrientationLock.swift in Sources */,
 				8865FDA6BC93E8AC9A1462CC /* BackgroundRefreshManager.swift in Sources */,
 				AED31D6C586582649FEA832B /* CacheManager.swift in Sources */,
+				ACC64A9E50274304A36364D8 /* ThumbnailNetworkPolicy.swift in Sources */,
 				70A1EF5AE3CB27185A6C038B /* LoginViewModel.swift in Sources */,
 				36D66273CE63FEA089FD9D04 /* ProjectSelectionViewModel.swift in Sources */,
 				0D90EFF30F1E07F00CA4CCF4 /* SyncAnchorSelectionViewModel.swift in Sources */,

--- a/DS3DriveApp/BackgroundTasks/ThumbnailBackfillTaskHandler.swift
+++ b/DS3DriveApp/BackgroundTasks/ThumbnailBackfillTaskHandler.swift
@@ -1,0 +1,64 @@
+#if os(iOS)
+    import BackgroundTasks
+    import Foundation
+    import os.log
+
+    @MainActor
+    final class ThumbnailBackfillTaskHandler {
+        static let identifier = "io.cubbit.DS3Drive.thumbnailBackfill"
+        private static let batchSize = 10
+        private static let logger = Logger(subsystem: "io.cubbit.DS3Drive", category: "bgtask")
+
+        private let driver: ForegroundBackfillDriver
+
+        init(driver: ForegroundBackfillDriver) {
+            self.driver = driver
+        }
+
+        func register() {
+            BGTaskScheduler.shared.register(
+                forTaskWithIdentifier: Self.identifier,
+                using: nil
+            ) { [weak self] task in
+                guard let self, let processingTask = task as? BGProcessingTask else {
+                    task.setTaskCompleted(success: false)
+                    return
+                }
+                self.handle(task: processingTask)
+            }
+            Self.logger.info("Registered BGProcessingTask: \(Self.identifier, privacy: .public)")
+        }
+
+        func schedule() {
+            let request = BGProcessingTaskRequest(identifier: Self.identifier)
+            request.requiresNetworkConnectivity = true
+            request.requiresExternalPower = false
+            request.earliestBeginDate = Date(timeIntervalSinceNow: 60)
+            do {
+                try BGTaskScheduler.shared.submit(request)
+                Self.logger.info("Submitted BGProcessingTask request")
+            } catch {
+                Self.logger.error(
+                    "Failed to submit BGProcessingTask: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+
+        private func handle(task: BGProcessingTask) {
+            Self.logger.info("BGProcessingTask started")
+            schedule()
+
+            var workTask: Task<Void, Never>?
+            task.expirationHandler = {
+                Self.logger.warning("BGProcessingTask expiring — cancelling work")
+                workTask?.cancel()
+            }
+
+            workTask = Task { @MainActor in
+                let processed = await driver.drainBatch(maxItems: Self.batchSize)
+                Self.logger.info("BGProcessingTask drained \(processed, privacy: .public) items")
+                task.setTaskCompleted(success: true)
+            }
+        }
+    }
+#endif

--- a/DS3DriveApp/DS3DriveApp.swift
+++ b/DS3DriveApp/DS3DriveApp.swift
@@ -13,6 +13,7 @@ struct DS3DriveApp: App {
     @State private var updateChecker = UpdateChecker()
     #if os(iOS)
         @State private var thumbnailBackfillDriver: ForegroundBackfillDriver
+        private let thumbnailBackfillHandler: ThumbnailBackfillTaskHandler
     #endif
 
     var body: some Scene {
@@ -30,6 +31,9 @@ struct DS3DriveApp: App {
                         Task { await updateChecker.checkForUpdates() }
                     } else if newPhase == .background {
                         BackgroundRefreshManager.scheduleNextRefresh()
+                        #if os(iOS)
+                            thumbnailBackfillHandler.schedule()
+                        #endif
                     }
                     #if os(iOS)
                         thumbnailBackfillDriver.handleScenePhase(newPhase)
@@ -71,7 +75,11 @@ struct DS3DriveApp: App {
         let driveManager = DS3DriveManager(appStatusManager: appStatusManager)
         _ds3DriveManager = State(initialValue: driveManager)
         #if os(iOS)
-            _thumbnailBackfillDriver = State(initialValue: ForegroundBackfillDriver(driveManager: driveManager))
+            let backfillDriver = ForegroundBackfillDriver(driveManager: driveManager)
+            _thumbnailBackfillDriver = State(initialValue: backfillDriver)
+            let handler = ThumbnailBackfillTaskHandler(driver: backfillDriver)
+            thumbnailBackfillHandler = handler
+            handler.register()
         #endif
     }
 }

--- a/DS3DriveApp/DS3DriveApp.swift
+++ b/DS3DriveApp/DS3DriveApp.swift
@@ -11,6 +11,9 @@ struct DS3DriveApp: App {
     @State private var appStatusManager: AppStatusManager
     @State private var hasStartedRefreshTimer = false
     @State private var updateChecker = UpdateChecker()
+    #if os(iOS)
+        @State private var thumbnailBackfillDriver: ForegroundBackfillDriver
+    #endif
 
     var body: some Scene {
         WindowGroup {
@@ -28,6 +31,9 @@ struct DS3DriveApp: App {
                     } else if newPhase == .background {
                         BackgroundRefreshManager.scheduleNextRefresh()
                     }
+                    #if os(iOS)
+                        thumbnailBackfillDriver.handleScenePhase(newPhase)
+                    #endif
                 }
                 .onAppear {
                     if !hasStartedRefreshTimer, ds3Authentication.isLogged {
@@ -62,6 +68,10 @@ struct DS3DriveApp: App {
             .defaultCoordinatorURL
         let urls = CubbitAPIURLs(coordinatorURL: coordinatorURL)
         _ds3Authentication = State(initialValue: DS3Authentication.loadFromPersistenceOrCreateNew(urls: urls))
-        _ds3DriveManager = State(initialValue: DS3DriveManager(appStatusManager: appStatusManager))
+        let driveManager = DS3DriveManager(appStatusManager: appStatusManager)
+        _ds3DriveManager = State(initialValue: driveManager)
+        #if os(iOS)
+            _thumbnailBackfillDriver = State(initialValue: ForegroundBackfillDriver(driveManager: driveManager))
+        #endif
     }
 }

--- a/DS3DriveApp/DS3DriveApp.swift
+++ b/DS3DriveApp/DS3DriveApp.swift
@@ -24,7 +24,12 @@ struct DS3DriveApp: App {
                 .environment(appStatusManager)
                 .environment(updateChecker)
                 .font(IOSTypography.body)
-                .onChange(of: scenePhase) { _, newPhase in
+                .onChange(of: scenePhase, initial: true) { _, newPhase in
+                    #if os(iOS)
+                        // Drive must always observe scene phase, even before login,
+                        // so cold-launch + later login also kicks the drain.
+                        thumbnailBackfillDriver.handleScenePhase(newPhase)
+                    #endif
                     guard ds3Authentication.isLogged else { return }
                     if newPhase == .active {
                         Task { await BackgroundRefreshManager.signalAllDrives() }
@@ -35,9 +40,6 @@ struct DS3DriveApp: App {
                             thumbnailBackfillHandler.schedule()
                         #endif
                     }
-                    #if os(iOS)
-                        thumbnailBackfillDriver.handleScenePhase(newPhase)
-                    #endif
                 }
                 .onAppear {
                     if !hasStartedRefreshTimer, ds3Authentication.isLogged {
@@ -49,6 +51,12 @@ struct DS3DriveApp: App {
                     if isLogged, !hasStartedRefreshTimer {
                         _ = ds3Authentication.startProactiveRefreshTimer()
                         hasStartedRefreshTimer = true
+                        #if os(iOS)
+                            // Login may complete after scenePhase already became
+                            // .active, missing the .onChange transition. Kick the
+                            // drain now that a drive is available.
+                            thumbnailBackfillDriver.handleScenePhase(scenePhase)
+                        #endif
                     } else if !isLogged {
                         // Timer exits on its own when the refresh token is rejected;
                         // reset the latch so re-login spins up a fresh timer.

--- a/DS3DriveApp/Helpers/ThumbnailNetworkPolicy.swift
+++ b/DS3DriveApp/Helpers/ThumbnailNetworkPolicy.swift
@@ -1,0 +1,45 @@
+#if os(iOS)
+    import DS3Lib
+    import Foundation
+    import Network
+
+    /// Decides whether thumbnail downloads are allowed given current network conditions.
+    /// Cellular is blocked by default; user can opt in via Settings.
+    final class ThumbnailNetworkPolicy: @unchecked Sendable {
+        static let shared = ThumbnailNetworkPolicy()
+
+        private let monitor = NWPathMonitor()
+        private let monitorQueue = DispatchQueue(label: "io.cubbit.DS3Drive.thumbnailNetworkMonitor")
+        private var currentPath: NWPath?
+
+        var cellularOptIn: Bool {
+            get {
+                UserDefaults(suiteName: DefaultSettings.appGroup)?
+                    .bool(forKey: DefaultSettings.UserDefaultsKeys.thumbnailCellularOptIn) ?? false
+            }
+            set {
+                UserDefaults(suiteName: DefaultSettings.appGroup)?
+                    .set(newValue, forKey: DefaultSettings.UserDefaultsKeys.thumbnailCellularOptIn)
+            }
+        }
+
+        private init() {
+            monitor.pathUpdateHandler = { [weak self] path in
+                self?.currentPath = path
+            }
+            monitor.start(queue: monitorQueue)
+        }
+
+        /// Returns true when thumbnail downloads should proceed.
+        /// Wi-Fi: always allowed. Cellular: only when user has opted in.
+        func isAllowed() -> Bool {
+            guard let path = currentPath, path.status == .satisfied else {
+                return true // No path yet — fail open (don't block drain on startup)
+            }
+            if path.isExpensive {
+                return cellularOptIn
+            }
+            return true
+        }
+    }
+#endif

--- a/DS3DriveApp/Helpers/ThumbnailNetworkPolicy.swift
+++ b/DS3DriveApp/Helpers/ThumbnailNetworkPolicy.swift
@@ -2,6 +2,7 @@
     import DS3Lib
     import Foundation
     import Network
+    import os.lock
 
     /// Decides whether thumbnail downloads are allowed given current network conditions.
     /// Cellular is blocked by default; user can opt in via Settings.
@@ -10,7 +11,10 @@
 
         private let monitor = NWPathMonitor()
         private let monitorQueue = DispatchQueue(label: "io.cubbit.DS3Drive.thumbnailNetworkMonitor")
-        private var currentPath: NWPath?
+        /// `currentPath` is mutated from the NWPathMonitor callback queue and
+        /// read from arbitrary threads via `isAllowed()`. The lock keeps the
+        /// read/write atomic under `@unchecked Sendable`.
+        private let pathLock = OSAllocatedUnfairLock<NWPath?>(initialState: nil)
 
         var cellularOptIn: Bool {
             get {
@@ -25,16 +29,21 @@
 
         private init() {
             monitor.pathUpdateHandler = { [weak self] path in
-                self?.currentPath = path
+                self?.pathLock.withLock { $0 = path }
             }
             monitor.start(queue: monitorQueue)
         }
 
         /// Returns true when thumbnail downloads should proceed.
         /// Wi-Fi: always allowed. Cellular: only when user has opted in.
+        /// Unknown path (monitor not yet delivered first update): allow only
+        /// if the user has opted in to cellular — fail closed so a backfill
+        /// kicked off before the first NWPath update can never hit cellular
+        /// for a user who never agreed to it.
         func isAllowed() -> Bool {
-            guard let path = currentPath, path.status == .satisfied else {
-                return true // No path yet — fail open (don't block drain on startup)
+            let snapshot = pathLock.withLock { $0 }
+            guard let path = snapshot, path.status == .satisfied else {
+                return cellularOptIn
             }
             if path.isExpensive {
                 return cellularOptIn

--- a/DS3DriveApp/Info.plist
+++ b/DS3DriveApp/Info.plist
@@ -32,6 +32,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>io.cubbit.DS3Drive.refreshDrives</string>
+		<string>io.cubbit.DS3Drive.thumbnailBackfill</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -40,6 +40,7 @@
 
         /// Call from scenePhase onChange in the app root.
         func handleScenePhase(_ phase: ScenePhase) {
+            logger.info("Backfill: scenePhase=\(String(describing: phase), privacy: .public)")
             if phase == .active {
                 startDrain()
             } else {
@@ -50,7 +51,11 @@
         // MARK: - Private
 
         private func startDrain() {
-            guard drainTask == nil else { return }
+            guard drainTask == nil else {
+                logger.info("Backfill: startDrain skipped — already running")
+                return
+            }
+            logger.info("Backfill: starting drain loop")
             isRunning = true
             drainTask = Task { @MainActor [weak self] in
                 await self?.drainLoop()
@@ -58,12 +63,14 @@
         }
 
         private func stopDrain() {
+            logger.info("Backfill: stopping drain loop")
             drainTask?.cancel()
             drainTask = nil
             isRunning = false
         }
 
         private func wakeIfIdle() {
+            logger.info("Backfill: Darwin wake — drainTask=\(self.drainTask == nil ? "nil" : "live", privacy: .public)")
             guard drainTask == nil || drainTask?.isCancelled == true else { return }
             startDrain()
         }
@@ -118,7 +125,13 @@
             // skip → dequeue (renderOne returns early without completing the
             // item, so the same key would be redelivered forever).
             guard ThumbnailNetworkPolicy.shared.isAllowed() else {
+                logger.info("Backfill: drainBatch blocked by cellular gate")
                 return 0
+            }
+
+            let initial = await queue.pendingCount
+            if initial > 0 {
+                logger.info("Backfill: drainBatch starting — pending=\(initial, privacy: .public)")
             }
 
             while processed < maxItems {

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -113,6 +113,14 @@
             let queue = ThumbnailRenderQueue.shared
             var processed = 0
 
+            // Cellular gate: check once per drain. If blocked, return 0 so the
+            // outer loop sleeps instead of spinning on dequeue → renderOne →
+            // skip → dequeue (renderOne returns early without completing the
+            // item, so the same key would be redelivered forever).
+            guard ThumbnailNetworkPolicy.shared.isAllowed() else {
+                return 0
+            }
+
             while processed < maxItems {
                 let batch = await queue.dequeue(maxItems: 1)
                 guard let item = batch.first else { break }

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -247,16 +247,30 @@
                 return
             }
 
-            // 7. Signal File Provider so iOS Files re-fetches thumbnails for this drive
+            // 7. Signal File Provider so iOS Files re-fetches thumbnails for this drive.
+            //    Working-set signal alone is not enough — Files.app caches per-container
+            //    thumbnail responses, so the parent container must also be invalidated.
             let domain = NSFileProviderDomain(
                 identifier: NSFileProviderDomainIdentifier(rawValue: drive.id.uuidString),
                 displayName: drive.name
             )
+            let manager = NSFileProviderManager(for: domain)
             do {
-                try await NSFileProviderManager(for: domain)?.signalEnumerator(for: .workingSet)
+                try await manager?.signalEnumerator(for: .workingSet)
             } catch {
                 logger.warning(
-                    "Backfill: signalEnumerator failed for \(drive.name, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    "Backfill: signalEnumerator(workingSet) failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+            let parentKey = (item.s3Key as NSString).deletingLastPathComponent
+            let parentId: NSFileProviderItemIdentifier = parentKey.isEmpty
+                ? .rootContainer
+                : NSFileProviderItemIdentifier(rawValue: parentKey + "/")
+            do {
+                try await manager?.signalEnumerator(for: parentId)
+            } catch {
+                logger.warning(
+                    "Backfill: signalEnumerator(\(parentKey, privacy: .public)) failed: \(error.localizedDescription, privacy: .public)"
                 )
             }
 

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -145,6 +145,23 @@
             return processed
         }
 
+        /// Signals an enumerator on `manager` and logs warnings on failure.
+        /// The label is used purely for log output (the parent key, or
+        /// `"workingSet"`).
+        private func signalEnumerator(
+            _ manager: NSFileProviderManager?,
+            container: NSFileProviderItemIdentifier,
+            label: String
+        ) async {
+            do {
+                try await manager?.signalEnumerator(for: container)
+            } catch {
+                logger.warning(
+                    "Backfill: signalEnumerator(\(label, privacy: .public)) failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+
         // swiftlint:disable:next function_body_length
         private func renderOne(_ item: ThumbnailRenderQueueItem) async {
             let queue = ThumbnailRenderQueue.shared
@@ -255,24 +272,12 @@
                 displayName: drive.name
             )
             let manager = NSFileProviderManager(for: domain)
-            do {
-                try await manager?.signalEnumerator(for: .workingSet)
-            } catch {
-                logger.warning(
-                    "Backfill: signalEnumerator(workingSet) failed: \(error.localizedDescription, privacy: .public)"
-                )
-            }
             let parentKey = (item.s3Key as NSString).deletingLastPathComponent
             let parentId: NSFileProviderItemIdentifier = parentKey.isEmpty
                 ? .rootContainer
                 : NSFileProviderItemIdentifier(rawValue: parentKey + "/")
-            do {
-                try await manager?.signalEnumerator(for: parentId)
-            } catch {
-                logger.warning(
-                    "Backfill: signalEnumerator(\(parentKey, privacy: .public)) failed: \(error.localizedDescription, privacy: .public)"
-                )
-            }
+            await signalEnumerator(manager, container: .workingSet, label: "workingSet")
+            await signalEnumerator(manager, container: parentId, label: parentKey)
 
             // 8. Mark complete
             await queue.complete(item)

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -1,0 +1,191 @@
+#if os(iOS)
+    import DS3Lib
+    @preconcurrency import FileProvider
+    import Foundation
+    import os.log
+    import SwiftUI
+
+    /// Drains the iOS thumbnail render queue while the app is in the foreground.
+    ///
+    /// Lifecycle: instantiated once at app launch and held in @State. When the app
+    /// becomes active, starts a drain loop. When it moves to background/inactive, the
+    /// loop is cancelled after the current in-flight item finishes. Darwin notifications
+    /// from the extension wake the driver if it is idle.
+    @Observable
+    @MainActor
+    final class ForegroundBackfillDriver {
+        /// Count of items still waiting to be rendered, across all drives.
+        var pendingCount: Int = 0
+        /// True while the drain loop is running.
+        var isRunning: Bool = false
+
+        private let driveManager: DS3DriveManager
+        private let logger = Logger(subsystem: LogSubsystem.app, category: LogCategory.thumbnail.rawValue)
+        private var drainTask: Task<Void, Never>?
+        private var darwinObservation: DarwinNotificationObservation?
+
+        init(driveManager: DS3DriveManager) {
+            self.driveManager = driveManager
+            darwinObservation = DarwinNotificationCenter.shared.addObserver(
+                name: DarwinNotificationCenter.thumbnailRenderRequest
+            ) { [weak self] in
+                Task { @MainActor in self?.wakeIfIdle() }
+            }
+        }
+
+        /// Call from scenePhase onChange in the app root.
+        func handleScenePhase(_ phase: ScenePhase) {
+            if phase == .active {
+                startDrain()
+            } else {
+                stopDrain()
+            }
+        }
+
+        // MARK: - Private
+
+        private func startDrain() {
+            guard drainTask == nil else { return }
+            isRunning = true
+            drainTask = Task { @MainActor [weak self] in
+                await self?.drainLoop()
+            }
+        }
+
+        private func stopDrain() {
+            drainTask?.cancel()
+            drainTask = nil
+            isRunning = false
+        }
+
+        private func wakeIfIdle() {
+            guard drainTask == nil || drainTask?.isCancelled == true else { return }
+            startDrain()
+        }
+
+        private func drainLoop() async {
+            let queue = ThumbnailRenderQueue.shared
+
+            while !Task.isCancelled {
+                let batch = await queue.dequeue(maxItems: 1)
+
+                if batch.isEmpty {
+                    try? await Task.sleep(for: .seconds(2))
+                    pendingCount = await queue.pendingCount
+                    continue
+                }
+
+                await renderOne(batch[0])
+                pendingCount = await queue.pendingCount
+            }
+
+            isRunning = false
+            drainTask = nil
+        }
+
+        // swiftlint:disable:next function_body_length
+        private func renderOne(_ item: ThumbnailRenderQueueItem) async {
+            let queue = ThumbnailRenderQueue.shared
+
+            // 1. Cellular gate
+            guard ThumbnailNetworkPolicy.shared.isAllowed() else {
+                logger.info("Backfill: skipping \(item.s3Key, privacy: .public) — cellular blocked")
+                return
+            }
+
+            // 2. Drive lookup
+            guard let drive = driveManager.driveWithID(item.driveID) else {
+                logger.warning("Backfill: drive \(item.driveID, privacy: .public) not found — dropping item")
+                await queue.complete(item)
+                return
+            }
+
+            // 3. S3 client
+            let s3Client: DS3S3Client
+            do {
+                let ds3Client = try DS3Client(drive: drive)
+                guard let client = ds3Client.driveS3Client else {
+                    logger.error("Backfill: no S3 client for \(item.s3Key, privacy: .public)")
+                    await queue.fail(item)
+                    return
+                }
+                s3Client = client
+            } catch {
+                logger.error(
+                    "Backfill: S3 init failed for \(item.s3Key, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+                await queue.fail(item)
+                return
+            }
+
+            // 4. Download original to temp file
+            let ext = (item.s3Key as NSString).pathExtension
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString + (ext.isEmpty ? "" : "." + ext))
+
+            let bucket = drive.syncAnchor.bucket.name
+            do {
+                let data = try await s3Client.getObjectData(bucket: bucket, key: item.s3Key)
+                try data.write(to: tempURL)
+            } catch {
+                logger.error(
+                    "Backfill: download failed for \(item.s3Key, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+                await queue.fail(item)
+                return
+            }
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            // 5. Render JPEG off main thread — CPU-intensive
+            let renderResult = await Task.detached(priority: .utility) {
+                autoreleasepool { ThumbnailRenderer().renderJPEG(from: tempURL) }
+            }.value
+
+            let jpegBytes: Data
+            switch renderResult {
+            case let .success(bytes):
+                jpegBytes = bytes
+            case let .failure(reason):
+                logger.info(
+                    "Backfill: render failed for \(item.s3Key, privacy: .public) — \(reason.rawValue, privacy: .public)"
+                )
+                await queue.fail(item)
+                return
+            }
+
+            // 6. PUT thumbnail
+            let thumbKey = S3PathUtils.thumbnailKey(
+                forOriginalKey: item.s3Key,
+                drivePrefix: drive.syncAnchor.prefix
+            )
+            do {
+                _ = try await s3Client.putThumbnail(
+                    bucket: bucket, key: thumbKey, data: jpegBytes, sourceETag: ""
+                )
+            } catch {
+                logger.error(
+                    "Backfill: PUT failed for \(thumbKey, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+                await queue.fail(item)
+                return
+            }
+
+            // 7. Signal File Provider so iOS Files re-fetches thumbnails for this drive
+            let domain = NSFileProviderDomain(
+                identifier: NSFileProviderDomainIdentifier(rawValue: drive.id.uuidString),
+                displayName: drive.name
+            )
+            do {
+                try await NSFileProviderManager(for: domain)?.signalEnumerator(for: .workingSet)
+            } catch {
+                logger.warning(
+                    "Backfill: signalEnumerator failed for \(drive.name, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+
+            // 8. Mark complete
+            await queue.complete(item)
+            logger.info("Backfill: done for \(item.s3Key, privacy: .public) → \(thumbKey, privacy: .public)")
+        }
+    }
+#endif

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -24,6 +24,11 @@
         private var drainTask: Task<Void, Never>?
         private var darwinObservation: DarwinNotificationObservation?
 
+        /// One DS3Client per drive UUID. Reusing the client avoids spawning new NIO event loops
+        /// and HTTP client threads for every thumbnail render when the backlog is large.
+        /// Call `invalidateS3Client(for:)` when a drive is disconnected to release the event loop.
+        private var ds3ClientCache: [UUID: DS3Client] = [:]
+
         init(driveManager: DS3DriveManager) {
             self.driveManager = driveManager
             darwinObservation = DarwinNotificationCenter.shared.addObserver(
@@ -63,6 +68,29 @@
             startDrain()
         }
 
+        /// Returns a cached DS3Client for the given drive, creating one if needed.
+        ///
+        /// Reusing a single client per drive avoids spawning fresh NIO event loops and
+        /// HTTP connection pools for every thumbnail in a large backfill batch.
+        private func cachedDS3Client(for drive: DS3Drive) throws -> DS3Client {
+            if let cached = ds3ClientCache[drive.id] {
+                return cached
+            }
+            let client = try DS3Client(drive: drive)
+            ds3ClientCache[drive.id] = client
+            return client
+        }
+
+        /// Shuts down and removes the cached DS3Client for the given drive.
+        ///
+        /// Call this when a drive is disconnected (e.g., from `DriveDetailView.disconnectDrive`)
+        /// so the underlying NIO event loop is released promptly.
+        func invalidateS3Client(for driveId: UUID) {
+            if let client = ds3ClientCache.removeValue(forKey: driveId) {
+                client.shutdown()
+            }
+        }
+
         private func drainLoop() async {
             let queue = ThumbnailRenderQueue.shared
 
@@ -100,10 +128,11 @@
                 return
             }
 
-            // 3. S3 client
+            // 3. S3 client — reuse the cached DS3Client for this drive to avoid spawning new
+            //    NIO event loops and HTTP connection pools on every render iteration.
             let s3Client: DS3S3Client
             do {
-                let ds3Client = try DS3Client(drive: drive)
+                let ds3Client = try cachedDS3Client(for: drive)
                 guard let client = ds3Client.driveS3Client else {
                     logger.error("Backfill: no S3 client for \(item.s3Key, privacy: .public)")
                     await queue.fail(item)
@@ -118,15 +147,22 @@
                 return
             }
 
-            // 4. Download original to temp file
+            // 4. Download original to temp file (stream directly to disk — no 2× memory peak)
             let ext = (item.s3Key as NSString).pathExtension
             let tempURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString + (ext.isEmpty ? "" : "." + ext))
+            // defer MUST be registered before any early return so the temp file is always cleaned up.
+            defer { try? FileManager.default.removeItem(at: tempURL) }
 
             let bucket = drive.syncAnchor.bucket.name
+            // Create an empty file so FileHandle(forWritingTo:) can open it.
+            guard FileManager.default.createFile(atPath: tempURL.path, contents: nil) else {
+                logger.error("Backfill: could not create temp file for \(item.s3Key, privacy: .public)")
+                await queue.fail(item)
+                return
+            }
             do {
-                let data = try await s3Client.getObjectData(bucket: bucket, key: item.s3Key)
-                try data.write(to: tempURL)
+                _ = try await s3Client.getObject(bucket: bucket, key: item.s3Key, toFile: tempURL)
             } catch {
                 logger.error(
                     "Backfill: download failed for \(item.s3Key, privacy: .public): \(error.localizedDescription, privacy: .public)"
@@ -134,7 +170,6 @@
                 await queue.fail(item)
                 return
             }
-            defer { try? FileManager.default.removeItem(at: tempURL) }
 
             // 5. Render JPEG off main thread — CPU-intensive
             let renderResult = await Task.detached(priority: .utility) {

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -92,23 +92,36 @@
         }
 
         private func drainLoop() async {
-            let queue = ThumbnailRenderQueue.shared
-
             while !Task.isCancelled {
-                let batch = await queue.dequeue(maxItems: 1)
-
-                if batch.isEmpty {
+                let processed = await drainBatch(maxItems: Int.max)
+                if processed == 0 {
                     try? await Task.sleep(for: .seconds(2))
-                    pendingCount = await queue.pendingCount
-                    continue
+                    pendingCount = await ThumbnailRenderQueue.shared.pendingCount
                 }
-
-                await renderOne(batch[0])
-                pendingCount = await queue.pendingCount
             }
 
             isRunning = false
             drainTask = nil
+        }
+
+        /// Processes up to `maxItems` pending thumbnail items. Returns the number actually processed.
+        ///
+        /// Called by both the foreground drain loop and the background processing task handler
+        /// (`BGProcessingTask`). Passing `Int.max` from the drain loop is equivalent to the
+        /// original unbounded behaviour.
+        func drainBatch(maxItems: Int) async -> Int {
+            let queue = ThumbnailRenderQueue.shared
+            var processed = 0
+
+            while processed < maxItems {
+                let batch = await queue.dequeue(maxItems: 1)
+                guard let item = batch.first else { break }
+                await renderOne(item)
+                processed += 1
+                pendingCount = await queue.pendingCount
+            }
+
+            return processed
         }
 
         // swiftlint:disable:next function_body_length

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -197,6 +197,11 @@
             }
             do {
                 _ = try await s3Client.getObject(bucket: bucket, key: item.s3Key, toFile: tempURL)
+            } catch is CancellationError {
+                // Drain task cancelled (scenePhase → background). Don't burn an
+                // attempt — the item should retry on next foreground tick.
+                logger.info("Backfill: download cancelled for \(item.s3Key, privacy: .public) — leaving in queue")
+                return
             } catch {
                 logger.error(
                     "Backfill: download failed for \(item.s3Key, privacy: .public): \(error.localizedDescription, privacy: .public)"
@@ -231,6 +236,9 @@
                 _ = try await s3Client.putThumbnail(
                     bucket: bucket, key: thumbKey, data: jpegBytes, sourceETag: ""
                 )
+            } catch is CancellationError {
+                logger.info("Backfill: PUT cancelled for \(thumbKey, privacy: .public) — leaving in queue")
+                return
             } catch {
                 logger.error(
                     "Backfill: PUT failed for \(thumbKey, privacy: .public): \(error.localizedDescription, privacy: .public)"

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -166,11 +166,9 @@
         private func renderOne(_ item: ThumbnailRenderQueueItem) async {
             let queue = ThumbnailRenderQueue.shared
 
-            // 1. Cellular gate
-            guard ThumbnailNetworkPolicy.shared.isAllowed() else {
-                logger.info("Backfill: skipping \(item.s3Key, privacy: .public) — cellular blocked")
-                return
-            }
+            // Cellular gate is checked once per drainBatch — the network state
+            // does not flip between dequeue and renderOne, so re-checking here
+            // would only duplicate the path-monitor lookup. (1)
 
             // 2. Drive lookup
             guard let drive = driveManager.driveWithID(item.driveID) else {

--- a/DS3DriveProvider/FileProviderExtension+Create.swift
+++ b/DS3DriveProvider/FileProviderExtension+Create.swift
@@ -344,15 +344,14 @@ extension FileProviderExtension {
 
                 #if os(iOS)
                     // Phase 14 Part 2: enqueue raster uploads for background rendering.
+                    // Synchronous await — same rationale as consumeThumbnail: extension
+                    // can be reaped immediately after this Task returns, so a detached
+                    // Task would lose its file write.
                     if !s3Item.isFolder, S3PathUtils.isRasterExtension((key as NSString).pathExtension) {
-                        let driveID = drive.id
-                        let s3KeyCopy = key
-                        Task.detached(priority: .background) {
-                            await ThumbnailRenderQueue.shared.append(
-                                ThumbnailRenderQueueItem(driveID: driveID, s3Key: s3KeyCopy)
-                            )
-                            DarwinNotificationCenter.shared.post(name: DarwinNotificationCenter.thumbnailRenderRequest)
-                        }
+                        await ThumbnailRenderQueue.shared.append(
+                            ThumbnailRenderQueueItem(driveID: drive.id, s3Key: key)
+                        )
+                        DarwinNotificationCenter.shared.post(name: DarwinNotificationCenter.thumbnailRenderRequest)
                     }
                 #endif
 

--- a/DS3DriveProvider/FileProviderExtension+Create.swift
+++ b/DS3DriveProvider/FileProviderExtension+Create.swift
@@ -276,6 +276,20 @@ extension FileProviderExtension {
                     )
                 }
 
+                #if os(iOS)
+                    // Phase 14 Part 2: enqueue raster uploads for background rendering.
+                    if !s3Item.isFolder, S3PathUtils.isRasterExtension((key as NSString).pathExtension) {
+                        let driveID = drive.id
+                        let s3KeyCopy = key
+                        Task.detached(priority: .background) {
+                            await ThumbnailRenderQueue.shared.append(
+                                ThumbnailRenderQueueItem(driveID: driveID, s3Key: s3KeyCopy)
+                            )
+                            DarwinNotificationCenter.shared.post(name: DarwinNotificationCenter.thumbnailRenderRequest)
+                        }
+                    }
+                #endif
+
                 // Clear parent error badge if this item was previously in error
                 if let parentCleared = try? await self.metadataStore?.clearParentErrorIfResolved(
                     childKey: key, driveId: drive.id

--- a/DS3DriveProvider/FileProviderExtension+Create.swift
+++ b/DS3DriveProvider/FileProviderExtension+Create.swift
@@ -228,6 +228,64 @@ extension FileProviderExtension {
                 }
                 // --- End conflict detection ---
 
+                #if os(iOS)
+                    // Phase 4 — Task 4.4: route file uploads through the
+                    // background URLSession on iOS so the FP extension can be
+                    // reaped without aborting the transfer. Folders still take
+                    // the synchronous PUT path (zero-byte create).
+                    if !s3Item.isFolder, let coordinator = self.iosUploadCoordinator,
+                       let sourceURL = url {
+                        do {
+                            try await coordinator.startUpload(
+                                s3Item: s3Item,
+                                sourceFileURL: sourceURL,
+                                drive: drive,
+                                progress: uploadProgress
+                            )
+
+                            // Persist provisional metadata so enumerators surface
+                            // the in-flight item; etag/lastModified will be
+                            // patched by `finalizeMultipartCompletion`.
+                            try? await self.metadataStore?.upsertItem(
+                                s3Key: key,
+                                driveId: drive.id,
+                                etag: nil,
+                                lastModified: Date(),
+                                syncStatus: .syncing,
+                                parentKey: parentKey,
+                                contentType: nil,
+                                size: Int64(itemSize)
+                            )
+
+                            // Return provisional item immediately — completion
+                            // arrives later via BackgroundUploadSession callbacks.
+                            self.signalChanges()
+                            completionHandler(s3Item, NSFileProviderItemFields(), false, nil)
+                            return
+                        } catch {
+                            self.logger.error(
+                                """
+                                iOS background upload start failed for \
+                                \(key, privacy: .public): \
+                                \(error.localizedDescription, privacy: .public)
+                                """
+                            )
+                            progress.completedUnitCount = progress.totalUnitCount
+                            await self.markItemAndParentAsError(
+                                itemKey: key, driveId: drive.id, metadataStore: self.metadataStore
+                            )
+                            await nm.sendDriveChangedNotificationWithDebounce(status: .error)
+                            completionHandler(
+                                nil,
+                                NSFileProviderItemFields(),
+                                false,
+                                NSFileProviderError(.serverUnreachable) as NSError
+                            )
+                            return
+                        }
+                    }
+                #endif
+
                 let createETag = try await self.withAPIKeyRecovery {
                     try await s3Lib.putS3Item(s3Item, fileURL: url, withProgress: uploadProgress)
                 }

--- a/DS3DriveProvider/FileProviderExtension+Create.swift
+++ b/DS3DriveProvider/FileProviderExtension+Create.swift
@@ -42,12 +42,20 @@ extension FileProviderExtension {
         // Trashing flows through modifyItem(parent: .trashContainer) → performMoveToTrash,
         // never createItem. Reject directly so the system retries the right path
         // and we never write a sentinel-prefixed key into S3.
+        //
+        // Use .featureUnsupported (NSCocoaErrorDomain) instead of .noSuchItem.
+        // iOS Files.app retries .noSuchItem indefinitely, thrashing the extension.
+        // .featureUnsupported tells the system "this operation isn't supported
+        // through this code path" and it stops the loop.
         if itemTemplate.parentItemIdentifier == .trashContainer {
             self.logger
                 .warning(
                     "Rejecting createItem with .trashContainer parent for \(itemTemplate.filename, privacy: .public)"
                 )
-            completionHandler(nil, [], false, NSFileProviderError(.noSuchItem) as NSError)
+            completionHandler(
+                nil, [], false,
+                NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError)
+            )
             return Progress()
         }
 

--- a/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
+++ b/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
@@ -1,0 +1,150 @@
+#if os(iOS)
+    import DS3Lib
+    @preconcurrency import FileProvider
+    import os.log
+
+    /// iOS background-upload glue (Phase 4 — Task 4.4).
+    ///
+    /// Responsible for:
+    ///   - Building `PendingUploadStore`, `BackgroundUploadSession`, and
+    ///     `IOSUploadCoordinator` once the extension has its `s3Client`/drive.
+    ///   - Finalizing multipart uploads when every part has reported its etag.
+    ///   - Reconciling orphaned multipart records left over from a prior
+    ///     extension lifetime (extension reaped while uploads were in flight).
+    ///
+    /// All entry points run on `@MainActor` so the (also-MainActor) coordinator
+    /// and session can be touched without isolation hops.
+    extension FileProviderExtension {
+        /// Builds the iOS background-upload pipeline: PendingUploadStore actor,
+        /// BackgroundUploadSession (which lazily attaches to the persisted
+        /// `nsurlsessiond` session), and the IOSUploadCoordinator that bridges
+        /// Soto's control plane to URLSession's data plane. Also runs the orphan
+        /// cleanup pass.
+        @MainActor
+        func setupIOSUploadInfrastructure() async {
+            guard self.enabled, let drive = self.drive, let s3Client = self.s3Client else {
+                return
+            }
+
+            let store = PendingUploadStore()
+            self.pendingUploadStore = store
+
+            let session = BackgroundUploadSession(
+                pendingStore: store,
+                onAllPartsComplete: { [weak self] upload in
+                    await self?.finalizeMultipartCompletion(upload)
+                }
+            )
+            self.backgroundUploadSession = session
+
+            guard let manager = NSFileProviderManager(for: self.domain) else {
+                logger.error("Cannot set up iOS upload infrastructure: no FP manager for domain")
+                return
+            }
+            guard let tempDir = self.temporaryDirectory else {
+                logger.error("Cannot set up iOS upload infrastructure: no temp directory")
+                return
+            }
+
+            self.iosUploadCoordinator = IOSUploadCoordinator(
+                s3Client: s3Client,
+                pendingStore: store,
+                backgroundSession: session,
+                manager: manager,
+                temporaryDirectory: tempDir
+            )
+
+            logger.info(
+                "iOS upload infrastructure ready for drive \(drive.id, privacy: .public)"
+            )
+
+            await cleanupOrphanedMultiparts()
+        }
+
+        /// Called when `BackgroundUploadSession` reports every part of a multipart
+        /// upload has completed. Issues `CompleteMultipartUpload` via Soto, removes
+        /// the pending record, and signals the parent enumerator. On failure aborts
+        /// the multipart upload to free server-side state.
+        @MainActor
+        func finalizeMultipartCompletion(_ upload: PendingUploadStore.PendingUpload) async {
+            guard let store = self.pendingUploadStore, let s3Client = self.s3Client else { return }
+            let parts = upload.completedPartETags
+                .sorted { $0.key < $1.key }
+                .map { (partNumber: $0.key, etag: $0.value) }
+            do {
+                _ = try await s3Client.completeMultipartUpload(
+                    bucket: upload.bucket,
+                    key: upload.key,
+                    uploadId: upload.uploadId,
+                    parts: parts
+                )
+                await store.remove(forKey: upload.key)
+                let parentKey = parentKeyForS3Key(upload.key)
+                signalChanges(andParent: parentKey)
+                logger.info(
+                    "Background multipart complete: \(upload.key, privacy: .public)"
+                )
+            } catch {
+                logger.error(
+                    """
+                    CompleteMultipartUpload failed for \(upload.key, privacy: .public): \
+                    \(error.localizedDescription, privacy: .public)
+                    """
+                )
+                try? await s3Client.abortMultipartUpload(
+                    bucket: upload.bucket, key: upload.key, uploadId: upload.uploadId
+                )
+                await store.remove(forKey: upload.key)
+            }
+        }
+
+        /// Aborts any multipart uploads whose part records reference URLSession task
+        /// IDs that are no longer in flight. Run once at extension startup.
+        @MainActor
+        func cleanupOrphanedMultiparts() async {
+            guard let store = self.pendingUploadStore,
+                  let session = self.backgroundUploadSession
+            else { return }
+
+            let allRecords = await store.allPendingPartRecords()
+            guard !allRecords.isEmpty else { return }
+
+            // `allTasks` returns every URLSessionTask currently held by
+            // `nsurlsessiond` for our background session — survivors of any
+            // prior extension respawn.
+            let liveTasks = await session.session.allTasks
+            let liveTaskIds = Set(liveTasks.map(\.taskIdentifier))
+
+            var orphanedKeys = Set<String>()
+            for record in allRecords where !liveTaskIds.contains(record.taskIdentifier) {
+                orphanedKeys.insert(record.key)
+                try? FileManager.default.removeItem(at: record.tempFileURL)
+            }
+
+            for key in orphanedKeys {
+                guard let upload = await store.pendingUpload(forKey: key) else { continue }
+                logger.warning(
+                    "Orphaned multipart \(upload.uploadId, privacy: .public) — aborting"
+                )
+                if let s3Client = self.s3Client {
+                    try? await s3Client.abortMultipartUpload(
+                        bucket: upload.bucket, key: upload.key, uploadId: upload.uploadId
+                    )
+                }
+                await store.remove(forKey: upload.key)
+            }
+        }
+
+        /// Returns the parent S3 key (with trailing delimiter) for a given key,
+        /// or `""` for top-level items (which `signalChanges(andParent:)` treats
+        /// as `.rootContainer`).
+        func parentKeyForS3Key(_ key: String) -> String? {
+            let delimiter = String(DefaultSettings.S3.delimiter)
+            let trimmed = key.hasSuffix(delimiter) ? String(key.dropLast()) : key
+            guard let lastSlash = trimmed.lastIndex(of: Character(delimiter)) else {
+                return ""
+            }
+            return String(trimmed[...lastSlash])
+        }
+    }
+#endif

--- a/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
+++ b/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
@@ -91,6 +91,18 @@
                 logger.info(
                     "Background multipart complete: \(upload.key, privacy: .public)"
                 )
+                if S3PathUtils.isRasterExtension((upload.key as NSString).pathExtension) {
+                    let driveID = upload.driveId
+                    let s3Key = upload.key
+                    Task.detached(priority: .background) {
+                        await ThumbnailRenderQueue.shared.append(
+                            ThumbnailRenderQueueItem(driveID: driveID, s3Key: s3Key)
+                        )
+                        DarwinNotificationCenter.shared.post(
+                            name: DarwinNotificationCenter.thumbnailRenderRequest
+                        )
+                    }
+                }
             } catch {
                 logger.error(
                     """

--- a/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
+++ b/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
@@ -92,16 +92,12 @@
                     "Background multipart complete: \(upload.key, privacy: .public)"
                 )
                 if S3PathUtils.isRasterExtension((upload.key as NSString).pathExtension) {
-                    let driveID = upload.driveId
-                    let s3Key = upload.key
-                    Task.detached(priority: .background) {
-                        await ThumbnailRenderQueue.shared.append(
-                            ThumbnailRenderQueueItem(driveID: driveID, s3Key: s3Key)
-                        )
-                        DarwinNotificationCenter.shared.post(
-                            name: DarwinNotificationCenter.thumbnailRenderRequest
-                        )
-                    }
+                    await ThumbnailRenderQueue.shared.append(
+                        ThumbnailRenderQueueItem(driveID: upload.driveId, s3Key: upload.key)
+                    )
+                    DarwinNotificationCenter.shared.post(
+                        name: DarwinNotificationCenter.thumbnailRenderRequest
+                    )
                 }
             } catch {
                 logger.error(

--- a/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
+++ b/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
@@ -59,6 +59,13 @@
             )
 
             await cleanupOrphanedMultiparts()
+
+            // Schedule S3-side orphan scan (rate-limited to once per 24h)
+            let cleaner = UploadOrphanCleaner(s3Client: s3Client)
+            Task { [weak self] in
+                guard self != nil else { return }
+                await cleaner.runIfDue(forDrive: drive, store: store)
+            }
         }
 
         /// Called when `BackgroundUploadSession` reports every part of a multipart

--- a/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
+++ b/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
@@ -32,8 +32,9 @@ extension FileProviderExtension {
                 switch command {
                 case let .refreshEnumeration(_, parentKey):
                     self?.logger.notice(
-                        "IPC: refreshEnumeration parent=\(parentKey ?? "<root>", privacy: .public) — signalling"
+                        "IPC: refreshEnumeration parent=\(parentKey ?? "<root>", privacy: .public) — refreshing"
                     )
+                    await self?.refreshMetadataForParent(parentKey: parentKey)
                     self?.signalChanges(andParent: parentKey)
                 case .emptyTrash:
                     continue
@@ -233,5 +234,60 @@ private class MaterializedItemObserver: NSObject, NSFileProviderEnumerationObser
 
     func finishEnumeratingWithError(_ error: Error) {
         onError?(error)
+    }
+}
+
+extension FileProviderExtension {
+    /// Re-lists S3 for the given parent prefix and updates MetadataStore so
+    /// `currentSyncAnchor` returns a fresh hash. Without this, signalEnumerator
+    /// is a no-op for items added by other processes (Share extension, web)
+    /// because the cached SyncAnchor matches the stale MetadataStore state.
+    func refreshMetadataForParent(parentKey: String?) async {
+        guard let drive = self.drive,
+              let s3Lib = self.s3Lib,
+              let metadataStore = self.metadataStore
+        else { return }
+
+        let normalizedPrefix: String? = {
+            guard let parentKey, !parentKey.isEmpty else { return nil }
+            return parentKey
+        }()
+
+        do {
+            var token: String?
+            var allItems: [S3Item] = []
+            repeat {
+                let (items, nextToken) = try await s3Lib.listS3Items(
+                    forDrive: drive,
+                    withPrefix: normalizedPrefix,
+                    recursively: false,
+                    withContinuationToken: token
+                )
+                allItems.append(contentsOf: items)
+                token = nextToken
+            } while token != nil
+
+            let visibleItems = allItems.filter {
+                S3Lib.isUserVisible($0.itemIdentifier.rawValue, drive: drive)
+            }
+            let upsertData = visibleItems.map {
+                MetadataStore.ItemUpsertData(from: $0, isMaterialized: true)
+            }
+            if !upsertData.isEmpty {
+                try? await metadataStore.batchUpsertItems(upsertData)
+            }
+            let parentForPrune = normalizedPrefix ?? ""
+            let allKeys = Set(upsertData.map(\.s3Key))
+            try? await metadataStore.pruneChildren(
+                parentKey: parentForPrune, driveId: drive.id, keepKeys: allKeys
+            )
+            self.logger.info(
+                "refreshMetadataForParent: \(visibleItems.count, privacy: .public) items reconciled for parent=\(parentKey ?? "<root>", privacy: .public)"
+            )
+        } catch {
+            self.logger.warning(
+                "refreshMetadataForParent failed for \(parentKey ?? "<root>", privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
+            )
+        }
     }
 }

--- a/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
+++ b/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
@@ -30,7 +30,12 @@ extension FileProviderExtension {
             for await command in ipcService.commands {
                 guard !Task.isCancelled, self != nil else { break }
                 switch command {
-                case .refreshEnumeration, .emptyTrash:
+                case let .refreshEnumeration(_, parentKey):
+                    self?.logger.notice(
+                        "IPC: refreshEnumeration parent=\(parentKey ?? "<root>", privacy: .public) — signalling"
+                    )
+                    self?.signalChanges(andParent: parentKey)
+                case .emptyTrash:
                     continue
                 }
             }

--- a/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
+++ b/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
@@ -284,10 +284,83 @@ extension FileProviderExtension {
             self.logger.info(
                 "refreshMetadataForParent: \(visibleItems.count, privacy: .public) items reconciled for parent=\(parentKey ?? "<root>", privacy: .public)"
             )
+
+            #if os(iOS)
+                await self.enqueueMissingThumbnails(visibleItems: visibleItems, drive: drive)
+            #endif
         } catch {
             self.logger.warning(
                 "refreshMetadataForParent failed for \(parentKey ?? "<root>", privacy: .public): \(DS3S3Client.describeSotoError(error), privacy: .public)"
             )
         }
     }
+
+    #if os(iOS)
+        /// Proactively enqueues raster items whose `.thumbnails/<file>.jpg` sidecar
+        /// is not yet on S3. Lists the parent's `.thumbnails/` prefix once to avoid
+        /// HEAD-per-item, then enqueues anything missing. The render queue dedups,
+        /// so duplicate appends are cheap. Drain runs whenever DS3DriveApp is
+        /// foreground (or BGProcessingTask fires).
+        func enqueueMissingThumbnails(visibleItems: [S3Item], drive: DS3Drive) async {
+            guard let s3Lib = self.s3Lib else { return }
+
+            let rasterItems = visibleItems.filter {
+                !$0.isFolder &&
+                    S3PathUtils.isRasterExtension(
+                        ($0.itemIdentifier.rawValue as NSString).pathExtension
+                    )
+            }
+            guard !rasterItems.isEmpty else { return }
+
+            // Build the .thumbnails/ prefix for the parent. All raster items
+            // under one parent share the same prefix, so list once.
+            let firstKey = rasterItems[0].itemIdentifier.rawValue
+            let firstThumbKey = S3PathUtils.thumbnailKey(forOriginalKey: firstKey)
+            let thumbPrefix = (firstThumbKey as NSString).deletingLastPathComponent + "/"
+
+            var existing: Set<String> = []
+            do {
+                var token: String?
+                repeat {
+                    let (items, nextToken) = try await s3Lib.listS3Items(
+                        forDrive: drive,
+                        withPrefix: thumbPrefix,
+                        recursively: false,
+                        withContinuationToken: token
+                    )
+                    for item in items where !item.isFolder {
+                        existing.insert(item.itemIdentifier.rawValue)
+                    }
+                    token = nextToken
+                } while token != nil
+            } catch {
+                // S3 list failed — fall through and enqueue everything; the
+                // render queue's dedup keeps us from spamming, and if the
+                // sidecar already exists the renderer just overwrites with
+                // the same bytes. Better than missing items.
+                self.logger.info(
+                    "enqueueMissingThumbnails: list \(thumbPrefix, privacy: .public) failed — enqueuing all raster items"
+                )
+            }
+
+            var enqueued = 0
+            for item in rasterItems {
+                let key = item.itemIdentifier.rawValue
+                let expectedThumb = S3PathUtils.thumbnailKey(forOriginalKey: key)
+                guard !existing.contains(expectedThumb) else { continue }
+                await ThumbnailRenderQueue.shared.append(
+                    ThumbnailRenderQueueItem(driveID: drive.id, s3Key: key)
+                )
+                enqueued += 1
+            }
+            if enqueued > 0 {
+                DarwinNotificationCenter.shared.post(
+                    name: DarwinNotificationCenter.thumbnailRenderRequest
+                )
+                self.logger.info(
+                    "enqueueMissingThumbnails: enqueued \(enqueued, privacy: .public) of \(rasterItems.count, privacy: .public) raster items (prefix=\(thumbPrefix, privacy: .public))"
+                )
+            }
+        }
+    #endif
 }

--- a/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
+++ b/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
@@ -312,35 +312,40 @@ extension FileProviderExtension {
             }
             guard !rasterItems.isEmpty else { return }
 
-            // Build the .thumbnails/ prefix for the parent. All raster items
-            // under one parent share the same prefix, so list once.
-            let firstKey = rasterItems[0].itemIdentifier.rawValue
-            let firstThumbKey = S3PathUtils.thumbnailKey(forOriginalKey: firstKey)
-            let thumbPrefix = (firstThumbKey as NSString).deletingLastPathComponent + "/"
+            // Group items by their `.thumbnails/` prefix so each distinct
+            // directory is listed once. Single-folder refresh = one entry.
+            // Root-level refresh = one entry per top-level subfolder.
+            var prefixes: Set<String> = []
+            for item in rasterItems {
+                let thumbKey = S3PathUtils.thumbnailKey(forOriginalKey: item.itemIdentifier.rawValue)
+                prefixes.insert((thumbKey as NSString).deletingLastPathComponent + "/")
+            }
 
             var existing: Set<String> = []
-            do {
-                var token: String?
-                repeat {
-                    let (items, nextToken) = try await s3Lib.listS3Items(
-                        forDrive: drive,
-                        withPrefix: thumbPrefix,
-                        recursively: false,
-                        withContinuationToken: token
+            for prefix in prefixes {
+                do {
+                    var token: String?
+                    repeat {
+                        let (items, nextToken) = try await s3Lib.listS3Items(
+                            forDrive: drive,
+                            withPrefix: prefix,
+                            recursively: false,
+                            withContinuationToken: token
+                        )
+                        for item in items where !item.isFolder {
+                            existing.insert(item.itemIdentifier.rawValue)
+                        }
+                        token = nextToken
+                    } while token != nil
+                } catch {
+                    // List failed for one prefix — fall through and enqueue
+                    // everything in it; the render queue's dedup keeps us from
+                    // spamming, and if the sidecar already exists the renderer
+                    // just overwrites with the same bytes.
+                    self.logger.info(
+                        "enqueueMissingThumbnails: list \(prefix, privacy: .public) failed — enqueuing all under it"
                     )
-                    for item in items where !item.isFolder {
-                        existing.insert(item.itemIdentifier.rawValue)
-                    }
-                    token = nextToken
-                } while token != nil
-            } catch {
-                // S3 list failed — fall through and enqueue everything; the
-                // render queue's dedup keeps us from spamming, and if the
-                // sidecar already exists the renderer just overwrites with
-                // the same bytes. Better than missing items.
-                self.logger.info(
-                    "enqueueMissingThumbnails: list \(thumbPrefix, privacy: .public) failed — enqueuing all raster items"
-                )
+                }
             }
 
             var enqueued = 0
@@ -358,7 +363,7 @@ extension FileProviderExtension {
                     name: DarwinNotificationCenter.thumbnailRenderRequest
                 )
                 self.logger.info(
-                    "enqueueMissingThumbnails: enqueued \(enqueued, privacy: .public) of \(rasterItems.count, privacy: .public) raster items (prefix=\(thumbPrefix, privacy: .public))"
+                    "enqueueMissingThumbnails: enqueued \(enqueued, privacy: .public) of \(rasterItems.count, privacy: .public) raster items across \(prefixes.count, privacy: .public) prefix(es)"
                 )
             }
         }

--- a/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
+++ b/DS3DriveProvider/FileProviderExtension+Lifecycle.swift
@@ -30,7 +30,13 @@ extension FileProviderExtension {
             for await command in ipcService.commands {
                 guard !Task.isCancelled, self != nil else { break }
                 switch command {
-                case let .refreshEnumeration(_, parentKey):
+                case let .refreshEnumeration(driveId, parentKey):
+                    // Filter to commands targeted at this domain. The iOS IPC
+                    // channel is shared across drives, so a sibling extension
+                    // would otherwise re-list its bucket on every signal.
+                    guard let selfDriveId = self?.drive?.id, selfDriveId == driveId else {
+                        continue
+                    }
                     self?.logger.notice(
                         "IPC: refreshEnumeration parent=\(parentKey ?? "<root>", privacy: .public) — refreshing"
                     )

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
@@ -78,6 +78,19 @@ func consumeThumbnail(
             // can route into `consumeThumbnailFallback` (Phase 13.2 Plan 02).
             // `mapThumbnailFetchError` never returns `.noSuchItem`, so this
             // sentinel is unambiguous.
+            #if os(iOS)
+                // Phase 14 Part 2: enqueue for background rendering in the main app.
+                // Fire-and-forget — perItemHandler fires immediately with .noSuchItem
+                // (iOS interceptor remaps to .serverUnreachable so Files.app retries).
+                let driveID = drive.id
+                let s3KeyToEnqueue = identifier.rawValue
+                Task.detached(priority: .background) {
+                    await ThumbnailRenderQueue.shared.append(
+                        ThumbnailRenderQueueItem(driveID: driveID, s3Key: s3KeyToEnqueue)
+                    )
+                    DarwinNotificationCenter.shared.post(name: DarwinNotificationCenter.thumbnailRenderRequest)
+                }
+            #endif
             perItemHandler(identifier, nil, NSFileProviderError(.noSuchItem) as NSError)
         }
     } catch {

--- a/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
+++ b/DS3DriveProvider/FileProviderExtension+ThumbnailConsume.swift
@@ -80,16 +80,14 @@ func consumeThumbnail(
             // sentinel is unambiguous.
             #if os(iOS)
                 // Phase 14 Part 2: enqueue for background rendering in the main app.
-                // Fire-and-forget — perItemHandler fires immediately with .noSuchItem
-                // (iOS interceptor remaps to .serverUnreachable so Files.app retries).
-                let driveID = drive.id
-                let s3KeyToEnqueue = identifier.rawValue
-                Task.detached(priority: .background) {
-                    await ThumbnailRenderQueue.shared.append(
-                        ThumbnailRenderQueueItem(driveID: driveID, s3Key: s3KeyToEnqueue)
-                    )
-                    DarwinNotificationCenter.shared.post(name: DarwinNotificationCenter.thumbnailRenderRequest)
-                }
+                // Synchronous: extension can be reaped immediately after responding
+                // to fetchThumbnails, so a detached Task would lose its work. We're
+                // already in async context, the append is a small file write, and
+                // perItemHandler still fires before this function returns.
+                await ThumbnailRenderQueue.shared.append(
+                    ThumbnailRenderQueueItem(driveID: drive.id, s3Key: identifier.rawValue)
+                )
+                DarwinNotificationCenter.shared.post(name: DarwinNotificationCenter.thumbnailRenderRequest)
             #endif
             perItemHandler(identifier, nil, NSFileProviderError(.noSuchItem) as NSError)
         }

--- a/DS3DriveProvider/FileProviderExtension+Thumbnails.swift
+++ b/DS3DriveProvider/FileProviderExtension+Thumbnails.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import DS3Lib
 @preconcurrency import FileProvider
 import os.log
@@ -156,13 +157,14 @@ extension FileProviderExtension {
 // MARK: - Thumbnails (Phase 13 cache-first consume path)
 
 extension FileProviderExtension {
-    /// `NSFileProviderThumbnailing` entry point. Cache-first: reads
-    /// `.thumbnails/<key>.jpg` from S3 and returns bytes; on 404, marks the
-    /// item `.pending` for backfill and returns `.noSuchItem` so Finder draws
-    /// the default UTType icon and retries on next browse.
-    ///
-    /// Phase 13 D-11, D-12, D-13: this path NEVER renders, NEVER downloads
-    /// originals, and NEVER returns custom error domains across the boundary.
+    // NSFileProviderThumbnailing entry point. Cache-first: reads
+    // `.thumbnails/<key>.jpg` from S3 and returns bytes; on 404, marks the
+    // item `.pending` for backfill and returns `.noSuchItem` so Finder draws
+    // the default UTType icon and retries on next browse.
+    //
+    // Phase 13 D-11, D-12, D-13: this path NEVER renders, NEVER downloads
+    // originals, and NEVER returns custom error domains across the boundary.
+    // swiftlint:disable:next function_body_length
     func fetchThumbnails(
         for itemIdentifiers: [NSFileProviderItemIdentifier],
         requestedSize _: CGSize,
@@ -172,16 +174,53 @@ extension FileProviderExtension {
         let progress = Progress(totalUnitCount: Int64(itemIdentifiers.count))
 
         #if os(iOS)
-            // On iOS, skip all thumbnail generation to stay within the 20MB memory limit.
-            // Each thumbnail requires S3 HEAD + download + image processing which quickly
-            // exhausts the extension's memory budget, causing jetsam kills. iOS has its
-            // own consume path (Phase 14) that will read `.thumbnails/` once Phase 13
-            // generation has populated the prefix.
-            for identifier in itemIdentifiers {
-                perThumbnailCompletionHandler(identifier, nil, nil)
+            let completed = OSAllocatedUnfairLock(initialState: false)
+            let boxedFinalCb = UncheckedBox(value: completionHandler)
+
+            @Sendable
+            func completeFinal(_ error: Error?) {
+                let shouldCall = completed.withLock { flag -> Bool in
+                    guard !flag else { return false }
+                    flag = true
+                    return true
+                }
+                guard shouldCall else { return }
+                boxedFinalCb.value(error)
             }
-            completionHandler(nil)
-            progress.completedUnitCount = Int64(itemIdentifiers.count)
+
+            guard self.enabled else {
+                for identifier in itemIdentifiers {
+                    perThumbnailCompletionHandler(identifier, nil, nil)
+                }
+                progress.completedUnitCount = Int64(itemIdentifiers.count)
+                completeFinal(NSFileProviderError(.notAuthenticated) as NSError)
+                return progress
+            }
+
+            guard let drive = self.drive, let s3Client = self.s3Client else {
+                for identifier in itemIdentifiers {
+                    perThumbnailCompletionHandler(identifier, nil, nil)
+                }
+                progress.completedUnitCount = Int64(itemIdentifiers.count)
+                completeFinal(NSFileProviderError(.cannotSynchronize) as NSError)
+                return progress
+            }
+
+            self.logger.info("fetchThumbnails: starting for \(itemIdentifiers.count) items (cache-first, iOS)")
+
+            let task = self.spawnCacheFirstThumbnailTaskIOS(
+                itemIdentifiers: itemIdentifiers,
+                drive: drive,
+                s3Client: s3Client,
+                progress: progress,
+                perThumbnailCompletionHandler: perThumbnailCompletionHandler,
+                completeFinal: completeFinal
+            )
+
+            progress.cancellationHandler = {
+                task.cancel()
+            }
+
             return progress
         #else
 
@@ -383,6 +422,98 @@ extension FileProviderExtension {
                                     perItemHandler: perItemCb
                                 )
                             }
+                            await limiter.release()
+                            progress.completedUnitCount += 1
+                        }
+                    }
+                }
+                completeFinal(nil)
+            }
+        }
+    #endif
+
+    #if os(iOS)
+        /// iOS-only cache-first consume helper. Structurally mirrors the macOS
+        /// `spawnCacheFirstThumbnailTask` but drops the fallback render/PUT
+        /// pipeline (rendering is impossible under the 20 MB jetsam ceiling).
+        /// Cache misses return `.serverUnreachable` so Files.app retries on
+        /// next browse without requiring a `contentVersion` bump (Phase 14).
+        private func spawnCacheFirstThumbnailTaskIOS(
+            itemIdentifiers: [NSFileProviderItemIdentifier],
+            drive: DS3Drive,
+            s3Client: DS3S3Client,
+            progress: Progress,
+            perThumbnailCompletionHandler: @escaping (NSFileProviderItemIdentifier, Data?, Error?) -> Void,
+            completeFinal: @escaping @Sendable (Error?) -> Void
+        ) -> Task<Void, Never> {
+            let limiter = self.thumbnailFetchLimiter
+            let boxedMemoCache = UncheckedBox(value: self.thumbnailMemoCache)
+            let boxedPerItemCb = UncheckedBox(value: perThumbnailCompletionHandler)
+
+            let fetchBytes: ThumbnailByteFetcher = { @Sendable bucket, key in
+                let cache = boxedMemoCache.value
+                if let cached = cache.object(forKey: key as NSString) {
+                    return cached as Data
+                }
+                let data = try await s3Client.getThumbnailBytesViaDownloadTask(bucket: bucket, key: key)
+                if let data {
+                    cache.setObject(data as NSData, forKey: key as NSString, cost: data.count)
+                }
+                return data
+            }
+
+            let perItemCb: PerThumbnailCompletionHandler = { id, data, error in
+                boxedPerItemCb.value(id, data, error)
+            }
+
+            return Task {
+                await withTaskGroup(of: Void.self) { group in
+                    for identifier in itemIdentifiers {
+                        group.addTask {
+                            do {
+                                try await limiter.acquire()
+                            } catch is CancellationError {
+                                perItemCb(
+                                    identifier, nil,
+                                    NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)
+                                )
+                                return
+                            } catch {
+                                perItemCb(
+                                    identifier, nil,
+                                    NSFileProviderError(.cannotSynchronize) as NSError
+                                )
+                                return
+                            }
+
+                            // Remap the `.noSuchItem` cache-miss sentinel to
+                            // `.serverUnreachable` on iOS so Files.app retries
+                            // naturally on the next folder browse. There is no
+                            // inline fallback on iOS (rendering would breach the
+                            // jetsam ceiling); generation is deferred to the main
+                            // app via ThumbnailRenderQueue (Phase 14 Part 2).
+                            let noSuchItemCode = NSFileProviderError.Code.noSuchItem.rawValue
+                            let interceptor: PerThumbnailCompletionHandler = { id, data, error in
+                                if data == nil,
+                                   let nsErr = error as? NSError,
+                                   nsErr.domain == NSFileProviderErrorDomain,
+                                   nsErr.code == noSuchItemCode {
+                                    perItemCb(
+                                        id, nil,
+                                        NSFileProviderError(.serverUnreachable) as NSError
+                                    )
+                                } else {
+                                    perItemCb(id, data, error)
+                                }
+                            }
+
+                            await consumeThumbnail(
+                                identifier: identifier,
+                                drive: drive,
+                                fetchBytes: fetchBytes,
+                                perItemHandler: interceptor
+                            )
+
                             await limiter.release()
                             progress.completedUnitCount += 1
                         }

--- a/DS3DriveProvider/FileProviderExtension.swift
+++ b/DS3DriveProvider/FileProviderExtension.swift
@@ -68,11 +68,27 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension,
         let fetchSemaphore = AsyncSemaphore(value: 20)
     #endif
 
-    /// Bounds concurrent thumbnail GETs from `fetchThumbnails` (Phase 13 D-12,
-    /// THUMB-14). macOS=4. Mirror of `BucketListingLimiter` for the consume
-    /// path. Upload generator and backfill coordinator do NOT route through
-    /// this limiter (Pitfall 4).
-    let thumbnailFetchLimiter = ThumbnailFetchLimiter(maxSlots: 4)
+    // Bounds concurrent thumbnail GETs from `fetchThumbnails` (Phase 13 D-12,
+    // THUMB-14). macOS=4, iOS=2 (tighter jetsam ceiling). Upload generator
+    // and backfill coordinator do NOT route through this limiter (Pitfall 4).
+    #if os(iOS)
+        let thumbnailFetchLimiter = ThumbnailFetchLimiter(maxSlots: 2)
+    #else
+        let thumbnailFetchLimiter = ThumbnailFetchLimiter(maxSlots: 4)
+    #endif
+
+    // iOS-only in-flight coalescing cache for thumbnail bytes. Prevents
+    // duplicate S3 GETs when Files.app fans out multiple requests for the
+    // same key in one `fetchThumbnails` batch. NSCache evicts under memory
+    // pressure — safe for the 20 MB extension jetsam ceiling.
+    #if os(iOS)
+        let thumbnailMemoCache: NSCache<NSString, NSData> = {
+            let cache = NSCache<NSString, NSData>()
+            cache.totalCostLimit = 1 * 1024 * 1024
+            cache.name = "ThumbnailConsumeCoalesce"
+            return cache
+        }()
+    #endif
 
     /// Phase 13.2 D-02: 2-slot limiter for the cache-miss fallback render path.
     /// Strict separation from the 4-slot `thumbnailFetchLimiter` (cached-thumb

--- a/DS3DriveProvider/FileProviderExtension.swift
+++ b/DS3DriveProvider/FileProviderExtension.swift
@@ -110,6 +110,18 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension,
     let systemService: any SystemService
     let ipcService: any IPCService
 
+    #if os(iOS)
+        // iOS-only: background upload infrastructure (Phase 4 — Task 4.4).
+        // Soto cannot drive a background URLSession, so the iOS extension splits
+        // multipart uploads: control plane via Soto (DS3S3Client), data plane via
+        // URLSession.background tasks managed by `BackgroundUploadSession`.
+        // Properties are wired in `setupIOSUploadInfrastructure()` (lives in
+        // `FileProviderExtension+IOSUpload.swift`), hence module-internal access.
+        var pendingUploadStore: PendingUploadStore?
+        var backgroundUploadSession: BackgroundUploadSession?
+        var iosUploadCoordinator: IOSUploadCoordinator?
+    #endif
+
     required init(domain: NSFileProviderDomain) {
         self.enabled = false
         self.domain = domain
@@ -162,6 +174,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension,
         self.startCommandListener()
         self.startWorkingSetSignaller()
 
+        #if os(iOS)
+            Task { @MainActor [weak self] in
+                await self?.setupIOSUploadInfrastructure()
+            }
+        #endif
+
         logMemoryUsage(label: "init-complete", logger: logger)
     }
 
@@ -188,6 +206,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension,
         if let s3Lib = self.s3Lib {
             Task { try? await s3Lib.shutdown() }
         }
+
+        // NOTE: do NOT invalidate `backgroundUploadSession.session` here. The iOS
+        // background URLSession lives in `nsurlsessiond` and MUST outlive any
+        // single extension instance — invalidating it would cancel in-flight
+        // multipart uploads when the FP system reaps us mid-transfer. The session
+        // is reattached by identifier when a fresh extension instance is spawned.
     }
 
     // MARK: - Pure async business logic

--- a/DS3DriveProvider/FileProviderExtension.swift
+++ b/DS3DriveProvider/FileProviderExtension.swift
@@ -401,19 +401,32 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension,
         return progress
     }
 
-    /// Signals the system to re-enumerate changes after a local CRUD operation.
-    func signalChanges() {
+    func signalChanges(andParent parentKey: String? = nil) {
         guard let manager = NSFileProviderManager(for: self.domain) else {
-            logger
-                .warning(
-                    "Cannot signal enumerator: no manager for domain \(self.domain.identifier.rawValue, privacy: .public)"
-                )
+            logger.warning(
+                "Cannot signal enumerator: no manager for domain \(self.domain.identifier.rawValue, privacy: .public)"
+            )
             return
         }
 
         manager.signalEnumerator(for: .workingSet) { [weak self] error in
             if let error {
                 self?.logger.error("Failed to signal working set: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        if let parentKey {
+            let parentId: NSFileProviderItemIdentifier = parentKey.isEmpty
+                ? .rootContainer
+                : NSFileProviderItemIdentifier(rawValue: parentKey)
+            manager.signalEnumerator(for: parentId) { [weak self] error in
+                if let error {
+                    self?.logger.error(
+                        "Failed to signal parent \(parentKey, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
+                } else {
+                    self?.logger.debug("Signalled parent enumerator: \(parentKey, privacy: .public)")
+                }
             }
         }
     }

--- a/DS3DriveProvider/S3Lib+Transfers.swift
+++ b/DS3DriveProvider/S3Lib+Transfers.swift
@@ -173,7 +173,13 @@ extension S3Lib {
         if size < DefaultSettings.S3.multipartThreshold || s3Item.contentType == .folder {
             return try await self.putS3ItemStandard(s3Item, fileURL: fileURL, withProgress: progress)
         }
-        return try await self.putS3ItemMultipart(s3Item, fileURL: fileURL, withProgress: progress)
+        #if os(iOS)
+            // On iOS large files are routed through the background-upload pipeline before
+            // putS3Item is called; this path should never be reached at runtime.
+            return try await self.putS3ItemStandard(s3Item, fileURL: fileURL, withProgress: progress)
+        #else
+            return try await self.putS3ItemMultipart(s3Item, fileURL: fileURL, withProgress: progress)
+        #endif
     }
 
     /// Performs a standard PUT request for a given S3Item
@@ -227,58 +233,61 @@ extension S3Lib {
         return etag
     }
 
-    /// Performs a multipart upload for a given S3Item using parallel part uploads.
-    private func putS3ItemMultipart(
-        _ s3Item: S3Item,
-        fileURL: URL? = nil,
-        withProgress progress: Progress? = nil
-    ) async throws -> String? {
-        guard let fileURL else {
-            throw FileProviderExtensionError.fileNotFound
-        }
+    #if !os(iOS)
+        /// Performs a multipart upload for a given S3Item using parallel part uploads.
+        /// Not used on iOS — the background-upload pipeline handles multipart there.
+        private func putS3ItemMultipart(
+            _ s3Item: S3Item,
+            fileURL: URL? = nil,
+            withProgress progress: Progress? = nil
+        ) async throws -> String? {
+            guard let fileURL else {
+                throw FileProviderExtensionError.fileNotFound
+            }
 
-        let key = s3Item.itemIdentifier.rawValue
-        let documentTotalSize = Int64(truncating: s3Item.documentSize ?? 0)
-        let driveId = s3Item.drive.id
-        let nm = self.notificationManager
-        let filename = s3Item.filename
+            let key = s3Item.itemIdentifier.rawValue
+            let documentTotalSize = Int64(truncating: s3Item.documentSize ?? 0)
+            let driveId = s3Item.drive.id
+            let nm = self.notificationManager
+            let filename = s3Item.filename
 
-        // Send an initial notification so the file appears in the tray immediately
-        await nm.sendTransferSpeedNotification(
-            DriveTransferStats(
-                driveId: driveId, size: 0, duration: 0, direction: .upload,
-                filename: filename, totalSize: documentTotalSize
+            // Send an initial notification so the file appears in the tray immediately
+            await nm.sendTransferSpeedNotification(
+                DriveTransferStats(
+                    driveId: driveId, size: 0, duration: 0, direction: .upload,
+                    filename: filename, totalSize: documentTotalSize
+                )
             )
-        )
 
-        do {
-            return try await client.putObjectMultipart(
-                bucket: s3Item.drive.syncAnchor.bucket.name,
-                key: key,
-                fileURL: fileURL,
-                totalSize: documentTotalSize,
-                pendingUploadStore: pendingUploadStore,
-                driveId: driveId,
-                onPartComplete: { _ in
-                    progress?.completedUnitCount += 1
-                },
-                onProgress: { transferProgress in
-                    let stats = DriveTransferStats(
-                        driveId: driveId,
-                        size: transferProgress.bytesTransferred,
-                        duration: transferProgress.duration,
-                        direction: .upload,
-                        filename: filename,
-                        totalSize: documentTotalSize
-                    )
-                    Task { await nm.sendTransferSpeedNotification(stats) }
-                }
-            )
-        } catch DS3ClientError.missingETag {
-            self.logger.error("Multipart upload returned no ETag for key \(key, privacy: .public)")
-            throw FileProviderExtensionError.uploadValidationFailed
+            do {
+                return try await client.putObjectMultipart(
+                    bucket: s3Item.drive.syncAnchor.bucket.name,
+                    key: key,
+                    fileURL: fileURL,
+                    totalSize: documentTotalSize,
+                    pendingUploadStore: pendingUploadStore,
+                    driveId: driveId,
+                    onPartComplete: { _ in
+                        progress?.completedUnitCount += 1
+                    },
+                    onProgress: { transferProgress in
+                        let stats = DriveTransferStats(
+                            driveId: driveId,
+                            size: transferProgress.bytesTransferred,
+                            duration: transferProgress.duration,
+                            direction: .upload,
+                            filename: filename,
+                            totalSize: documentTotalSize
+                        )
+                        Task { await nm.sendTransferSpeedNotification(stats) }
+                    }
+                )
+            } catch DS3ClientError.missingETag {
+                self.logger.error("Multipart upload returned no ETag for key \(key, privacy: .public)")
+                throw FileProviderExtensionError.uploadValidationFailed
+            }
         }
-    }
+    #endif
 
     /// Aborts a multipart upload for a given S3Item and uploadId
     func abortS3MultipartUpload(

--- a/DS3DriveProvider/iOS/BackgroundUploadSession.swift
+++ b/DS3DriveProvider/iOS/BackgroundUploadSession.swift
@@ -52,7 +52,7 @@
             )
             // Persist temp files / state inside the App Group container so any
             // future extension instance can reach them.
-            config.sharedContainerIdentifier = "group.X889956QSM.io.cubbit.DS3Drive"
+            config.sharedContainerIdentifier = DefaultSettings.appGroup
             config.isDiscretionary = false
             config.sessionSendsLaunchEvents = true
             config.allowsCellularAccess = true

--- a/DS3DriveProvider/iOS/BackgroundUploadSession.swift
+++ b/DS3DriveProvider/iOS/BackgroundUploadSession.swift
@@ -1,0 +1,194 @@
+#if os(iOS)
+    import DS3Lib
+    import FileProvider
+    import Foundation
+    import os.log
+
+    /// Manages the `URLSession.background` instance used by the iOS File Provider
+    /// extension to upload S3 multipart parts.
+    ///
+    /// Why a background session?
+    /// ------------------------
+    /// Soto's default URLSession is foreground and dies as soon as the FP extension
+    /// process is reaped. iOS will happily reap our extension mid-upload, leaving
+    /// in-flight tasks orphaned and triggering an upload death-loop. A
+    /// `URLSession.background(withIdentifier:)` lives in `nsurlsessiond`, which holds
+    /// onto in-flight tasks across extension respawns. When the extension is
+    /// re-spawned and re-creates a session with the same identifier, pending
+    /// delegate callbacks are delivered to the new instance.
+    ///
+    /// The identifier MUST stay stable across builds and respawns — it is the only
+    /// handle into the persisted session state held by `nsurlsessiond`.
+    @MainActor
+    final class BackgroundUploadSession: NSObject {
+        /// Stable identifier for the FP extension's background URLSession.
+        /// Do NOT change this value — it is the key `nsurlsessiond` uses to
+        /// reconnect a fresh extension instance to its persisted upload tasks.
+        static let configurationIdentifier =
+            "group.X889956QSM.io.cubbit.DS3Drive.fp-upload"
+
+        private let logger = Logger(
+            subsystem: "io.cubbit.DS3Drive.provider",
+            category: "bg-upload"
+        )
+
+        private let pendingStore: PendingUploadStore
+        private let onAllPartsComplete:
+            @Sendable (PendingUploadStore.PendingUpload) async -> Void
+
+        /// Keys of uploads we've already dispatched to `onAllPartsComplete`. Guards
+        /// against the case where two parts of the same upload finish almost
+        /// simultaneously — both delegate callbacks would observe the same
+        /// "all parts complete" snapshot before the finalizer has had a chance to
+        /// call `pendingStore.remove(forKey:)`.
+        private var finalizingKeys: Set<String> = []
+
+        /// Lazily constructed background session. Background sessions cannot be
+        /// re-initialised with the same identifier in a single process, so this
+        /// stays a single instance for the lifetime of the extension.
+        private(set) lazy var session: URLSession = {
+            let config = URLSessionConfiguration.background(
+                withIdentifier: Self.configurationIdentifier
+            )
+            // Persist temp files / state inside the App Group container so any
+            // future extension instance can reach them.
+            config.sharedContainerIdentifier = "group.X889956QSM.io.cubbit.DS3Drive"
+            config.isDiscretionary = false
+            config.sessionSendsLaunchEvents = true
+            config.allowsCellularAccess = true
+            return URLSession(
+                configuration: config,
+                delegate: self,
+                delegateQueue: .main
+            )
+        }()
+
+        init(
+            pendingStore: PendingUploadStore,
+            onAllPartsComplete:
+            @escaping @Sendable (PendingUploadStore.PendingUpload) async -> Void
+        ) {
+            self.pendingStore = pendingStore
+            self.onAllPartsComplete = onAllPartsComplete
+        }
+    }
+
+    // MARK: - URLSessionDelegate
+
+    extension BackgroundUploadSession: URLSessionDelegate {
+        nonisolated func urlSessionDidFinishEvents(
+            forBackgroundURLSession session: URLSession
+        ) {
+            // No app-level handler required for FP extensions: the system does not
+            // launch us via `application(_:handleEventsForBackgroundURLSession:)`.
+            // Delegate callbacks alone drive the state machine.
+        }
+    }
+
+    // MARK: - URLSessionTaskDelegate
+
+    extension BackgroundUploadSession: URLSessionTaskDelegate {
+        nonisolated func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            didCompleteWithError error: Error?
+        ) {
+            let taskId = task.taskIdentifier
+            let httpStatus = (task.response as? HTTPURLResponse)?.statusCode ?? -1
+            let etag = (task.response as? HTTPURLResponse)?
+                .value(forHTTPHeaderField: "ETag")?
+                .replacingOccurrences(of: "\"", with: "")
+
+            Task { @MainActor [weak self] in
+                await self?.handleTaskCompletion(
+                    taskId: taskId,
+                    httpStatus: httpStatus,
+                    etag: etag,
+                    error: error
+                )
+            }
+        }
+    }
+
+    // MARK: - State machine
+
+    extension BackgroundUploadSession {
+        private func handleTaskCompletion(
+            taskId: Int,
+            httpStatus: Int,
+            etag: String?,
+            error: Error?
+        ) async {
+            if let error {
+                logger.error(
+                    "Upload task \(taskId) error: \(error.localizedDescription, privacy: .public)"
+                )
+                await abortUploadForTask(taskId)
+                return
+            }
+
+            if httpStatus == 403 {
+                logger.warning(
+                    "Upload task \(taskId) presigned URL expired (HTTP 403) — aborting"
+                )
+                await abortUploadForTask(taskId)
+                return
+            }
+
+            guard (200 ..< 300).contains(httpStatus), let etag else {
+                logger.error(
+                    "Upload task \(taskId) unexpected HTTP \(httpStatus, privacy: .public)"
+                )
+                await abortUploadForTask(taskId)
+                return
+            }
+
+            // Mark the part complete. This persists the etag against the parent
+            // PendingUpload and removes the per-task record + temp file.
+            await pendingStore.markPartCompleted(
+                taskIdentifier: taskId,
+                etag: etag
+            )
+            logger.debug(
+                "Task \(taskId) part complete, etag=\(etag, privacy: .public)"
+            )
+
+            // Find any uploads whose every expected part has now arrived. Typical
+            // case is 0 or 1 candidates per call.
+            let completed = await pendingStore.allCompletedUploads()
+            for upload in completed {
+                guard !finalizingKeys.contains(upload.key) else {
+                    // Another delegate callback is already finalizing this upload
+                    // (or has just finalized it but `remove(forKey:)` hasn't yet
+                    // settled). Skip to avoid double-finalization.
+                    continue
+                }
+                finalizingKeys.insert(upload.key)
+                logger.info(
+                    "All parts complete for \(upload.key, privacy: .public) — finalizing"
+                )
+
+                let key = upload.key
+                let handler = onAllPartsComplete
+                // Dispatch finalization on a Task so the delegate queue stays
+                // responsive. The finalizer is responsible for calling
+                // `pendingStore.remove(forKey:)` on success/failure, after which
+                // the upload will not appear in `allCompletedUploads()` again.
+                Task { @MainActor [weak self] in
+                    await handler(upload)
+                    self?.finalizingKeys.remove(key)
+                }
+            }
+        }
+
+        private func abortUploadForTask(_ taskId: Int) async {
+            guard
+                let record = await pendingStore.partRecord(forTaskIdentifier: taskId)
+            else { return }
+            // Best-effort cleanup of the temp chunk file. The S3-level multipart
+            // upload abort is owned by the orphan reconciler invoked at extension
+            // init time (see Lifecycle).
+            try? FileManager.default.removeItem(at: record.tempFileURL)
+        }
+    }
+#endif

--- a/DS3DriveProvider/iOS/IOSUploadCoordinator.swift
+++ b/DS3DriveProvider/iOS/IOSUploadCoordinator.swift
@@ -1,0 +1,224 @@
+#if os(iOS)
+    import DS3Lib
+    import FileProvider
+    import Foundation
+    import os.log
+
+    /// Orchestrates the iOS File Provider upload path.
+    ///
+    /// Soto v6 cannot drive a background `URLSession` (Soto Discussion #484), so
+    /// the iOS extension splits multipart upload responsibilities:
+    ///   - **Control plane (Soto):** CreateMultipartUpload, presign each
+    ///     UploadPart with SigV4, CompleteMultipartUpload, AbortMultipartUpload.
+    ///   - **Data plane (URLSession.background):** plain `URLSessionUploadTask`
+    ///     instances upload chunk files via the presigned PUT URLs.
+    ///
+    /// Each task is registered with `NSFileProviderManager.register(_:forItemWithIdentifier:)`
+    /// so the FP extension's lifetime is anchored to the in-flight upload — the
+    /// system will not reap us mid-transfer, and a respawn re-attaches to the
+    /// same `nsurlsessiond`-held tasks via `BackgroundUploadSession`.
+    ///
+    /// Persistence of upload state (uploadId, per-part task identifiers, temp
+    /// chunk files) lives in `PendingUploadStore`, in the App Group container,
+    /// so a freshly-spawned extension can resolve delegate callbacks back to
+    /// the parent multipart upload.
+    @MainActor
+    final class IOSUploadCoordinator {
+        private let logger = Logger(
+            subsystem: "io.cubbit.DS3Drive.provider",
+            category: "ios-upload"
+        )
+
+        private let s3Client: DS3S3Client
+        private let pendingStore: PendingUploadStore
+        private let backgroundSession: BackgroundUploadSession
+        private let manager: NSFileProviderManager
+        private let temporaryDirectory: URL
+
+        /// Multipart part size (5 MiB) — matches the S3 minimum for non-final parts.
+        /// Mirrors `DefaultSettings.S3.multipartUploadPartSize` semantics.
+        private let partSize: Int64 = 5 * 1024 * 1024
+
+        /// Presigned URL expiry. 1 hour is generous given that uploads run in
+        /// `nsurlsessiond` and may be deferred while the device is locked.
+        private let presignExpiry: TimeInterval = 3600
+
+        init(
+            s3Client: DS3S3Client,
+            pendingStore: PendingUploadStore,
+            backgroundSession: BackgroundUploadSession,
+            manager: NSFileProviderManager,
+            temporaryDirectory: URL
+        ) {
+            self.s3Client = s3Client
+            self.pendingStore = pendingStore
+            self.backgroundSession = backgroundSession
+            self.manager = manager
+            self.temporaryDirectory = temporaryDirectory
+        }
+
+        /// Kicks off background upload for the given file. Returns once every
+        /// `URLSessionUploadTask` has been registered with the FP manager and
+        /// resumed; completion arrives later via `BackgroundUploadSession`'s
+        /// delegate callbacks.
+        ///
+        /// - Parameters:
+        ///   - s3Item: The file-provider item being uploaded
+        ///   - sourceFileURL: Local file URL of the bytes to upload
+        ///   - drive: The DS3Drive (provides bucket + driveId for store keying)
+        ///   - progress: Caller-supplied Progress; `totalUnitCount` is set to the
+        ///     part count and `completedUnitCount` is incremented as parts are
+        ///     dispatched (not as bytes complete — that lives in the delegate).
+        func startUpload(
+            s3Item: S3Item,
+            sourceFileURL: URL,
+            drive: DS3Drive,
+            progress: Progress
+        ) async throws {
+            let bucket = drive.syncAnchor.bucket.name
+            let key = s3Item.itemIdentifier.rawValue
+            let fileSize = (try? FileManager.default
+                .attributesOfItem(atPath: sourceFileURL.path)[.size] as? Int64) ?? 0
+            let partCount = max(1, Int((fileSize + partSize - 1) / partSize))
+
+            logger.info(
+                """
+                iOS upload start: \(key, privacy: .public) \
+                size=\(fileSize, privacy: .public) parts=\(partCount, privacy: .public)
+                """
+            )
+
+            // 1. Create the multipart upload via Soto (control-plane only).
+            let uploadId = try await s3Client.createMultipartUpload(bucket: bucket, key: key)
+
+            // 2. Persist registration BEFORE dispatching any part — a respawn
+            //    must be able to find the parent upload from a part record.
+            await pendingStore.register(
+                uploadId: uploadId,
+                bucket: bucket,
+                key: key,
+                driveId: drive.id,
+                expectedPartCount: partCount
+            )
+
+            progress.totalUnitCount = Int64(partCount)
+
+            do {
+                try await dispatchParts(
+                    uploadId: uploadId,
+                    bucket: bucket,
+                    key: key,
+                    sourceFileURL: sourceFileURL,
+                    partCount: partCount,
+                    fileSize: fileSize,
+                    s3ItemIdentifier: s3Item.itemIdentifier,
+                    progress: progress
+                )
+            } catch {
+                logger.error(
+                    """
+                    iOS upload dispatch failed for \(key, privacy: .public): \
+                    \(String(describing: error), privacy: .public)
+                    """
+                )
+                // Best-effort abort; reconciler will pick up any leftover state.
+                try? await s3Client.abortMultipartUpload(
+                    bucket: bucket, key: key, uploadId: uploadId
+                )
+                await pendingStore.remove(forKey: key)
+                throw error
+            }
+
+            logger.info(
+                """
+                iOS upload tasks registered: \(key, privacy: .public) \
+                uploadId=\(uploadId, privacy: .public)
+                """
+            )
+        }
+
+        // Splits the source file into part-sized chunk files, presigns each
+        // `UploadPart`, registers the resulting `URLSessionUploadTask` with
+        // `NSFileProviderManager`, and resumes it.
+        // swiftlint:disable:next function_parameter_count
+        private func dispatchParts(
+            uploadId: String,
+            bucket: String,
+            key: String,
+            sourceFileURL: URL,
+            partCount: Int,
+            fileSize: Int64,
+            s3ItemIdentifier: NSFileProviderItemIdentifier,
+            progress: Progress
+        ) async throws {
+            let inputHandle = try FileHandle(forReadingFrom: sourceFileURL)
+            defer { try? inputHandle.close() }
+
+            for partNumber in 1 ... partCount {
+                let offset = UInt64(partNumber - 1) * UInt64(partSize)
+                try inputHandle.seek(toOffset: offset)
+
+                // Last part may be shorter than partSize — that's correct per S3 spec.
+                let remaining = fileSize - Int64(offset)
+                let thisPartSize = Int(min(Int64(partSize), max(0, remaining)))
+                let chunkData = inputHandle.readData(ofLength: thisPartSize)
+
+                // Each part needs a file URL (URLSessionUploadTask cannot upload
+                // from in-memory Data on a background session).
+                let chunkURL = temporaryDirectory
+                    .appendingPathComponent("\(uploadId)-part\(partNumber).bin")
+                if FileManager.default.fileExists(atPath: chunkURL.path) {
+                    try? FileManager.default.removeItem(at: chunkURL)
+                }
+                try chunkData.write(to: chunkURL, options: .atomic)
+
+                // Presign the UploadPart URL via Soto SigV4.
+                let signedRequest = try await s3Client.presignUploadPart(
+                    bucket: bucket,
+                    key: key,
+                    uploadId: uploadId,
+                    partNumber: partNumber,
+                    expiresIn: presignExpiry
+                )
+
+                // Hand the signed PUT to the background URLSession.
+                let task = backgroundSession.session.uploadTask(
+                    with: signedRequest,
+                    fromFile: chunkURL
+                )
+
+                // Persist taskIdentifier → part mapping. The delegate looks
+                // this up to resolve which parent upload a callback belongs to.
+                await pendingStore.recordPartTask(
+                    forKey: key,
+                    partNumber: partNumber,
+                    taskIdentifier: task.taskIdentifier,
+                    tempFileURL: chunkURL
+                )
+
+                // Anchor the FP extension's lifetime to this transfer. Per
+                // Apple's guidance, the system will keep us alive while any
+                // registered task is in flight.
+                try await registerTaskWithManager(task, identifier: s3ItemIdentifier)
+
+                task.resume()
+                progress.completedUnitCount = Int64(partNumber)
+            }
+        }
+
+        private func registerTaskWithManager(
+            _ task: URLSessionUploadTask,
+            identifier: NSFileProviderItemIdentifier
+        ) async throws {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                manager.register(task, forItemWithIdentifier: identifier) { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+    }
+#endif

--- a/DS3DriveProvider/iOS/IOSUploadCoordinator.swift
+++ b/DS3DriveProvider/iOS/IOSUploadCoordinator.swift
@@ -77,8 +77,16 @@
         ) async throws {
             let bucket = drive.syncAnchor.bucket.name
             let key = s3Item.itemIdentifier.rawValue
-            let fileSize = (try? FileManager.default
-                .attributesOfItem(atPath: sourceFileURL.path)[.size] as? Int64) ?? 0
+            // Read size strictly. Falling back to 0 would create an empty
+            // multipart upload with one zero-byte part — a silent corruption.
+            let attrs = try FileManager.default.attributesOfItem(atPath: sourceFileURL.path)
+            guard let fileSize = attrs[.size] as? Int64, fileSize > 0 else {
+                throw NSError(
+                    domain: NSCocoaErrorDomain,
+                    code: NSFileReadUnknownError,
+                    userInfo: [NSLocalizedDescriptionKey: "Cannot read file size for \(key)"]
+                )
+            }
             let partCount = max(1, Int((fileSize + partSize - 1) / partSize))
 
             logger.info(

--- a/DS3DriveProvider/iOS/UploadOrphanCleaner.swift
+++ b/DS3DriveProvider/iOS/UploadOrphanCleaner.swift
@@ -29,7 +29,7 @@
                 let inflight = try await s3Client.listMultipartUploads(
                     bucket: drive.syncAnchor.bucket.name
                 )
-                let known = store.allKnownUploadIds()
+                let known = await store.allKnownUploadIds()
                 for (key, uploadId) in inflight where !known.contains(uploadId) {
                     logger.warning(
                         "Aborting unknown multipart \(uploadId, privacy: .public) for \(key, privacy: .public)"

--- a/DS3DriveProvider/iOS/UploadOrphanCleaner.swift
+++ b/DS3DriveProvider/iOS/UploadOrphanCleaner.swift
@@ -1,0 +1,46 @@
+#if os(iOS)
+    import DS3Lib
+    import Foundation
+    import os.log
+
+    /// Scans for multipart uploads on S3 that are not tracked in PendingUploadStore and aborts them.
+    /// Rate-limited to once per 24 hours via App Group UserDefaults to avoid excessive S3 API calls.
+    @MainActor
+    final class UploadOrphanCleaner {
+        private let logger = Logger(subsystem: "io.cubbit.DS3Drive.provider", category: "orphan-cleanup")
+        private let s3Client: DS3S3Client
+
+        init(s3Client: DS3S3Client) {
+            self.s3Client = s3Client
+        }
+
+        func runIfDue(forDrive drive: DS3Drive, store: PendingUploadStore) async {
+            let udKey = "lastOrphanScan-\(drive.id.uuidString)"
+            let defaults = UserDefaults(suiteName: DefaultSettings.appGroup)
+            let last = defaults?.double(forKey: udKey) ?? 0
+            let now = Date().timeIntervalSince1970
+            guard now - last > 86400 else {
+                logger.debug("Orphan scan skipped — ran within 24h")
+                return
+            }
+            defaults?.set(now, forKey: udKey)
+
+            do {
+                let inflight = try await s3Client.listMultipartUploads(
+                    bucket: drive.syncAnchor.bucket.name
+                )
+                let known = store.allKnownUploadIds()
+                for (key, uploadId) in inflight where !known.contains(uploadId) {
+                    logger.warning(
+                        "Aborting unknown multipart \(uploadId, privacy: .public) for \(key, privacy: .public)"
+                    )
+                    try? await s3Client.abortMultipartUpload(
+                        bucket: drive.syncAnchor.bucket.name, key: key, uploadId: uploadId
+                    )
+                }
+            } catch {
+                logger.error("Orphan scan failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+#endif

--- a/DS3DriveShareExtension/ShareUploadViewModel.swift
+++ b/DS3DriveShareExtension/ShareUploadViewModel.swift
@@ -74,7 +74,7 @@
 
         private(set) var lastUsedDriveId: UUID?
         private var lastUsedFolderPrefix: String?
-        private let appGroupDefaults = UserDefaults(suiteName: "group.X889956QSM.io.cubbit.DS3Drive")
+        private let appGroupDefaults = UserDefaults(suiteName: DefaultSettings.appGroup)
 
         private var uploadTask: Task<Void, Never>?
 
@@ -376,12 +376,24 @@
             if files.allSatisfy({ $0.status == .completed }) {
                 state = .complete
                 logger.info("All \(self.files.count) files uploaded successfully")
+                if let drive = selectedDrive {
+                    await signalFileProvider(for: drive, parentKey: selectedFolderPrefix)
+                }
                 try? await Task.sleep(for: .milliseconds(500))
                 NotificationCenter.default.post(name: .shareExtensionComplete, object: nil)
             } else {
                 state = .partialFailure
                 logger.warning("\(self.failedCount) of \(self.files.count) files failed to upload")
             }
+        }
+
+        /// Signals the File Provider extension to re-enumerate the destination folder.
+        private func signalFileProvider(for drive: DS3Drive, parentKey: String?) async {
+            let ipc = makeDefaultIPCService()
+            await ipc.postCommand(.refreshEnumeration(driveId: drive.id, parentKey: parentKey))
+            logger.notice(
+                "Posted refreshEnumeration IPC for \(drive.name, privacy: .public) parent=\(parentKey ?? "<root>", privacy: .public)"
+            )
         }
 
         // MARK: - Retry

--- a/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
@@ -54,6 +54,8 @@ public enum DefaultSettings {
         public static let lastCoordinatorURL = "io.cubbit.DS3Drive.userDefaults.lastCoordinatorURL"
         public static let autoCheckUpdates = "io.cubbit.DS3Drive.userDefaults.autoCheckUpdates"
         public static let lastUpdateCheck = "io.cubbit.DS3Drive.userDefaults.lastUpdateCheck"
+        /// App Group UserDefaults key for the global cellular-download opt-in for thumbnail generation.
+        public static let thumbnailCellularOptIn = "io.cubbit.DS3Drive.thumbnailCellularOptIn"
     }
 
     /// A unique identifier for the app. It is used to identify the specific app instance when creating API keys.
@@ -159,6 +161,9 @@ public enum DefaultSettings {
 
         /// The name of the file used to store per-drive thumbnail settings.
         public static let thumbnailSettingsFileName = "thumbnailSettings.json"
+
+        /// The name of the file used to store the iOS thumbnail render queue.
+        public static let thumbnailRenderQueueFileName = "thumbnailRenderQueue.json"
     }
 
     /// Group of settings related to the S3 client.

--- a/DS3Lib/Sources/DS3Lib/DS3S3Client+Thumbnails.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3S3Client+Thumbnails.swift
@@ -89,3 +89,32 @@ public extension DS3S3ClientProtocol {
         )
     }
 }
+
+#if os(iOS)
+    public extension DS3S3Client {
+        /// iOS-only: fetches thumbnail bytes via URLSessionDownloadTask (writes to disk,
+        /// then mmap-maps the file) to stay within the extension's 20 MB jetsam ceiling.
+        /// Returns nil on HTTP 404 (cache miss). Throws URLError on other failures so
+        /// callers can map via `mapThumbnailFetchError`.
+        func getThumbnailBytesViaDownloadTask(bucket: String, key: String) async throws -> Data? {
+            let signedURL = try await presignedGetURL(bucket: bucket, key: key, expiresIn: 300)
+            let (tempURL, response) = try await URLSession.shared.download(from: signedURL)
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            guard let http = response as? HTTPURLResponse else {
+                throw URLError(.resourceUnavailable)
+            }
+
+            switch http.statusCode {
+            case 404:
+                return nil
+            case 200 ..< 300:
+                return try autoreleasepool {
+                    try Data(contentsOf: tempURL, options: .alwaysMapped)
+                }
+            default:
+                throw URLError(.resourceUnavailable)
+            }
+        }
+    }
+#endif

--- a/DS3Lib/Sources/DS3Lib/DS3S3Client+Transfers.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3S3Client+Transfers.swift
@@ -252,6 +252,74 @@ public extension DS3S3Client {
         _ = try await s3.abortMultipartUpload(request)
     }
 
+    /// Lists all in-progress multipart uploads for a bucket.
+    /// Used by the iOS reconciler at extension launch to find orphans.
+    /// - Returns: Array of (key, uploadId) pairs for each in-progress upload
+    func listMultipartUploads(bucket: String) async throws -> [(key: String, uploadId: String)] {
+        let request = S3.ListMultipartUploadsRequest(bucket: bucket)
+        let response = try await s3.listMultipartUploads(request)
+        return (response.uploads ?? []).compactMap { upload in
+            guard let key = upload.key, let uploadId = upload.uploadId else { return nil }
+            return (key: key, uploadId: uploadId)
+        }
+    }
+
+    /// Generates a presigned PUT URLRequest for an S3 multipart UploadPart call.
+    ///
+    /// Used exclusively by the iOS background-upload path: the FP extension
+    /// presigns each part via Soto SigV4, then hands the request to a
+    /// `URLSessionUploadTask` for the actual transfer (Soto cannot drive a
+    /// background URLSession — see Soto Discussion #484).
+    ///
+    /// - Parameters:
+    ///   - bucket: The bucket name
+    ///   - key: The S3 object key
+    ///   - uploadId: The multipart upload ID returned by `createMultipartUpload`
+    ///   - partNumber: Sequential part number (1-based, max 10,000)
+    ///   - expiresIn: Seconds until the URL expires; must be in (0, 604800]
+    /// - Returns: A signed `URLRequest` with `httpMethod = "PUT"`
+    /// - Throws: `PresignError.invalidPresignExpiry` for out-of-range expiry,
+    ///           `PresignError.invalidObjectURL` if no custom endpoint is configured
+    func presignUploadPart(
+        bucket: String,
+        key: String,
+        uploadId: String,
+        partNumber: Int,
+        expiresIn: TimeInterval
+    ) async throws -> URLRequest {
+        let expirySeconds = Int64(expiresIn)
+        guard expirySeconds > 0, expirySeconds <= 604_800 else {
+            throw PresignError.invalidPresignExpiry
+        }
+        guard let endpoint = customEndpoint else {
+            throw PresignError.invalidObjectURL
+        }
+
+        // Build path-style URL with required query params.
+        // S3 UploadPart spec: PUT /<bucket>/<key>?partNumber=N&uploadId=ID
+        let baseURL = try Self.buildObjectURL(endpoint: endpoint, bucket: bucket, key: key)
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw PresignError.invalidObjectURL
+        }
+        components.queryItems = [
+            URLQueryItem(name: "partNumber", value: String(partNumber)),
+            URLQueryItem(name: "uploadId", value: uploadId)
+        ]
+        guard let urlWithQuery = components.url else {
+            throw PresignError.invalidObjectURL
+        }
+
+        let signedURL = try await s3.signURL(
+            url: urlWithQuery,
+            httpMethod: .PUT,
+            expires: .seconds(expirySeconds)
+        )
+
+        var request = URLRequest(url: signedURL)
+        request.httpMethod = "PUT"
+        return request
+    }
+
     /// Performs a full multipart upload with concurrent parts, resume via PendingUploadStore, and abort on failure.
     func putObjectMultipart(
         bucket: String,

--- a/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
@@ -227,6 +227,17 @@ public actor PendingUploadStore {
         Set(uploads.values.map(\.uploadId))
     }
 
+    /// All pending uploads whose `expectedPartCount` is known and all parts have
+    /// completed (i.e. `completedPartETags.count == expectedPartCount`).
+    /// Caller is responsible for finalizing (CompleteMultipartUpload) and then
+    /// invoking `remove(forKey:)` so the upload is not re-emitted.
+    public func allCompletedUploads() -> [PendingUpload] {
+        uploads.values.filter { upload in
+            upload.expectedPartCount > 0 &&
+                upload.completedPartETags.count == upload.expectedPartCount
+        }
+    }
+
     // MARK: - Lookup / removal
 
     /// Get the pending upload for a key, if any.

--- a/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
@@ -15,12 +15,16 @@ public actor PendingUploadStore {
         /// ETags keyed by part number for completed parts.
         public var completedPartETags: [Int: String]
         public let createdAt: Date
+        /// Total number of parts expected for this upload. `0` means unknown
+        /// (e.g. legacy entry persisted before this field was introduced).
+        public let expectedPartCount: Int
 
         public init(
             uploadId: String,
             bucket: String,
             key: String,
-            driveId: UUID
+            driveId: UUID,
+            expectedPartCount: Int = 0
         ) {
             self.uploadId = uploadId
             self.bucket = bucket
@@ -28,10 +32,64 @@ public actor PendingUploadStore {
             self.driveId = driveId
             self.completedPartETags = [:]
             self.createdAt = Date()
+            self.expectedPartCount = expectedPartCount
+        }
+
+        /// Custom decoding so legacy on-disk entries without `expectedPartCount`
+        /// still load (decode as 0).
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.uploadId = try container.decode(String.self, forKey: .uploadId)
+            self.bucket = try container.decode(String.self, forKey: .bucket)
+            self.key = try container.decode(String.self, forKey: .key)
+            self.driveId = try container.decode(UUID.self, forKey: .driveId)
+            self.completedPartETags = try container
+                .decodeIfPresent([Int: String].self, forKey: .completedPartETags) ?? [:]
+            self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+            self.expectedPartCount = try container.decodeIfPresent(Int.self, forKey: .expectedPartCount) ?? 0
+        }
+    }
+
+    /// Records a single in-flight URLSessionUploadTask for one part of a multipart upload.
+    /// Indexed by `URLSessionTask.taskIdentifier` so background-session delegate callbacks
+    /// (which receive only the task, not our own state) can resolve which part finished.
+    public struct PartUploadRecord: Codable, Sendable {
+        public let uploadId: String
+        public let key: String
+        public let partNumber: Int
+        public let taskIdentifier: Int
+        public let tempFileURL: URL
+
+        public init(
+            uploadId: String,
+            key: String,
+            partNumber: Int,
+            taskIdentifier: Int,
+            tempFileURL: URL
+        ) {
+            self.uploadId = uploadId
+            self.key = key
+            self.partNumber = partNumber
+            self.taskIdentifier = taskIdentifier
+            self.tempFileURL = tempFileURL
+        }
+    }
+
+    /// On-disk wrapper holding both maps. Separate from `PendingUpload` so future
+    /// fields don't require schema migrations.
+    private struct PersistedState: Codable {
+        var uploads: [String: PendingUpload]
+        var partRecords: [Int: PartUploadRecord]
+
+        init(uploads: [String: PendingUpload] = [:], partRecords: [Int: PartUploadRecord] = [:]) {
+            self.uploads = uploads
+            self.partRecords = partRecords
         }
     }
 
     private var uploads: [String: PendingUpload] = [:]
+    /// Keyed by `URLSessionTask.taskIdentifier`.
+    private var partRecords: [Int: PartUploadRecord] = [:]
     private let fileURL: URL
 
     public init() {
@@ -44,24 +102,132 @@ public actor PendingUploadStore {
                     "App Group container unavailable, pending uploads will use temporary directory and won't survive restarts"
                 )
         }
-        self.fileURL = (containerURL ?? URL(fileURLWithPath: NSTemporaryDirectory()))
+        let url = (containerURL ?? URL(fileURLWithPath: NSTemporaryDirectory()))
             .appendingPathComponent("pendingUploads.json")
-        self.uploads = Self.loadFromDisk(url: self.fileURL)
+        self.fileURL = url
+        let loaded = Self.loadFromDisk(url: url)
+        self.uploads = loaded.uploads
+        self.partRecords = loaded.partRecords
     }
 
-    /// Register a new multipart upload.
-    public func register(uploadId: String, bucket: String, key: String, driveId: UUID) {
-        uploads[key] = PendingUpload(uploadId: uploadId, bucket: bucket, key: key, driveId: driveId)
+    /// Testable initializer that reads/writes a caller-supplied URL instead of the
+    /// App Group container. Used by unit tests; safe to use anywhere a custom path
+    /// is desired.
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+        let loaded = Self.loadFromDisk(url: fileURL)
+        self.uploads = loaded.uploads
+        self.partRecords = loaded.partRecords
+    }
+
+    // MARK: - Upload registration
+
+    /// Register a new multipart upload. The expected part count is used to detect
+    /// when all parts have completed (see `allPartsComplete(forKey:)`).
+    public func register(
+        uploadId: String,
+        bucket: String,
+        key: String,
+        driveId: UUID,
+        expectedPartCount: Int
+    ) {
+        uploads[key] = PendingUpload(
+            uploadId: uploadId,
+            bucket: bucket,
+            key: key,
+            driveId: driveId,
+            expectedPartCount: expectedPartCount
+        )
         saveToDisk()
     }
 
-    /// Record a successfully uploaded part.
+    /// Register a new multipart upload without a known part count.
+    /// Existing callers that don't yet supply an expected count keep working;
+    /// `allPartsComplete(forKey:)` will return `false` for these entries.
+    public func register(uploadId: String, bucket: String, key: String, driveId: UUID) {
+        register(
+            uploadId: uploadId,
+            bucket: bucket,
+            key: key,
+            driveId: driveId,
+            expectedPartCount: 0
+        )
+    }
+
+    // MARK: - Part completion (foreground / explicit)
+
+    /// Record a successfully uploaded part by key + part number.
     public func markPartCompleted(key: String, partNumber: Int, etag: String) {
         guard var upload = uploads[key] else { return }
         upload.completedPartETags[partNumber] = etag
         uploads[key] = upload
         saveToDisk()
     }
+
+    // MARK: - Part task tracking (background URLSession)
+
+    /// Record an in-flight URLSession upload task for a given part of a multipart upload.
+    /// Stored by `taskIdentifier` so a freshly-spawned extension instance can resolve
+    /// `URLSessionTaskDelegate` callbacks back to a specific part.
+    public func recordPartTask(
+        forKey key: String,
+        partNumber: Int,
+        taskIdentifier: Int,
+        tempFileURL: URL
+    ) {
+        guard let upload = uploads[key] else {
+            logger.warning("recordPartTask: no pending upload for key \(key, privacy: .public)")
+            return
+        }
+        partRecords[taskIdentifier] = PartUploadRecord(
+            uploadId: upload.uploadId,
+            key: key,
+            partNumber: partNumber,
+            taskIdentifier: taskIdentifier,
+            tempFileURL: tempFileURL
+        )
+        saveToDisk()
+    }
+
+    /// Look up a part record by URLSession task identifier.
+    public func partRecord(forTaskIdentifier taskIdentifier: Int) -> PartUploadRecord? {
+        partRecords[taskIdentifier]
+    }
+
+    /// Mark a part as completed via its URLSession task identifier.
+    /// Persists the etag to the parent `PendingUpload`, removes the part record,
+    /// and best-effort deletes the temp file backing the upload body.
+    public func markPartCompleted(taskIdentifier: Int, etag: String) {
+        guard let record = partRecords[taskIdentifier] else {
+            logger.warning("markPartCompleted: unknown taskIdentifier \(taskIdentifier)")
+            return
+        }
+        markPartCompleted(key: record.key, partNumber: record.partNumber, etag: etag)
+        partRecords.removeValue(forKey: taskIdentifier)
+        // Best-effort cleanup of the temp file used as the upload body.
+        try? FileManager.default.removeItem(at: record.tempFileURL)
+        saveToDisk()
+    }
+
+    /// Returns `true` when the number of completed part etags matches the expected
+    /// part count. Returns `false` when expected count is unknown (legacy entries).
+    public func allPartsComplete(forKey key: String) -> Bool {
+        guard let upload = uploads[key], upload.expectedPartCount > 0 else { return false }
+        return upload.completedPartETags.count == upload.expectedPartCount
+    }
+
+    /// All in-flight part records across all uploads.
+    public func allPendingPartRecords() -> [PartUploadRecord] {
+        Array(partRecords.values)
+    }
+
+    /// Set of all upload IDs currently tracked. Useful for reconciliation against
+    /// active S3 multipart uploads at startup.
+    public func allKnownUploadIds() -> Set<String> {
+        Set(uploads.values.map(\.uploadId))
+    }
+
+    // MARK: - Lookup / removal
 
     /// Get the pending upload for a key, if any.
     public func pendingUpload(forKey key: String) -> PendingUpload? {
@@ -71,25 +237,40 @@ public actor PendingUploadStore {
     /// Remove the pending upload record (after completion or abort).
     public func remove(forKey key: String) {
         uploads.removeValue(forKey: key)
+        // Drop any part records associated with this key.
+        partRecords = partRecords.filter { $0.value.key != key }
         saveToDisk()
     }
 
     /// Remove all uploads for a drive.
     public func removeAll(forDrive driveId: UUID) {
+        let keysToDrop = Set(uploads.filter { $0.value.driveId == driveId }.map(\.key))
         uploads = uploads.filter { $0.value.driveId != driveId }
+        partRecords = partRecords.filter { !keysToDrop.contains($0.value.key) }
         saveToDisk()
     }
 
     // MARK: - Persistence
 
-    private static func loadFromDisk(url: URL) -> [String: PendingUpload] {
-        guard let data = try? Data(contentsOf: url) else { return [:] }
-        return (try? JSONDecoder().decode([String: PendingUpload].self, from: data)) ?? [:]
+    private static func loadFromDisk(url: URL) -> PersistedState {
+        guard let data = try? Data(contentsOf: url) else { return PersistedState() }
+        let decoder = JSONDecoder()
+        // Preferred (current) shape: wrapped state.
+        if let wrapped = try? decoder.decode(PersistedState.self, from: data) {
+            return wrapped
+        }
+        // Legacy shape: flat [String: PendingUpload]. Migrate forward in-memory;
+        // it'll be persisted in the new shape on the next save.
+        if let flat = try? decoder.decode([String: PendingUpload].self, from: data) {
+            return PersistedState(uploads: flat, partRecords: [:])
+        }
+        return PersistedState()
     }
 
     private func saveToDisk() {
         do {
-            let data = try JSONEncoder().encode(uploads)
+            let state = PersistedState(uploads: uploads, partRecords: partRecords)
+            let data = try JSONEncoder().encode(state)
             try data.write(to: fileURL, options: .atomic)
         } catch {
             logger.error("Failed to persist pending uploads: \(error.localizedDescription)")

--- a/DS3Lib/Sources/DS3Lib/Platform/DarwinNotificationCenter.swift
+++ b/DS3Lib/Sources/DS3Lib/Platform/DarwinNotificationCenter.swift
@@ -125,3 +125,9 @@ private final class Box: @unchecked Sendable {
         self.callback = callback
     }
 }
+
+public extension DarwinNotificationCenter {
+    /// Darwin notification name posted by the extension to wake the main app's
+    /// ForegroundBackfillDriver when a new thumbnail render request is enqueued.
+    static let thumbnailRenderRequest = "io.cubbit.DS3Drive.thumbnailRenderRequest"
+}

--- a/DS3Lib/Sources/DS3Lib/Platform/IPCCommand.swift
+++ b/DS3Lib/Sources/DS3Lib/Platform/IPCCommand.swift
@@ -2,8 +2,13 @@ import Foundation
 
 /// Commands the main app sends to the File Provider extension via IPC.
 public enum IPCCommand: Codable, Sendable, Equatable {
-    /// Request the extension to re-enumerate a specific drive
-    case refreshEnumeration(driveId: UUID)
+    /// Request the extension to re-enumerate a specific drive.
+    /// - Parameters:
+    ///   - driveId: The drive whose enumeration should be refreshed.
+    ///   - parentKey: Optional S3 key of the folder to signal (e.g. "Photos/"). When provided,
+    ///     the extension signals only that folder's container so Files.app refreshes immediately.
+    ///     `nil` triggers a full-drive enumeration (legacy behaviour, default).
+    case refreshEnumeration(driveId: UUID, parentKey: String? = nil)
 
     /// Empty the trash for a specific drive
     case emptyTrash(driveId: UUID)

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
@@ -56,11 +56,21 @@ public actor ThumbnailRenderQueue {
 
     // MARK: - Queue Operations
 
-    /// Appends an item if (driveID, s3Key) is not already present. No-op if duplicate.
+    /// Appends an item if (driveID, s3Key) is not already present. If a duplicate
+    /// exists with `attempts >= maxAttempts` (poisoned), its attempts are reset to
+    /// zero — caller is asking for the item to be processed again, so honor that.
     public func append(_ item: ThumbnailRenderQueueItem) {
         loadIfNeeded()
-        guard !items.contains(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) else {
-            queueLogger.info("Queue.append: duplicate \(item.s3Key, privacy: .public) — skip")
+        if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
+            if items[idx].attempts >= Self.maxAttempts {
+                items[idx].attempts = 0
+                persist()
+                queueLogger.info(
+                    "Queue.append: revived poisoned \(item.s3Key, privacy: .public) — attempts reset"
+                )
+            } else {
+                queueLogger.info("Queue.append: duplicate \(item.s3Key, privacy: .public) — skip")
+            }
             return
         }
         items.append(item)

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
@@ -60,10 +60,14 @@ public actor ThumbnailRenderQueue {
     public func append(_ item: ThumbnailRenderQueueItem) {
         loadIfNeeded()
         guard !items.contains(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) else {
+            queueLogger.info("Queue.append: duplicate \(item.s3Key, privacy: .public) — skip")
             return
         }
         items.append(item)
         persist()
+        queueLogger.info(
+            "Queue.append: \(item.s3Key, privacy: .public) → total=\(self.items.count, privacy: .public) file=\(self.fileURL?.path ?? "nil", privacy: .public)"
+        )
     }
 
     /// Returns up to `maxItems` pending items (attempts < maxAttempts).
@@ -118,7 +122,12 @@ public actor ThumbnailRenderQueue {
     /// the same App Group file. A one-shot load flag would let one process
     /// silently overwrite the other's writes.
     private func loadIfNeeded() {
-        guard let url = fileURL, FileManager.default.fileExists(atPath: url.path) else {
+        guard let url = fileURL else {
+            queueLogger.error("Queue.load: no fileURL (no App Group container?)")
+            items = []
+            return
+        }
+        guard FileManager.default.fileExists(atPath: url.path) else {
             items = []
             return
         }
@@ -127,7 +136,7 @@ public actor ThumbnailRenderQueue {
             items = try JSONDecoder().decode([ThumbnailRenderQueueItem].self, from: data)
         } catch {
             queueLogger.error(
-                "ThumbnailRenderQueue: load failed (\(error.localizedDescription, privacy: .public)) — starting empty"
+                "Queue.load failed (\(error.localizedDescription, privacy: .public)) — file=\(url.path, privacy: .public)"
             )
             items = []
         }

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
@@ -12,7 +12,7 @@ private let queueLogger = Logger(
 public struct ThumbnailRenderQueueItem: Codable, Sendable, Equatable {
     public let driveID: UUID
     public let s3Key: String
-    public let addedAt: Date
+    public var addedAt: Date
     public var attempts: Int
 
     public init(driveID: UUID, s3Key: String, addedAt: Date = Date(), attempts: Int = 0) {
@@ -37,6 +37,12 @@ public actor ThumbnailRenderQueue {
     /// Maximum render attempts before an item is considered poison.
     public static let maxAttempts = 3
 
+    /// Minimum age before a poisoned item can be revived by a new `append` call.
+    /// Prevents thrashing when an item keeps failing for a real reason: each
+    /// burst of cache-misses from Files.app would otherwise reset attempts and
+    /// drain it again, paying the download+render cost on every browse.
+    public static let revivalCooldownSeconds: TimeInterval = 3600
+
     /// Shared singleton backed by the App Group container.
     public static let shared = ThumbnailRenderQueue()
 
@@ -57,13 +63,19 @@ public actor ThumbnailRenderQueue {
     // MARK: - Queue Operations
 
     /// Appends an item if (driveID, s3Key) is not already present. If a duplicate
-    /// exists with `attempts >= maxAttempts` (poisoned), its attempts are reset to
-    /// zero — caller is asking for the item to be processed again, so honor that.
+    /// exists with `attempts >= maxAttempts` (poisoned) AND was added more than
+    /// `revivalCooldownSeconds` ago, its attempts are reset and `addedAt` is
+    /// stamped now — caller asked for it again and enough time has passed that
+    /// transient conditions may have changed. Within cooldown, the duplicate is
+    /// a no-op so a busy folder browse does not thrash known-failing items.
     public func append(_ item: ThumbnailRenderQueueItem) {
         loadIfNeeded()
         if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
-            if items[idx].attempts >= Self.maxAttempts {
+            let existing = items[idx]
+            let age = Date().timeIntervalSince(existing.addedAt)
+            if existing.attempts >= Self.maxAttempts, age >= Self.revivalCooldownSeconds {
                 items[idx].attempts = 0
+                items[idx].addedAt = Date()
                 persist()
                 queueLogger.info(
                     "Queue.append: revived poisoned \(item.s3Key, privacy: .public) — attempts reset"

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
@@ -1,0 +1,143 @@
+import Foundation
+import os.log
+
+private let queueLogger = Logger(
+    subsystem: LogSubsystem.app,
+    category: LogCategory.thumbnail.rawValue
+)
+
+/// Represents one item in the iOS thumbnail render backlog.
+/// The extension appends when it gets a cache miss (or after a new raster upload).
+/// The main app drains by downloading the original, rendering a JPEG, and PUTting to S3.
+public struct ThumbnailRenderQueueItem: Codable, Sendable, Equatable {
+    public let driveID: UUID
+    public let s3Key: String
+    public let addedAt: Date
+    public var attempts: Int
+
+    public init(driveID: UUID, s3Key: String, addedAt: Date = Date(), attempts: Int = 0) {
+        self.driveID = driveID
+        self.s3Key = s3Key
+        self.addedAt = addedAt
+        self.attempts = attempts
+    }
+}
+
+/// JSON-backed persistent queue for iOS thumbnail render requests.
+///
+/// Extension writes via `append`; main app drains via `dequeue`/`complete`/`fail`.
+/// Actor serializes within-process; `.atomic` write makes cross-process writes safe
+/// (extension appends while main app is in background; drain only runs in foreground
+/// so the two processes don't write simultaneously).
+///
+/// Deduplication: `append` is a no-op if (driveID, s3Key) already exists.
+/// Poison: items with `attempts >= maxAttempts` are excluded from `dequeue` results
+/// but remain in the JSON file for inspection.
+public actor ThumbnailRenderQueue {
+    /// Maximum render attempts before an item is considered poison.
+    public static let maxAttempts = 3
+
+    /// Shared singleton backed by the App Group container.
+    public static let shared = ThumbnailRenderQueue()
+
+    private var items: [ThumbnailRenderQueueItem] = []
+    private let fileURL: URL?
+    private var loaded = false
+
+    private init() {
+        fileURL = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: DefaultSettings.appGroup)?
+            .appendingPathComponent(DefaultSettings.FileNames.thumbnailRenderQueueFileName)
+    }
+
+    /// For testing only: backed by the given URL instead of the App Group container.
+    public init(testFileURL: URL) {
+        fileURL = testFileURL
+    }
+
+    // MARK: - Queue Operations
+
+    /// Appends an item if (driveID, s3Key) is not already present. No-op if duplicate.
+    public func append(_ item: ThumbnailRenderQueueItem) {
+        loadIfNeeded()
+        guard !items.contains(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) else {
+            return
+        }
+        items.append(item)
+        persist()
+    }
+
+    /// Returns up to `maxItems` pending items (attempts < maxAttempts).
+    /// Does NOT remove them — call `complete` or `fail` after processing.
+    public func dequeue(maxItems: Int) -> [ThumbnailRenderQueueItem] {
+        loadIfNeeded()
+        return Array(items.filter { $0.attempts < Self.maxAttempts }.prefix(maxItems))
+    }
+
+    /// Removes a successfully processed item from the queue.
+    public func complete(_ item: ThumbnailRenderQueueItem) {
+        loadIfNeeded()
+        items.removeAll { $0.driveID == item.driveID && $0.s3Key == item.s3Key }
+        persist()
+    }
+
+    /// Bumps attempts. Items reaching `maxAttempts` are poisoned (excluded from future dequeues).
+    public func fail(_ item: ThumbnailRenderQueueItem) {
+        loadIfNeeded()
+        if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
+            items[idx].attempts += 1
+        }
+        persist()
+    }
+
+    /// Returns (pending, poison) counts for a specific drive.
+    public func count(driveID: UUID) -> (pending: Int, poison: Int) {
+        loadIfNeeded()
+        let driveItems = items.filter { $0.driveID == driveID }
+        let pending = driveItems.count(where: { $0.attempts < Self.maxAttempts })
+        let poison = driveItems.count(where: { $0.attempts >= Self.maxAttempts })
+        return (pending, poison)
+    }
+
+    /// Removes all items for a drive (Settings "Reset" and drive deletion).
+    public func clearAll(driveID: UUID) {
+        loadIfNeeded()
+        items.removeAll { $0.driveID == driveID }
+        persist()
+    }
+
+    /// Total pending items across all drives.
+    public var pendingCount: Int {
+        loadIfNeeded()
+        return items.count(where: { $0.attempts < Self.maxAttempts })
+    }
+
+    // MARK: - Private
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+        guard let url = fileURL, FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            let data = try Data(contentsOf: url)
+            items = try JSONDecoder().decode([ThumbnailRenderQueueItem].self, from: data)
+        } catch {
+            queueLogger.error(
+                "ThumbnailRenderQueue: load failed (\(error.localizedDescription, privacy: .public)) — starting empty"
+            )
+            items = []
+        }
+    }
+
+    private func persist() {
+        guard let url = fileURL else { return }
+        do {
+            let data = try JSONEncoder().encode(items)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            queueLogger.error(
+                "ThumbnailRenderQueue: persist failed (\(error.localizedDescription, privacy: .public))"
+            )
+        }
+    }
+}

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderQueue.swift
@@ -42,7 +42,6 @@ public actor ThumbnailRenderQueue {
 
     private var items: [ThumbnailRenderQueueItem] = []
     private let fileURL: URL?
-    private var loaded = false
 
     private init() {
         fileURL = FileManager.default
@@ -114,10 +113,15 @@ public actor ThumbnailRenderQueue {
 
     // MARK: - Private
 
+    /// Always reads the latest state from disk before each operation.
+    /// Cross-process consistency: extension appends and main app drains touch
+    /// the same App Group file. A one-shot load flag would let one process
+    /// silently overwrite the other's writes.
     private func loadIfNeeded() {
-        guard !loaded else { return }
-        loaded = true
-        guard let url = fileURL, FileManager.default.fileExists(atPath: url.path) else { return }
+        guard let url = fileURL, FileManager.default.fileExists(atPath: url.path) else {
+            items = []
+            return
+        }
         do {
             let data = try Data(contentsOf: url)
             items = try JSONDecoder().decode([ThumbnailRenderQueueItem].self, from: data)

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
@@ -23,114 +23,107 @@ public enum RenderFailure: String, Error, Sendable, Equatable {
     case jpegEncode
 }
 
-// THUMB-07: whole-type `#if os(macOS)` gate so the iOS extension cannot link
-// ImageIO and blow its 20 MB jetsam budget. Body-level gating leaks the symbol.
-#if os(macOS)
+public struct ThumbnailRenderer {
+    public let maxDimension: CGFloat
+    public let jpegQuality: Float
 
-    public struct ThumbnailRenderer {
-        public let maxDimension: CGFloat
-        public let jpegQuality: Float
-
-        public init(
-            maxDimension: CGFloat = CGFloat(DefaultSettings.S3.thumbnailMaxDimension),
-            jpegQuality: Float = DefaultSettings.S3.thumbnailJPEGQuality
-        ) {
-            self.maxDimension = maxDimension
-            self.jpegQuality = jpegQuality
-        }
-
-        public func renderJPEG(from fileURL: URL) -> Result<Data, RenderFailure> {
-            #if canImport(UIKit)
-                // Dead code under the outer macOS gate; kept as defense-in-depth
-                // in case the gate is ever loosened.
-                let availableMemory = os_proc_available_memory()
-                if availableMemory > 0, availableMemory < Self.minAvailableMemoryBytes {
-                    return .failure(.dataLoad)
-                }
-            #endif
-
-            return autoreleasepool {
-                // Phase 13.1 Finding 2 (D-09): eager Data snapshot replaces the
-                // previous lazy URL-backed image source. The lazy form holds a
-                // reference to the URL and reads bytes on demand during
-                // CGImageSourceCreateThumbnailAtIndex — but FileProvider releases
-                // temp URLs after createItem returns, AND under concurrent decode
-                // pressure the URL-backed lazy reader has been observed to
-                // silently return nil from the thumbnail-create call. Mapping the
-                // bytes once at renderer entry decouples the decode from URL
-                // lifetime and removes the concurrent-pressure failure mode.
-                // `.mappedIfSafe` keeps memory bounded — mmap when the filesystem
-                // supports, eager copy when it does not (e.g., FileProvider's
-                // tempdir on some volumes).
-                let data: Data
-                do {
-                    data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
-                } catch {
-                    return .failure(.dataLoad)
-                }
-
-                let sourceOptions: [CFString: Any] = [
-                    kCGImageSourceShouldCache: false
-                ]
-                guard let source = CGImageSourceCreateWithData(
-                    data as CFData,
-                    sourceOptions as CFDictionary
-                )
-                else { return .failure(.sourceCreate) }
-
-                // Reject RAW, PDF, etc. by UTI (file extension is unreliable).
-                guard let sourceType = CGImageSourceGetType(source),
-                      Self.allowedRasterUTIs.contains(sourceType)
-                else { return .failure(.utiReject) }
-
-                let options: [CFString: Any] = [
-                    kCGImageSourceCreateThumbnailFromImageAlways: true,
-                    kCGImageSourceThumbnailMaxPixelSize: self.maxDimension,
-                    kCGImageSourceCreateThumbnailWithTransform: true, // MANDATORY — EXIF orientation
-                    kCGImageSourceShouldCacheImmediately: true
-                ]
-
-                guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
-                    source, 0, options as CFDictionary
-                )
-                else { return .failure(.thumbnailCreate) }
-
-                guard let bytes = jpegData(from: cgImage) else {
-                    return .failure(.jpegEncode)
-                }
-                return .success(bytes)
-            }
-        }
-
-        private func jpegData(from cgImage: CGImage) -> Data? {
-            let data = NSMutableData()
-            guard let dest = CGImageDestinationCreateWithData(
-                data as CFMutableData,
-                UTType.jpeg.identifier as CFString,
-                1,
-                nil
-            )
-            else { return nil }
-            CGImageDestinationAddImage(
-                dest,
-                cgImage,
-                [kCGImageDestinationLossyCompressionQuality: Double(self.jpegQuality)] as CFDictionary
-            )
-            guard CGImageDestinationFinalize(dest) else { return nil }
-            return data as Data
-        }
-
-        private nonisolated(unsafe) static let allowedRasterUTIs: Set<CFString> = [
-            "public.jpeg" as CFString,
-            "public.png" as CFString,
-            "public.heic" as CFString,
-            "public.heif" as CFString,
-            "org.webmproject.webp" as CFString,
-            "com.compuserve.gif" as CFString,
-            "public.tiff" as CFString
-        ]
-
-        private static let minAvailableMemoryBytes: Int = 64 * 1024 * 1024
+    public init(
+        maxDimension: CGFloat = CGFloat(DefaultSettings.S3.thumbnailMaxDimension),
+        jpegQuality: Float = DefaultSettings.S3.thumbnailJPEGQuality
+    ) {
+        self.maxDimension = maxDimension
+        self.jpegQuality = jpegQuality
     }
 
-#endif
+    public func renderJPEG(from fileURL: URL) -> Result<Data, RenderFailure> {
+        #if canImport(UIKit)
+            // Memory guard for the iOS extension jetsam ceiling.
+            let availableMemory = os_proc_available_memory()
+            if availableMemory > 0, availableMemory < Self.minAvailableMemoryBytes {
+                return .failure(.dataLoad)
+            }
+        #endif
+
+        return autoreleasepool {
+            // Phase 13.1 Finding 2 (D-09): eager Data snapshot replaces the
+            // previous lazy URL-backed image source. The lazy form holds a
+            // reference to the URL and reads bytes on demand during
+            // CGImageSourceCreateThumbnailAtIndex — but FileProvider releases
+            // temp URLs after createItem returns, AND under concurrent decode
+            // pressure the URL-backed lazy reader has been observed to
+            // silently return nil from the thumbnail-create call. Mapping the
+            // bytes once at renderer entry decouples the decode from URL
+            // lifetime and removes the concurrent-pressure failure mode.
+            // `.mappedIfSafe` keeps memory bounded — mmap when the filesystem
+            // supports, eager copy when it does not (e.g., FileProvider's
+            // tempdir on some volumes).
+            let data: Data
+            do {
+                data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+            } catch {
+                return .failure(.dataLoad)
+            }
+
+            let sourceOptions: [CFString: Any] = [
+                kCGImageSourceShouldCache: false
+            ]
+            guard let source = CGImageSourceCreateWithData(
+                data as CFData,
+                sourceOptions as CFDictionary
+            )
+            else { return .failure(.sourceCreate) }
+
+            // Reject RAW, PDF, etc. by UTI (file extension is unreliable).
+            guard let sourceType = CGImageSourceGetType(source),
+                  Self.allowedRasterUTIs.contains(sourceType)
+            else { return .failure(.utiReject) }
+
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceThumbnailMaxPixelSize: self.maxDimension,
+                kCGImageSourceCreateThumbnailWithTransform: true, // MANDATORY — EXIF orientation
+                kCGImageSourceShouldCacheImmediately: true
+            ]
+
+            guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
+                source, 0, options as CFDictionary
+            )
+            else { return .failure(.thumbnailCreate) }
+
+            guard let bytes = jpegData(from: cgImage) else {
+                return .failure(.jpegEncode)
+            }
+            return .success(bytes)
+        }
+    }
+
+    private func jpegData(from cgImage: CGImage) -> Data? {
+        let data = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        )
+        else { return nil }
+        CGImageDestinationAddImage(
+            dest,
+            cgImage,
+            [kCGImageDestinationLossyCompressionQuality: Double(self.jpegQuality)] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(dest) else { return nil }
+        return data as Data
+    }
+
+    private nonisolated(unsafe) static let allowedRasterUTIs: Set<CFString> = [
+        "public.jpeg" as CFString,
+        "public.png" as CFString,
+        "public.heic" as CFString,
+        "public.heif" as CFString,
+        "org.webmproject.webp" as CFString,
+        "com.compuserve.gif" as CFString,
+        "public.tiff" as CFString
+    ]
+
+    private static let minAvailableMemoryBytes: Int = 64 * 1024 * 1024
+}

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
@@ -97,7 +97,41 @@ public struct ThumbnailRenderer {
         }
     }
 
+    /// Strips the alpha channel from `source` by redrawing into an opaque RGB context.
+    ///
+    /// JPEG does not support alpha — passing an RGBA image directly to
+    /// `CGImageDestinationAddImage` produces `AlphaPremulLast` warnings from ImageIO
+    /// and wastes encoder cycles on a channel that is discarded. This helper removes
+    /// alpha before encoding.
+    ///
+    /// If `source` already has no alpha (`alphaInfo` is `.none`, `.noneSkipFirst`, or
+    /// `.noneSkipLast`) the original image is returned unchanged (zero extra allocation).
+    func stripAlpha(from source: CGImage) -> CGImage {
+        let alpha = source.alphaInfo
+        guard alpha != .none,
+              alpha != .noneSkipFirst,
+              alpha != .noneSkipLast
+        else { return source }
+
+        let colorSpace = source.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
+        guard let context = CGContext(
+            data: nil,
+            width: source.width,
+            height: source.height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        )
+        else { return source }
+
+        context.draw(source, in: CGRect(x: 0, y: 0, width: source.width, height: source.height))
+        return context.makeImage() ?? source
+    }
+
     private func jpegData(from cgImage: CGImage) -> Data? {
+        let opaqueImage = stripAlpha(from: cgImage)
         let data = NSMutableData()
         guard let dest = CGImageDestinationCreateWithData(
             data as CFMutableData,
@@ -108,7 +142,7 @@ public struct ThumbnailRenderer {
         else { return nil }
         CGImageDestinationAddImage(
             dest,
-            cgImage,
+            opaqueImage,
             [kCGImageDestinationLossyCompressionQuality: Double(self.jpegQuality)] as CFDictionary
         )
         guard CGImageDestinationFinalize(dest) else { return nil }

--- a/DS3Lib/Tests/DS3LibTests/IPCCommandTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/IPCCommandTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import DS3Lib
+
+final class IPCCommandTests: XCTestCase {
+
+    func test_refreshEnumeration_encodesParentKey() throws {
+        let driveId = UUID()
+        let cmd = IPCCommand.refreshEnumeration(driveId: driveId, parentKey: "Personal/Images/")
+        let data = try JSONEncoder().encode(cmd)
+        let decoded = try JSONDecoder().decode(IPCCommand.self, from: data)
+        guard case .refreshEnumeration(let id, let key) = decoded else {
+            XCTFail("Wrong case after decode"); return
+        }
+        XCTAssertEqual(id, driveId)
+        XCTAssertEqual(key, "Personal/Images/")
+    }
+
+    func test_refreshEnumeration_decodesLegacyPayloadWithoutParentKey() throws {
+        // Backwards compatibility: old Share extension builds may post commands without parentKey
+        let driveId = UUID()
+        let legacyJSON = #"{"refreshEnumeration":{"driveId":"\#(driveId.uuidString)"}}"#
+        let data = legacyJSON.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(IPCCommand.self, from: data)
+        guard case .refreshEnumeration(let id, let key) = decoded else {
+            XCTFail("Wrong case after decode"); return
+        }
+        XCTAssertEqual(id, driveId)
+        XCTAssertNil(key)
+    }
+}

--- a/DS3Lib/Tests/DS3LibTests/PendingUploadStoreTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/PendingUploadStoreTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import DS3Lib
+
+final class PendingUploadStoreBackgroundTests: XCTestCase {
+    var store: PendingUploadStore!
+    let testDriveId = UUID()
+
+    override func setUp() async throws {
+        // Use a temp URL so tests don't pollute App Group storage
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".json")
+        store = PendingUploadStore(fileURL: tempURL)
+    }
+
+    func test_recordPartTask_andRetrieveByTaskId() async throws {
+        await store.register(
+            uploadId: "u1", bucket: "b", key: "k/file.jpg",
+            driveId: testDriveId, expectedPartCount: 2
+        )
+        await store.recordPartTask(
+            forKey: "k/file.jpg", partNumber: 1,
+            taskIdentifier: 42, tempFileURL: URL(fileURLWithPath: "/tmp/p1.bin")
+        )
+        let record = await store.partRecord(forTaskIdentifier: 42)
+        XCTAssertNotNil(record)
+        XCTAssertEqual(record?.partNumber, 1)
+        XCTAssertEqual(record?.uploadId, "u1")
+    }
+
+    func test_markPartCompleted_persistsETag() async throws {
+        await store.register(
+            uploadId: "u2", bucket: "b", key: "k2/file.jpg",
+            driveId: testDriveId, expectedPartCount: 1
+        )
+        await store.recordPartTask(
+            forKey: "k2/file.jpg", partNumber: 1,
+            taskIdentifier: 100, tempFileURL: URL(fileURLWithPath: "/tmp/p1.bin")
+        )
+        await store.markPartCompleted(taskIdentifier: 100, etag: "abc-123")
+        let upload = await store.pendingUpload(forKey: "k2/file.jpg")
+        XCTAssertEqual(upload?.completedPartETags[1], "abc-123")
+    }
+
+    func test_allPartsComplete_trueWhenAllReceived() async throws {
+        await store.register(
+            uploadId: "u3", bucket: "b", key: "k3/file.jpg",
+            driveId: testDriveId, expectedPartCount: 3
+        )
+        for i in 1...3 {
+            await store.recordPartTask(
+                forKey: "k3/file.jpg", partNumber: i,
+                taskIdentifier: i + 200, tempFileURL: URL(fileURLWithPath: "/tmp/\(i).bin")
+            )
+        }
+        let before = await store.allPartsComplete(forKey: "k3/file.jpg")
+        XCTAssertFalse(before)
+        for i in 1...3 {
+            await store.markPartCompleted(taskIdentifier: i + 200, etag: "etag-\(i)")
+        }
+        let after = await store.allPartsComplete(forKey: "k3/file.jpg")
+        XCTAssertTrue(after)
+    }
+
+    func test_legacyDecode_missingExpectedPartCount_decodesCleanly() async throws {
+        // Simulates a PendingUpload JSON from before expectedPartCount was added
+        // It should decode with expectedPartCount == 0 or similar sentinel
+        let driveId = testDriveId
+        let legacyJSON = """
+        {"uploads":{"k4/file.jpg":{"uploadId":"u4","bucket":"b","key":"k4/file.jpg","driveId":"\(driveId.uuidString)","completedPartETags":{}}},"partRecords":{}}
+        """.data(using: .utf8)!
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".json")
+        try legacyJSON.write(to: tempURL)
+        let storeFromDisk = PendingUploadStore(fileURL: tempURL)
+        let upload = await storeFromDisk.pendingUpload(forKey: "k4/file.jpg")
+        XCTAssertNotNil(upload, "Legacy upload should decode without error")
+        XCTAssertEqual(upload?.uploadId, "u4")
+    }
+
+    func test_legacyFlatFormat_decodes() async throws {
+        // The pre-wrapper on-disk format was a flat [String: PendingUpload] dict.
+        // Existing on-disk state must still be readable.
+        let driveId = testDriveId
+        let legacyFlatJSON = """
+        {"k5/file.jpg":{"uploadId":"u5","bucket":"b","key":"k5/file.jpg","driveId":"\(driveId.uuidString)","completedPartETags":{},"createdAt":700000000}}
+        """.data(using: .utf8)!
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".json")
+        try legacyFlatJSON.write(to: tempURL)
+        let storeFromDisk = PendingUploadStore(fileURL: tempURL)
+        let upload = await storeFromDisk.pendingUpload(forKey: "k5/file.jpg")
+        XCTAssertNotNil(upload, "Pre-wrapper flat format must still decode")
+        XCTAssertEqual(upload?.uploadId, "u5")
+        XCTAssertEqual(upload?.expectedPartCount, 0, "Missing field defaults to 0")
+    }
+
+    func test_allPendingPartRecords_returnsAll() async throws {
+        await store.register(
+            uploadId: "u6", bucket: "b", key: "k6/file.jpg",
+            driveId: testDriveId, expectedPartCount: 2
+        )
+        await store.recordPartTask(
+            forKey: "k6/file.jpg", partNumber: 1,
+            taskIdentifier: 600, tempFileURL: URL(fileURLWithPath: "/tmp/p1.bin")
+        )
+        await store.recordPartTask(
+            forKey: "k6/file.jpg", partNumber: 2,
+            taskIdentifier: 601, tempFileURL: URL(fileURLWithPath: "/tmp/p2.bin")
+        )
+        let all = await store.allPendingPartRecords()
+        XCTAssertEqual(all.count, 2)
+        XCTAssertEqual(Set(all.map { $0.taskIdentifier }), Set([600, 601]))
+    }
+
+    func test_allKnownUploadIds_returnsAll() async throws {
+        await store.register(
+            uploadId: "u7a", bucket: "b", key: "k7a", driveId: testDriveId, expectedPartCount: 1
+        )
+        await store.register(
+            uploadId: "u7b", bucket: "b", key: "k7b", driveId: testDriveId, expectedPartCount: 1
+        )
+        let ids = await store.allKnownUploadIds()
+        XCTAssertEqual(ids, Set(["u7a", "u7b"]))
+    }
+}

--- a/DS3Lib/Tests/DS3LibTests/ThumbnailAlphaStrippingTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ThumbnailAlphaStrippingTests.swift
@@ -1,0 +1,52 @@
+import CoreGraphics
+import Foundation
+import XCTest
+
+@testable import DS3Lib
+
+final class ThumbnailAlphaStrippingTests: XCTestCase {
+    func test_stripAlpha_returnsOpaqueImage_whenSourceHasAlpha() throws {
+        let width = 64
+        let height = 64
+        let context = CGContext(
+            data: nil,
+            width: width, height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 0.5))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let rgbaImage = context.makeImage()!
+
+        let renderer = ThumbnailRenderer()
+        let stripped = renderer.stripAlpha(from: rgbaImage)
+        XCTAssertTrue(
+            stripped.alphaInfo == .none ||
+                stripped.alphaInfo == .noneSkipFirst ||
+                stripped.alphaInfo == .noneSkipLast,
+            "Expected no alpha, got \(stripped.alphaInfo.rawValue)"
+        )
+    }
+
+    func test_stripAlpha_returnsOriginal_whenSourceHasNoAlpha() throws {
+        let context = CGContext(
+            data: nil, width: 32, height: 32,
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        )!
+        let opaqueImage = context.makeImage()!
+
+        let renderer = ThumbnailRenderer()
+        let result = renderer.stripAlpha(from: opaqueImage)
+        // Should return the same image (no re-draw needed)
+        XCTAssertEqual(result.width, opaqueImage.width)
+        XCTAssertTrue(
+            result.alphaInfo == .none ||
+                result.alphaInfo == .noneSkipFirst ||
+                result.alphaInfo == .noneSkipLast
+        )
+    }
+}

--- a/DS3Lib/Tests/DS3LibTests/ThumbnailRenderQueueTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ThumbnailRenderQueueTests.swift
@@ -25,27 +25,46 @@ final class ThumbnailRenderQueueTests: XCTestCase {
         XCTAssertEqual(visible.first?.s3Key, "Foo/bar.JPG")
     }
 
-    func testAppendRevivesPoisonedItem() async throws {
+    func testAppendRevivesPoisonedItemAfterCooldown() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("queue-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: url) }
 
         let queue = ThumbnailRenderQueue(testFileURL: url)
         let driveID = UUID()
-        let item = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/poison.JPG")
+        // Stamp `addedAt` more than the cooldown ago so the next append revives.
+        let pastDate = Date(timeIntervalSinceNow: -ThumbnailRenderQueue.revivalCooldownSeconds - 60)
+        let item = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/poison.JPG", addedAt: pastDate)
         await queue.append(item)
-        // Poison it via three failures.
         for _ in 0..<ThumbnailRenderQueue.maxAttempts {
             await queue.fail(item)
         }
         let beforeRevive = await queue.dequeue(maxItems: 10)
-        XCTAssertTrue(beforeRevive.isEmpty, "poisoned item should be excluded from dequeue")
+        XCTAssertTrue(beforeRevive.isEmpty)
 
-        // Caller asks again — append should revive it.
         await queue.append(item)
         let afterRevive = await queue.dequeue(maxItems: 10)
         XCTAssertEqual(afterRevive.count, 1)
         XCTAssertEqual(afterRevive.first?.attempts, 0)
+    }
+
+    func testAppendDoesNotRevivePoisonedItemWithinCooldown() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let queue = ThumbnailRenderQueue(testFileURL: url)
+        let driveID = UUID()
+        // Fresh `addedAt` — within cooldown, revival must be a no-op.
+        let item = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/recent-fail.JPG")
+        await queue.append(item)
+        for _ in 0..<ThumbnailRenderQueue.maxAttempts {
+            await queue.fail(item)
+        }
+
+        await queue.append(item)
+        let dequeued = await queue.dequeue(maxItems: 10)
+        XCTAssertTrue(dequeued.isEmpty, "poisoned item still within cooldown should remain poisoned")
     }
 
     func testCompleteFromOneInstanceVisibleToOther() async throws {

--- a/DS3Lib/Tests/DS3LibTests/ThumbnailRenderQueueTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ThumbnailRenderQueueTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import DS3Lib
+
+final class ThumbnailRenderQueueTests: XCTestCase {
+    func testCrossProcessAppendIsVisibleToSecondInstance() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let producer = ThumbnailRenderQueue(testFileURL: url)
+        let consumer = ThumbnailRenderQueue(testFileURL: url)
+
+        // Consumer warms up its in-memory state with an empty queue.
+        let initial = await consumer.dequeue(maxItems: 10)
+        XCTAssertTrue(initial.isEmpty)
+
+        // Producer (simulating extension) appends.
+        let driveID = UUID()
+        await producer.append(ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/bar.JPG"))
+
+        // Consumer (simulating main app drain) must see the appended item even
+        // though it already loaded once.
+        let visible = await consumer.dequeue(maxItems: 10)
+        XCTAssertEqual(visible.count, 1)
+        XCTAssertEqual(visible.first?.s3Key, "Foo/bar.JPG")
+    }
+
+    func testCompleteFromOneInstanceVisibleToOther() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let a = ThumbnailRenderQueue(testFileURL: url)
+        let b = ThumbnailRenderQueue(testFileURL: url)
+
+        let driveID = UUID()
+        let item = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/baz.JPG")
+        await a.append(item)
+
+        let beforeComplete = await b.dequeue(maxItems: 10)
+        XCTAssertEqual(beforeComplete.count, 1)
+
+        await a.complete(item)
+
+        let afterComplete = await b.dequeue(maxItems: 10)
+        XCTAssertTrue(afterComplete.isEmpty)
+    }
+}

--- a/DS3Lib/Tests/DS3LibTests/ThumbnailRenderQueueTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ThumbnailRenderQueueTests.swift
@@ -25,6 +25,29 @@ final class ThumbnailRenderQueueTests: XCTestCase {
         XCTAssertEqual(visible.first?.s3Key, "Foo/bar.JPG")
     }
 
+    func testAppendRevivesPoisonedItem() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let queue = ThumbnailRenderQueue(testFileURL: url)
+        let driveID = UUID()
+        let item = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/poison.JPG")
+        await queue.append(item)
+        // Poison it via three failures.
+        for _ in 0..<ThumbnailRenderQueue.maxAttempts {
+            await queue.fail(item)
+        }
+        let beforeRevive = await queue.dequeue(maxItems: 10)
+        XCTAssertTrue(beforeRevive.isEmpty, "poisoned item should be excluded from dequeue")
+
+        // Caller asks again — append should revive it.
+        await queue.append(item)
+        let afterRevive = await queue.dequeue(maxItems: 10)
+        XCTAssertEqual(afterRevive.count, 1)
+        XCTAssertEqual(afterRevive.first?.attempts, 0)
+    }
+
     func testCompleteFromOneInstanceVisibleToOther() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("queue-\(UUID().uuidString).json")

--- a/DS3Lib/Tests/DS3LibTests/ThumbnailRendererTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ThumbnailRendererTests.swift
@@ -24,361 +24,355 @@ import XCTest
 /// - **Default init:** `ThumbnailRenderer()` with no args uses the Phase 11
 ///   defaults from `DefaultSettings.S3` and still produces a valid JPEG.
 ///
-/// macOS-only: `ThumbnailRenderer` is wrapped in `#if os(macOS)` at the type
-/// level (see Pitfall 4 in 12-RESEARCH.md). On iOS the type is undeclared, so
-/// these tests would be a compile error there. The `#if os(macOS)` gate on the
-/// test class keeps DS3LibTests buildable on the iOS test platform too.
-#if os(macOS)
-    final class ThumbnailRendererTests: XCTestCase {
-        private let thumbnailSize: CGFloat = 256
+final class ThumbnailRendererTests: XCTestCase {
+    private let thumbnailSize: CGFloat = 256
 
-        // MARK: - Fixture Loading
+    // MARK: - Fixture Loading
 
-        /// Loads a fixture URL from the SPM test bundle. Returns nil if the resource
-        /// is missing (XCTSkip is raised by the caller so a misconfigured Resources
-        /// declaration is surfaced as a skip, not a crash).
-        private func fixtureURL(name: String, ext: String) -> URL? {
-            Bundle.module.url(forResource: name, withExtension: ext)
-        }
+    /// Loads a fixture URL from the SPM test bundle. Returns nil if the resource
+    /// is missing (XCTSkip is raised by the caller so a misconfigured Resources
+    /// declaration is surfaced as a skip, not a crash).
+    private func fixtureURL(name: String, ext: String) -> URL? {
+        Bundle.module.url(forResource: name, withExtension: ext)
+    }
 
-        // MARK: - T-11-04: Format Allow-List
+    // MARK: - T-11-04: Format Allow-List
 
-        /// A PDF file (UTI `com.adobe.pdf`) must be rejected by the raster UTI
-        /// allow-list in `renderJPEG`, even though `CGImageSource` accepts PDFs as
-        /// image sources. Returns nil silently — no throw, no crash.
-        func testRenderJPEGRejectsPDFByUTIAllowList() throws {
-            let pdfURL = try XCTUnwrap(
-                fixtureURL(name: "unsupported", ext: "pdf"),
-                "unsupported.pdf fixture missing — check DS3LibTests resources(.process(\"Fixtures\"))"
-            )
+    /// A PDF file (UTI `com.adobe.pdf`) must be rejected by the raster UTI
+    /// allow-list in `renderJPEG`, even though `CGImageSource` accepts PDFs as
+    /// image sources. Returns nil silently — no throw, no crash.
+    func testRenderJPEGRejectsPDFByUTIAllowList() throws {
+        let pdfURL = try XCTUnwrap(
+            fixtureURL(name: "unsupported", ext: "pdf"),
+            "unsupported.pdf fixture missing — check DS3LibTests resources(.process(\"Fixtures\"))"
+        )
 
-            let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
-            let result = renderer.renderJPEG(from: pdfURL)
+        let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
+        let result = renderer.renderJPEG(from: pdfURL)
 
-            XCTAssertEqual(
-                result, .failure(.utiReject),
-                "PDF (UTI com.adobe.pdf) must be rejected by the raster allow-list"
-            )
-        }
+        XCTAssertEqual(
+            result, .failure(.utiReject),
+            "PDF (UTI com.adobe.pdf) must be rejected by the raster allow-list"
+        )
+    }
 
-        // MARK: - T-11-05: Autoreleasepool / Memory Discipline
+    // MARK: - T-11-05: Autoreleasepool / Memory Discipline
 
-        /// Surrogate "doesn't regress" guard for the autoreleasepool wrap + no-cache
-        /// source options: 50 sequential decodes on a small PNG must all succeed and
-        /// complete in reasonable wall-clock. If autoreleasepool were removed and
-        /// ImageIO buffers leaked, a process-level allocator would still probably
-        /// let this pass — the real value is that broken flag combinations (e.g.
-        /// `kCGImageSourceShouldCache: true` on a large source) typically manifest
-        /// as either slowdowns or decode failures visible to this test.
-        func testRenderJPEGRepeatedInvocationsReturnNonNil() throws {
-            let pngURL = try XCTUnwrap(
-                fixtureURL(name: "large-test", ext: "png"),
-                "large-test.png fixture missing"
-            )
+    /// Surrogate "doesn't regress" guard for the autoreleasepool wrap + no-cache
+    /// source options: 50 sequential decodes on a small PNG must all succeed and
+    /// complete in reasonable wall-clock. If autoreleasepool were removed and
+    /// ImageIO buffers leaked, a process-level allocator would still probably
+    /// let this pass — the real value is that broken flag combinations (e.g.
+    /// `kCGImageSourceShouldCache: true` on a large source) typically manifest
+    /// as either slowdowns or decode failures visible to this test.
+    func testRenderJPEGRepeatedInvocationsReturnNonNil() throws {
+        let pngURL = try XCTUnwrap(
+            fixtureURL(name: "large-test", ext: "png"),
+            "large-test.png fixture missing"
+        )
 
-            let iterations = 50
-            let startedAt = Date()
-            let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
+        let iterations = 50
+        let startedAt = Date()
+        let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
 
-            for index in 0 ..< iterations {
-                let result = renderer.renderJPEG(from: pngURL)
-                guard case .success = result else {
-                    XCTFail("iteration \(index): expected .success, got \(result)")
-                    return
-                }
-            }
-
-            let elapsed = Date().timeIntervalSince(startedAt)
-            // 50 small PNG decodes should finish well under 5 seconds on any CI runner.
-            // Generous ceiling — we only want to catch catastrophic regressions.
-            XCTAssertLessThan(
-                elapsed, 5.0,
-                "\(iterations) repeated decodes took \(elapsed)s — suspect memory pressure or missing allow-list"
-            )
-        }
-
-        // MARK: - EXIF Orientation Preservation
-
-        /// `kCGImageSourceCreateThumbnailWithTransform: true` must be honored — a
-        /// landscape-pixel JPEG carrying EXIF orientation 6 (which instructs readers
-        /// to rotate 90° CW) is rendered as a portrait bitmap.
-        ///
-        /// Shipped fixtures `exif6-portrait.jpg` and `exif6-portrait.heic` were
-        /// generated via `sips` which does NOT inject EXIF orientation. We synthesize
-        /// an EXIF-6 landscape JPEG on the fly so the test meaningfully distinguishes
-        /// "transform applied" from "transform dropped".
-        func testRenderJPEGAppliesEXIF6RotationToPortraitOutput() throws {
-            let sourceURL = try makeEXIF6LandscapeJPEG(width: 200, height: 100)
-            defer { try? FileManager.default.removeItem(at: sourceURL) }
-
-            let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
-            let renderResult = renderer.renderJPEG(from: sourceURL)
-            guard case .success(let thumbnailData) = renderResult else {
-                XCTFail("expected .success, got \(renderResult)")
-                return
-            }
-
-            // Decode the generated JPEG and inspect its pixel geometry.
-            let decodedSource = try XCTUnwrap(
-                CGImageSourceCreateWithData(thumbnailData as CFData, nil),
-                "generated thumbnail bytes are not a valid image source"
-            )
-            let decodedImage = try XCTUnwrap(
-                CGImageSourceCreateImageAtIndex(decodedSource, 0, nil),
-                "could not decode generated thumbnail"
-            )
-
-            // A landscape source with EXIF orientation 6 must be written out as a
-            // portrait bitmap when the transform flag is honored. If transform is
-            // dropped, the output pixel geometry stays landscape.
-            XCTAssertGreaterThan(
-                decodedImage.height, decodedImage.width,
-                "EXIF-6 transform was not applied — got \(decodedImage.width)x\(decodedImage.height), expected portrait (h > w)"
-            )
-        }
-
-        // MARK: - Default Init Smoke Test
-
-        /// `ThumbnailRenderer()` (no args) must use `DefaultSettings.S3.thumbnailMaxDimension`
-        /// and `DefaultSettings.S3.thumbnailJPEGQuality`. Smoke-test against the PNG
-        /// fixture to confirm the default code path produces a valid JPEG.
-        func testRenderJPEGDefaultInitProducesValidJPEG() throws {
-            let pngURL = try XCTUnwrap(
-                fixtureURL(name: "large-test", ext: "png"),
-                "large-test.png fixture missing"
-            )
-
-            let renderer = ThumbnailRenderer()
-            let renderResult = renderer.renderJPEG(from: pngURL)
-            guard case .success(let thumbnailData) = renderResult else {
-                XCTFail("default renderer must produce a non-nil thumbnail, got \(renderResult)")
-                return
-            }
-
-            // Confirm we got a JPEG (not just any bytes).
-            let decodedSource = try XCTUnwrap(
-                CGImageSourceCreateWithData(thumbnailData as CFData, nil),
-                "default renderer output is not a valid image source"
-            )
-            XCTAssertEqual(
-                CGImageSourceGetType(decodedSource) as String?,
-                UTType.jpeg.identifier,
-                "default renderer must emit a JPEG"
-            )
-            XCTAssertEqual(
-                renderer.maxDimension,
-                CGFloat(DefaultSettings.S3.thumbnailMaxDimension),
-                "default maxDimension must match DefaultSettings.S3.thumbnailMaxDimension"
-            )
-            XCTAssertEqual(
-                renderer.jpegQuality,
-                DefaultSettings.S3.thumbnailJPEGQuality,
-                "default jpegQuality must match DefaultSettings.S3.thumbnailJPEGQuality"
-            )
-        }
-
-        // MARK: - Phase 13.1 Finding 2 regression suite (D-11)
-
-        /// Bulk-paste fanout: 8 concurrent renderJPEG calls on the same fixture
-        /// within a tight time window. Pins the 2026-04-27 15:14:35 audit
-        /// symptom (6/8 nil under bulk-paste pressure).
-        func testRenderJPEGSurvivesBulkPasteFanout() async throws {
-            let pngURL = try XCTUnwrap(
-                fixtureURL(name: "large-test", ext: "png"),
-                "large-test.png fixture missing"
-            )
-            // Capture only `Sendable` values into the task-group closures —
-            // `ThumbnailRenderer` is a value type but isn't declared `Sendable`,
-            // so we instantiate it inside each task. Strict concurrency safe.
-            let dimension = thumbnailSize
-            let tempDir = FileManager.default.temporaryDirectory
-
-            // 8 concurrent renders on DISTINCT file copies — matches the audit's
-            // bulk-paste scenario where 8 different files are rendered in parallel.
-            // Reading the same URL from multiple tasks would mask URL/page-cache
-            // contention bugs that only surface across distinct backing files.
-            let results = await withTaskGroup(
-                of: Result<Data, RenderFailure>.self,
-                returning: [Result<Data, RenderFailure>].self
-            ) { group in
-                for _ in 0..<8 {
-                    group.addTask {
-                        let copy = tempDir.appendingPathComponent("fanout-\(UUID().uuidString).png")
-                        try? FileManager.default.copyItem(at: pngURL, to: copy)
-                        defer { try? FileManager.default.removeItem(at: copy) }
-                        let renderer = ThumbnailRenderer(maxDimension: dimension)
-                        return renderer.renderJPEG(from: copy)
-                    }
-                }
-                var collected: [Result<Data, RenderFailure>] = []
-                for await result in group { collected.append(result) }
-                return collected
-            }
-
-            XCTAssertEqual(results.count, 8)
-            let successCount = results.filter { if case .success = $0 { return true } else { return false } }.count
-            XCTAssertEqual(
-                successCount, 8,
-                "All 8 concurrent renders must succeed (audit baseline: 2/8 — should be 8/8 after Finding 2 fix)"
-            )
-        }
-
-        /// Re-render of identical bytes after a delay. Pins the audit symptom
-        /// where IMG_0015.HEIC succeeded at 15:06:41 but failed at 15:10:13
-        /// despite identical ETag (8cb65f96791c2ce30cb315044f4a0c7b).
-        func testRenderJPEGSucceedsOnRepeatedDecodesOfIdenticalBytes() async throws {
-            let heicURL = try XCTUnwrap(
-                fixtureURL(name: "exif6-portrait", ext: "heic"),
-                "exif6-portrait.heic fixture missing"
-            )
-            let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
-
-            let firstResult = renderer.renderJPEG(from: heicURL)
-            guard case .success = firstResult else {
-                XCTFail("First render of HEIC must succeed, got \(firstResult)")
-                return
-            }
-
-            // 200ms delay simulates the user re-paste timing in the audit.
-            try await Task.sleep(for: .milliseconds(200))
-
-            let secondResult = renderer.renderJPEG(from: heicURL)
-            guard case .success = secondResult else {
-                XCTFail(
-                    "Second render of identical HEIC bytes must succeed (audit symptom: nil on repeat), got \(secondResult)"
-                )
-                return
-            }
-        }
-
-        /// Backfill path: renderer reads from a renderer-owned temp file that the
-        /// coordinator allocated and copied into. Pins the audit's 15:19:03
-        /// backfill-failure on Cubbit retreat photo where the URL came NOT from
-        /// FileProvider but from the coordinator's tempfile API.
-        func testRenderJPEGSucceedsForCoordinatorOwnedTempFile() async throws {
-            let pngURL = try XCTUnwrap(
-                fixtureURL(name: "large-test", ext: "png"),
-                "large-test.png fixture missing"
-            )
-            // Copy fixture to a fresh temp file the way the coordinator would.
-            let tempDir = FileManager.default.temporaryDirectory
-            let tempURL = tempDir.appendingPathComponent(
-                "phase13-1-finding2-\(UUID().uuidString).png"
-            )
-            try FileManager.default.copyItem(at: pngURL, to: tempURL)
-            defer { try? FileManager.default.removeItem(at: tempURL) }
-
-            let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
-            let result = renderer.renderJPEG(from: tempURL)
-
+        for index in 0 ..< iterations {
+            let result = renderer.renderJPEG(from: pngURL)
             guard case .success = result else {
-                XCTFail(
-                    "Render from coordinator-owned temp file must succeed (audit symptom: nil on backfill path), got \(result)"
-                )
+                XCTFail("iteration \(index): expected .success, got \(result)")
                 return
             }
         }
 
-        // MARK: - RenderFailure Sub-reason Coverage (#141 Task 1)
+        let elapsed = Date().timeIntervalSince(startedAt)
+        // 50 small PNG decodes should finish well under 5 seconds on any CI runner.
+        // Generous ceiling — we only want to catch catastrophic regressions.
+        XCTAssertLessThan(
+            elapsed, 5.0,
+            "\(iterations) repeated decodes took \(elapsed)s — suspect memory pressure or missing allow-list"
+        )
+    }
 
-        /// Missing file → `Data(contentsOf:.mappedIfSafe)` throws → `.dataLoad`.
-        func testRenderJPEGReturnsDataLoadFailureForMissingFile() {
-            let missing = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString).jpg")
-            let result = ThumbnailRenderer().renderJPEG(from: missing)
-            XCTAssertEqual(result, .failure(.dataLoad))
+    // MARK: - EXIF Orientation Preservation
+
+    /// `kCGImageSourceCreateThumbnailWithTransform: true` must be honored — a
+    /// landscape-pixel JPEG carrying EXIF orientation 6 (which instructs readers
+    /// to rotate 90° CW) is rendered as a portrait bitmap.
+    ///
+    /// Shipped fixtures `exif6-portrait.jpg` and `exif6-portrait.heic` were
+    /// generated via `sips` which does NOT inject EXIF orientation. We synthesize
+    /// an EXIF-6 landscape JPEG on the fly so the test meaningfully distinguishes
+    /// "transform applied" from "transform dropped".
+    func testRenderJPEGAppliesEXIF6RotationToPortraitOutput() throws {
+        let sourceURL = try makeEXIF6LandscapeJPEG(width: 200, height: 100)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
+        let renderResult = renderer.renderJPEG(from: sourceURL)
+        guard case .success(let thumbnailData) = renderResult else {
+            XCTFail("expected .success, got \(renderResult)")
+            return
         }
 
-        /// Garbage bytes whose UTI cannot be sniffed → `.utiReject`.
-        ///
-        /// (`.sourceCreate` is left uncovered here because in practice
-        /// `CGImageSourceCreateWithData` is extremely permissive — it
-        /// returns a non-nil source even for empty / random CFData and
-        /// fails later at the `GetType` step, surfacing as `.utiReject`.
-        /// The PDF allow-list test exercises the same code path with a
-        /// real image source, and the missing-file test pins `.dataLoad`.)
-        func testRenderJPEGReturnsUTIRejectForGarbageBytes() throws {
-            let url = FileManager.default.temporaryDirectory.appendingPathComponent(
-                "garbage-\(UUID().uuidString).bin"
-            )
-            let garbage = Data(repeating: 0xFF, count: 1024)
-            try garbage.write(to: url)
-            defer { try? FileManager.default.removeItem(at: url) }
-            let result = ThumbnailRenderer().renderJPEG(from: url)
-            XCTAssertEqual(result, .failure(.utiReject))
+        // Decode the generated JPEG and inspect its pixel geometry.
+        let decodedSource = try XCTUnwrap(
+            CGImageSourceCreateWithData(thumbnailData as CFData, nil),
+            "generated thumbnail bytes are not a valid image source"
+        )
+        let decodedImage = try XCTUnwrap(
+            CGImageSourceCreateImageAtIndex(decodedSource, 0, nil),
+            "could not decode generated thumbnail"
+        )
+
+        // A landscape source with EXIF orientation 6 must be written out as a
+        // portrait bitmap when the transform flag is honored. If transform is
+        // dropped, the output pixel geometry stays landscape.
+        XCTAssertGreaterThan(
+            decodedImage.height, decodedImage.width,
+            "EXIF-6 transform was not applied — got \(decodedImage.width)x\(decodedImage.height), expected portrait (h > w)"
+        )
+    }
+
+    // MARK: - Default Init Smoke Test
+
+    /// `ThumbnailRenderer()` (no args) must use `DefaultSettings.S3.thumbnailMaxDimension`
+    /// and `DefaultSettings.S3.thumbnailJPEGQuality`. Smoke-test against the PNG
+    /// fixture to confirm the default code path produces a valid JPEG.
+    func testRenderJPEGDefaultInitProducesValidJPEG() throws {
+        let pngURL = try XCTUnwrap(
+            fixtureURL(name: "large-test", ext: "png"),
+            "large-test.png fixture missing"
+        )
+
+        let renderer = ThumbnailRenderer()
+        let renderResult = renderer.renderJPEG(from: pngURL)
+        guard case .success(let thumbnailData) = renderResult else {
+            XCTFail("default renderer must produce a non-nil thumbnail, got \(renderResult)")
+            return
         }
 
-        // MARK: - EXIF-6 Fixture Synthesis
+        // Confirm we got a JPEG (not just any bytes).
+        let decodedSource = try XCTUnwrap(
+            CGImageSourceCreateWithData(thumbnailData as CFData, nil),
+            "default renderer output is not a valid image source"
+        )
+        XCTAssertEqual(
+            CGImageSourceGetType(decodedSource) as String?,
+            UTType.jpeg.identifier,
+            "default renderer must emit a JPEG"
+        )
+        XCTAssertEqual(
+            renderer.maxDimension,
+            CGFloat(DefaultSettings.S3.thumbnailMaxDimension),
+            "default maxDimension must match DefaultSettings.S3.thumbnailMaxDimension"
+        )
+        XCTAssertEqual(
+            renderer.jpegQuality,
+            DefaultSettings.S3.thumbnailJPEGQuality,
+            "default jpegQuality must match DefaultSettings.S3.thumbnailJPEGQuality"
+        )
+    }
 
-        /// Writes a landscape JPEG with EXIF orientation 6 (value 6 = "rotate 90° CW
-        /// to display upright") to a temporary URL and returns that URL. Caller is
-        /// responsible for cleanup.
-        private func makeEXIF6LandscapeJPEG(width: Int, height: Int) throws -> URL {
-            precondition(width > height, "fixture must be landscape in raw pixels")
+    // MARK: - Phase 13.1 Finding 2 regression suite (D-11)
 
-            let colorSpace = CGColorSpaceCreateDeviceRGB()
-            let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
-            guard let context = CGContext(
-                data: nil,
-                width: width,
-                height: height,
-                bitsPerComponent: 8,
-                bytesPerRow: 0,
-                space: colorSpace,
-                bitmapInfo: bitmapInfo
+    /// Bulk-paste fanout: 8 concurrent renderJPEG calls on the same fixture
+    /// within a tight time window. Pins the 2026-04-27 15:14:35 audit
+    /// symptom (6/8 nil under bulk-paste pressure).
+    func testRenderJPEGSurvivesBulkPasteFanout() async throws {
+        let pngURL = try XCTUnwrap(
+            fixtureURL(name: "large-test", ext: "png"),
+            "large-test.png fixture missing"
+        )
+        // Capture only `Sendable` values into the task-group closures —
+        // `ThumbnailRenderer` is a value type but isn't declared `Sendable`,
+        // so we instantiate it inside each task. Strict concurrency safe.
+        let dimension = thumbnailSize
+        let tempDir = FileManager.default.temporaryDirectory
+
+        // 8 concurrent renders on DISTINCT file copies — matches the audit's
+        // bulk-paste scenario where 8 different files are rendered in parallel.
+        // Reading the same URL from multiple tasks would mask URL/page-cache
+        // contention bugs that only surface across distinct backing files.
+        let results = await withTaskGroup(
+            of: Result<Data, RenderFailure>.self,
+            returning: [Result<Data, RenderFailure>].self
+        ) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    let copy = tempDir.appendingPathComponent("fanout-\(UUID().uuidString).png")
+                    try? FileManager.default.copyItem(at: pngURL, to: copy)
+                    defer { try? FileManager.default.removeItem(at: copy) }
+                    let renderer = ThumbnailRenderer(maxDimension: dimension)
+                    return renderer.renderJPEG(from: copy)
+                }
+            }
+            var collected: [Result<Data, RenderFailure>] = []
+            for await result in group { collected.append(result) }
+            return collected
+        }
+
+        XCTAssertEqual(results.count, 8)
+        let successCount = results.filter { if case .success = $0 { return true } else { return false } }.count
+        XCTAssertEqual(
+            successCount, 8,
+            "All 8 concurrent renders must succeed (audit baseline: 2/8 — should be 8/8 after Finding 2 fix)"
+        )
+    }
+
+    /// Re-render of identical bytes after a delay. Pins the audit symptom
+    /// where IMG_0015.HEIC succeeded at 15:06:41 but failed at 15:10:13
+    /// despite identical ETag (8cb65f96791c2ce30cb315044f4a0c7b).
+    func testRenderJPEGSucceedsOnRepeatedDecodesOfIdenticalBytes() async throws {
+        let heicURL = try XCTUnwrap(
+            fixtureURL(name: "exif6-portrait", ext: "heic"),
+            "exif6-portrait.heic fixture missing"
+        )
+        let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
+
+        let firstResult = renderer.renderJPEG(from: heicURL)
+        guard case .success = firstResult else {
+            XCTFail("First render of HEIC must succeed, got \(firstResult)")
+            return
+        }
+
+        // 200ms delay simulates the user re-paste timing in the audit.
+        try await Task.sleep(for: .milliseconds(200))
+
+        let secondResult = renderer.renderJPEG(from: heicURL)
+        guard case .success = secondResult else {
+            XCTFail(
+                "Second render of identical HEIC bytes must succeed (audit symptom: nil on repeat), got \(secondResult)"
             )
-            else {
-                throw NSError(
-                    domain: "ThumbnailRendererTests", code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "failed to create bitmap context"]
-                )
-            }
-
-            // Fill with a solid color; actual pixels don't matter for the geometry
-            // assertion, only the declared dimensions.
-            context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.9, alpha: 1.0))
-            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
-
-            guard let cgImage = context.makeImage() else {
-                throw NSError(
-                    domain: "ThumbnailRendererTests", code: 2,
-                    userInfo: [NSLocalizedDescriptionKey: "failed to render bitmap"]
-                )
-            }
-
-            let tempURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent("exif6-landscape-\(UUID().uuidString).jpg")
-
-            guard let destination = CGImageDestinationCreateWithURL(
-                tempURL as CFURL, UTType.jpeg.identifier as CFString, 1, nil
-            )
-            else {
-                throw NSError(
-                    domain: "ThumbnailRendererTests", code: 3,
-                    userInfo: [NSLocalizedDescriptionKey: "failed to create JPEG destination"]
-                )
-            }
-
-            // EXIF orientation 6: rotate 90° CW when displaying. Stored under both
-            // the top-level kCGImagePropertyOrientation (Core Graphics convention,
-            // honored by CGImageSourceCreateThumbnailAtIndex with the transform flag)
-            // and the TIFF dictionary (what on-disk readers consult). Writing both
-            // matches how real-world EXIF-carrying files look.
-            let properties: [CFString: Any] = [
-                kCGImagePropertyOrientation: 6,
-                kCGImagePropertyTIFFDictionary: [
-                    kCGImagePropertyTIFFOrientation: 6
-                ]
-            ]
-
-            CGImageDestinationAddImage(destination, cgImage, properties as CFDictionary)
-            guard CGImageDestinationFinalize(destination) else {
-                throw NSError(
-                    domain: "ThumbnailRendererTests", code: 4,
-                    userInfo: [NSLocalizedDescriptionKey: "failed to finalize JPEG"]
-                )
-            }
-
-            return tempURL
+            return
         }
     }
-#endif
+
+    /// Backfill path: renderer reads from a renderer-owned temp file that the
+    /// coordinator allocated and copied into. Pins the audit's 15:19:03
+    /// backfill-failure on Cubbit retreat photo where the URL came NOT from
+    /// FileProvider but from the coordinator's tempfile API.
+    func testRenderJPEGSucceedsForCoordinatorOwnedTempFile() async throws {
+        let pngURL = try XCTUnwrap(
+            fixtureURL(name: "large-test", ext: "png"),
+            "large-test.png fixture missing"
+        )
+        // Copy fixture to a fresh temp file the way the coordinator would.
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempURL = tempDir.appendingPathComponent(
+            "phase13-1-finding2-\(UUID().uuidString).png"
+        )
+        try FileManager.default.copyItem(at: pngURL, to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let renderer = ThumbnailRenderer(maxDimension: thumbnailSize)
+        let result = renderer.renderJPEG(from: tempURL)
+
+        guard case .success = result else {
+            XCTFail(
+                "Render from coordinator-owned temp file must succeed (audit symptom: nil on backfill path), got \(result)"
+            )
+            return
+        }
+    }
+
+    // MARK: - RenderFailure Sub-reason Coverage (#141 Task 1)
+
+    /// Missing file → `Data(contentsOf:.mappedIfSafe)` throws → `.dataLoad`.
+    func testRenderJPEGReturnsDataLoadFailureForMissingFile() {
+        let missing = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString).jpg")
+        let result = ThumbnailRenderer().renderJPEG(from: missing)
+        XCTAssertEqual(result, .failure(.dataLoad))
+    }
+
+    /// Garbage bytes whose UTI cannot be sniffed → `.utiReject`.
+    ///
+    /// (`.sourceCreate` is left uncovered here because in practice
+    /// `CGImageSourceCreateWithData` is extremely permissive — it
+    /// returns a non-nil source even for empty / random CFData and
+    /// fails later at the `GetType` step, surfacing as `.utiReject`.
+    /// The PDF allow-list test exercises the same code path with a
+    /// real image source, and the missing-file test pins `.dataLoad`.)
+    func testRenderJPEGReturnsUTIRejectForGarbageBytes() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "garbage-\(UUID().uuidString).bin"
+        )
+        let garbage = Data(repeating: 0xFF, count: 1024)
+        try garbage.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let result = ThumbnailRenderer().renderJPEG(from: url)
+        XCTAssertEqual(result, .failure(.utiReject))
+    }
+
+    // MARK: - EXIF-6 Fixture Synthesis
+
+    /// Writes a landscape JPEG with EXIF orientation 6 (value 6 = "rotate 90° CW
+    /// to display upright") to a temporary URL and returns that URL. Caller is
+    /// responsible for cleanup.
+    private func makeEXIF6LandscapeJPEG(width: Int, height: Int) throws -> URL {
+        precondition(width > height, "fixture must be landscape in raw pixels")
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        )
+        else {
+            throw NSError(
+                domain: "ThumbnailRendererTests", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "failed to create bitmap context"]
+            )
+        }
+
+        // Fill with a solid color; actual pixels don't matter for the geometry
+        // assertion, only the declared dimensions.
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.9, alpha: 1.0))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        guard let cgImage = context.makeImage() else {
+            throw NSError(
+                domain: "ThumbnailRendererTests", code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "failed to render bitmap"]
+            )
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("exif6-landscape-\(UUID().uuidString).jpg")
+
+        guard let destination = CGImageDestinationCreateWithURL(
+            tempURL as CFURL, UTType.jpeg.identifier as CFString, 1, nil
+        )
+        else {
+            throw NSError(
+                domain: "ThumbnailRendererTests", code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "failed to create JPEG destination"]
+            )
+        }
+
+        // EXIF orientation 6: rotate 90° CW when displaying. Stored under both
+        // the top-level kCGImagePropertyOrientation (Core Graphics convention,
+        // honored by CGImageSourceCreateThumbnailAtIndex with the transform flag)
+        // and the TIFF dictionary (what on-disk readers consult). Writing both
+        // matches how real-world EXIF-carrying files look.
+        let properties: [CFString: Any] = [
+            kCGImagePropertyOrientation: 6,
+            kCGImagePropertyTIFFDictionary: [
+                kCGImagePropertyTIFFOrientation: 6
+            ]
+        ]
+
+        CGImageDestinationAddImage(destination, cgImage, properties as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            throw NSError(
+                domain: "ThumbnailRendererTests", code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "failed to finalize JPEG"]
+            )
+        }
+
+        return tempURL
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two iOS production bugs verified on physical iPhone, plus follow-ups uncovered during testing.

### Bug 1 — File Provider extension upload death-loop (FIXED)
Soto v6 used a foreground `URLSession`, which dies with the extension. iOS reaped `fileprovider-nonui` aggressively after `createItem` returned its `Progress`. Same `uploadId` re-resumed forever; files never completed on S3.

**Architecture:** iOS uploads now execute in `nsurlsessiond` via `URLSession.background` configured with `sharedContainerIdentifier`. Soto remains for SigV4 presigning + control-plane (CreateMP/CompleteMP/AbortMP); data transfer uses `URLSessionUploadTask` registered via `NSFileProviderManager.register(_:forItemWithIdentifier:)`. Multipart state persisted in `PendingUploadStore` (App Group container).

### Bug 2 — Main app SIGKILL during thumbnail backfill (FIXED)
`ForegroundBackfillDriver.renderOne` used in-memory GET, peaking 2× file size per image. New `DS3Client` per image spawned fresh NIO event loops. `IOSurface creation failed: e00002c2` exhausted compositor address space.

**Fixes:** stream downloads to disk, cache one `DS3Client` per drive, strip alpha before JPEG encode, render in `Task.detached(priority: .utility) + autoreleasepool`. `BGProcessingTask` drains queue when backgrounded.

### Files.app folder visibility (FIXED)
Share extension uploads now appear in Files.app within ~2s. The `refreshEnumeration` IPC carries `parentKey`; the FP extension lists S3 for that prefix, updates `MetadataStore`, then signals both `.workingSet` and the parent container.

## Key implementation choices

- **`NSFileProviderManager.register` is load-bearing** — anchors extension lifetime to upload tasks
- **Cross-process queue:** `loadIfNeeded` always re-reads disk so extension appends and main-app drains stay in sync
- **Synchronous `await` for queue appends** in extension paths — fire-and-forget `Task.detached(.background)` was being killed by extension reap before the disk write landed
- **Proactive enqueue:** after refresh, list `.thumbnails/` prefixes once and enqueue any raster item missing its sidecar
- **Poison revival cooldown (1h):** items that genuinely fail no longer cycle on every Files.app browse
- **Cancellation safety:** `CancellationError` from `scenePhase → .background` does not increment failure attempts
- **Cold-launch drain:** `.onChange(of: scenePhase, initial: true)` + login-completion kick

## macOS

`#if os(iOS)` boundaries everywhere; macOS upload/render path untouched. DS3Lib stays OS-agnostic.

## Tests

- 541 DS3Lib tests pass
- iOS + macOS Xcode builds green
- New tests: cross-process queue sync, poison revival with cooldown, alpha stripping, `PendingUploadStore` part records

## Production verification (physical iPhone)

- Bug 1: 8 concurrent uploads, 0 zombies, no respawn loop, ≤7 MB peak
- Bug 2: 9-photo backfill rendered, no SIGKILL
- Share extension: file in Files.app in ~2s
- Thumbnail E2E: upload → enqueue → drain → render → sidecar → Files.app cache hit → display

## Test plan

- [x] iOS large upload via Files.app (>5MB) — completes on S3, no death-loop
- [x] iOS small upload (<5MB) — single-shot path works
- [x] Share extension upload — visible in Files.app within 2s
- [x] Thumbnail backfill 50+ photos — no SIGKILL, all sidecars on S3
- [x] BGProcessingTask via lldb simulation
- [x] macOS regression: upload, download, rename, delete on Mac
- [x] 30-min sustained activity — `aws s3api list-multipart-uploads` empty

## Follow-up issues (deferred, tracked)

Surfaced during code review and Copilot triage. Each has rationale + suggested fix in its issue body.

- #149 — `BackgroundUploadSession.abortUploadForTask` should also clean up part record + sibling tasks + S3 multipart (orphan cleaner already covers it on next init)
- #150 — `BackgroundUploadSession.finalizingKeys` is in-memory only; double `CompleteMultipartUpload` after extension reap is currently absorbed by S3 idempotency
- #151 — `ThumbnailRenderer.stripAlpha` hardcodes `bitsPerComponent: 8`, fidelity loss for 16-bit sources
- #152 — `ThumbnailRenderQueue` cross-process append/complete race window (narrow; would need `flock` or merge-on-write to fully close)
- #153 — Files.app per-item thumbnail cache not invalidated for items rendered after their first enumeration; needs `WorkingSetEnumerator.enumerateChanges` to surface them
- #154 — DS3Lib portability audit: iOS-only types should be `#if os(iOS)`-gated to keep DS3Lib OS-agnostic
- #155 — Backfill `putThumbnail` writes empty `x-amz-meta-source-etag`; should HEAD original or omit field
