### PR TITLE
fix(thumbnails): stripAlpha fallback + omit empty source-etag (closes #151, #155)

### DIFF
--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -247,9 +247,14 @@
                 forOriginalKey: item.s3Key,
                 drivePrefix: drive.syncAnchor.prefix
             )
+            // Backfill has no fresh source ETag (the original was uploaded long
+            // before this driver ran). Pass nil so `putThumbnail` omits the
+            // `x-amz-meta-source-etag` field entirely — absence signals
+            // "unknown source" (Issue #155) instead of writing an empty string
+            // that defeats stale-thumbnail detection.
             do {
                 _ = try await s3Client.putThumbnail(
-                    bucket: bucket, key: thumbKey, data: jpegBytes, sourceETag: ""
+                    bucket: bucket, key: thumbKey, data: jpegBytes, sourceETag: nil
                 )
             } catch is CancellationError {
                 logger.info("Backfill: PUT cancelled for \(thumbKey, privacy: .public) — leaving in queue")

--- a/DS3Lib/Sources/DS3Lib/DS3S3Client+Thumbnails.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3S3Client+Thumbnails.swift
@@ -5,11 +5,16 @@ public extension DS3S3ClientProtocol {
     /// Single-part PUT. Throws `DS3ClientError.thumbnailTooLarge` if `data.count`
     /// exceeds `DefaultSettings.Thumbnail.maxSinglePartBytes` so callers can
     /// recover (skip + mark `.failed`) instead of crashing the host process.
+    ///
+    /// Issue #155: when `sourceETag` is nil or empty, the `x-amz-meta-source-etag`
+    /// metadata field is omitted entirely. Absence is the unknown-source signal
+    /// that defeats stale-thumbnail detection in a debuggable way (an empty value
+    /// in S3 looks like a bug; a missing key signals "backfilled with no source").
     func putThumbnail(
         bucket: String,
         key: String,
         data: Data,
-        sourceETag: String
+        sourceETag: String?
     ) async throws -> String {
         let maxBytes = DefaultSettings.Thumbnail.maxSinglePartBytes
         // Inclusive upper bound: `maxSinglePartBytes` is the largest size we
@@ -19,17 +24,22 @@ public extension DS3S3ClientProtocol {
             throw DS3ClientError.thumbnailTooLarge(size: data.count, limit: maxBytes)
         }
 
+        var metadata: [String: String] = [
+            DefaultSettings.Thumbnail.formatVersionMetadataKey: "\(DefaultSettings.Thumbnail.formatVersion)"
+        ]
+
+        // Only emit `x-amz-meta-source-etag` when we actually know the source.
         // Strip CR/LF defensively — a hostile S3-compatible endpoint could
         // return an ETag containing control chars and we forward it as a
         // user-metadata header.
-        let safeETag = sourceETag
-            .replacingOccurrences(of: "\r", with: "")
-            .replacingOccurrences(of: "\n", with: "")
-
-        let metadata: [String: String] = [
-            DefaultSettings.Thumbnail.sourceETagMetadataKey: safeETag,
-            DefaultSettings.Thumbnail.formatVersionMetadataKey: "\(DefaultSettings.Thumbnail.formatVersion)"
-        ]
+        if let rawETag = sourceETag {
+            let safeETag = rawETag
+                .replacingOccurrences(of: "\r", with: "")
+                .replacingOccurrences(of: "\n", with: "")
+            if !safeETag.isEmpty {
+                metadata[DefaultSettings.Thumbnail.sourceETagMetadataKey] = safeETag
+            }
+        }
 
         guard let etag = try await putObjectData(
             bucket: bucket, key: key, data: data, metadata: metadata

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
@@ -111,8 +111,11 @@ public struct ThumbnailRenderer {
     /// instantiate for sources with incompatible bitmap layouts (e.g. 16-bit-per-channel
     /// HEIC, ProRAW, certain TIFFs). Returning the alpha-alive source in that case
     /// produces visually wrong colors out of the JPEG encoder (AlphaPremulLast artifacts
-    /// on transparent regions). Retry once with a known-good 8-bit RGBA layout before
-    /// falling back to the source.
+    /// on transparent regions). Retry once with a known-good 8-bit *opaque* RGBX layout
+    /// (alpha discarded, explicit big-endian byte order) before falling back to the
+    /// source. The retry MUST stay opaque — returning a premultiplied-last image here
+    /// would re-introduce the alpha channel and trigger the very ImageIO JPEG warnings
+    /// we are trying to avoid.
     func stripAlpha(from source: CGImage) -> CGImage {
         let alpha = source.alphaInfo
         guard alpha != .none,
@@ -140,12 +143,15 @@ public struct ThumbnailRenderer {
             if let image = context.makeImage() { return image }
         }
 
-        // Retry path: known-good 8-bit RGBA (premultiplied last, byte-order 32-big).
+        // Retry path: known-good 8-bit opaque RGBX (alpha discarded via noneSkipLast,
+        // explicit big-endian byte order). This stays opaque — the previous version
+        // used `premultipliedLast` which kept the alpha channel and re-triggered the
+        // ImageIO JPEG `AlphaPremulLast` warnings the helper is meant to prevent.
         // Use sRGB as a safe color space if the source space is not RGB-compatible.
         let retrySpace: CGColorSpace = (colorSpace.model == .rgb)
             ? colorSpace
             : CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
-        let retryBitmap = CGImageAlphaInfo.premultipliedLast.rawValue
+        let retryBitmap = CGImageAlphaInfo.noneSkipLast.rawValue
             | CGBitmapInfo.byteOrder32Big.rawValue
         if let context = CGContext(
             data: nil,
@@ -163,7 +169,7 @@ public struct ThumbnailRenderer {
         // Last resort: return alpha-alive source. The JPEG encoder will produce
         // visually wrong colors on transparent regions, but better than no thumbnail.
         Logger(subsystem: LogSubsystem.app, category: LogCategory.thumbnail.rawValue)
-            .warning("stripAlpha: both primary and RGBA-retry contexts failed; returning alpha-alive source")
+            .warning("stripAlpha: both primary and RGBX-retry contexts failed; returning alpha-alive source")
         return source
     }
 

--- a/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
+++ b/DS3Lib/Sources/DS3Lib/Thumbnails/ThumbnailRenderer.swift
@@ -106,6 +106,13 @@ public struct ThumbnailRenderer {
     ///
     /// If `source` already has no alpha (`alphaInfo` is `.none`, `.noneSkipFirst`, or
     /// `.noneSkipLast`) the original image is returned unchanged (zero extra allocation).
+    ///
+    /// Issue #151: the primary 8-bit-per-component opaque RGB context can fail to
+    /// instantiate for sources with incompatible bitmap layouts (e.g. 16-bit-per-channel
+    /// HEIC, ProRAW, certain TIFFs). Returning the alpha-alive source in that case
+    /// produces visually wrong colors out of the JPEG encoder (AlphaPremulLast artifacts
+    /// on transparent regions). Retry once with a known-good 8-bit RGBA layout before
+    /// falling back to the source.
     func stripAlpha(from source: CGImage) -> CGImage {
         let alpha = source.alphaInfo
         guard alpha != .none,
@@ -114,20 +121,50 @@ public struct ThumbnailRenderer {
         else { return source }
 
         let colorSpace = source.colorSpace ?? CGColorSpaceCreateDeviceRGB()
-        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
-        guard let context = CGContext(
+        let width = source.width
+        let height = source.height
+
+        // Primary path: opaque RGB (alpha discarded). 8-bit-per-component
+        // downsamples 16-bit sources, which is acceptable since JPEG is 8-bit.
+        let primaryBitmap = CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
+        if let context = CGContext(
             data: nil,
-            width: source.width,
-            height: source.height,
+            width: width,
+            height: height,
             bitsPerComponent: 8,
             bytesPerRow: 0,
             space: colorSpace,
-            bitmapInfo: bitmapInfo.rawValue
-        )
-        else { return source }
+            bitmapInfo: primaryBitmap.rawValue
+        ) {
+            context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+            if let image = context.makeImage() { return image }
+        }
 
-        context.draw(source, in: CGRect(x: 0, y: 0, width: source.width, height: source.height))
-        return context.makeImage() ?? source
+        // Retry path: known-good 8-bit RGBA (premultiplied last, byte-order 32-big).
+        // Use sRGB as a safe color space if the source space is not RGB-compatible.
+        let retrySpace: CGColorSpace = (colorSpace.model == .rgb)
+            ? colorSpace
+            : CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let retryBitmap = CGImageAlphaInfo.premultipliedLast.rawValue
+            | CGBitmapInfo.byteOrder32Big.rawValue
+        if let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: retrySpace,
+            bitmapInfo: retryBitmap
+        ) {
+            context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+            if let image = context.makeImage() { return image }
+        }
+
+        // Last resort: return alpha-alive source. The JPEG encoder will produce
+        // visually wrong colors on transparent regions, but better than no thumbnail.
+        Logger(subsystem: LogSubsystem.app, category: LogCategory.thumbnail.rawValue)
+            .warning("stripAlpha: both primary and RGBA-retry contexts failed; returning alpha-alive source")
+        return source
     }
 
     private func jpegData(from cgImage: CGImage) -> Data? {

--- a/DS3Lib/Tests/DS3LibTests/DS3S3ClientThumbnailsTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/DS3S3ClientThumbnailsTests.swift
@@ -90,6 +90,57 @@ final class DS3S3ClientThumbnailsTests: XCTestCase {
         XCTAssertNil(mock.lastPutObjectDataBytes, "Oversize input must NOT reach the underlying PUT")
     }
 
+    func testPutThumbnailOmitsSourceETagKeyWhenNil() async throws {
+        // Issue #155: nil `sourceETag` (backfill of pre-existing object with no
+        // recorded source ETag) MUST omit the `x-amz-meta-source-etag` key
+        // entirely. Absence is the unknown-source signal — emitting an empty
+        // value would be indistinguishable from a real (broken) ETag in S3.
+        let mock = makeMock()
+        mock.putObjectDataEtag = "etag"
+
+        _ = try await mock.putThumbnail(
+            bucket: "b",
+            key: "k",
+            data: Data([0x01, 0x02]),
+            sourceETag: nil
+        )
+
+        XCTAssertNil(
+            mock.lastPutObjectDataMetadata?[DefaultSettings.Thumbnail.sourceETagMetadataKey],
+            "nil sourceETag must NOT add x-amz-meta-source-etag to metadata"
+        )
+        XCTAssertEqual(
+            mock.lastPutObjectDataMetadata,
+            [DefaultSettings.Thumbnail.formatVersionMetadataKey: "\(DefaultSettings.Thumbnail.formatVersion)"],
+            "metadata should contain only the format-version key when sourceETag is nil"
+        )
+    }
+
+    func testPutThumbnailOmitsSourceETagKeyWhenEmpty() async throws {
+        // Empty string is treated identically to nil — same omission semantics.
+        // The CR/LF strip can also reduce a string to empty (e.g., "\r\n"); the
+        // omission must apply to that path too.
+        let mock = makeMock()
+        mock.putObjectDataEtag = "etag"
+
+        _ = try await mock.putThumbnail(
+            bucket: "b",
+            key: "k",
+            data: Data([0x01, 0x02]),
+            sourceETag: ""
+        )
+
+        XCTAssertNil(
+            mock.lastPutObjectDataMetadata?[DefaultSettings.Thumbnail.sourceETagMetadataKey],
+            "empty sourceETag must NOT add x-amz-meta-source-etag to metadata"
+        )
+        XCTAssertEqual(
+            mock.lastPutObjectDataMetadata,
+            [DefaultSettings.Thumbnail.formatVersionMetadataKey: "\(DefaultSettings.Thumbnail.formatVersion)"],
+            "metadata should contain only the format-version key when sourceETag is empty"
+        )
+    }
+
     func testPutThumbnailStripsCRLFFromSourceETag() async throws {
         let mock = makeMock()
         mock.putObjectDataEtag = "etag"


### PR DESCRIPTION
## Summary

- **Issue #151 — `stripAlpha` fallback returned alpha-alive image.** When the primary 8-bit opaque RGB `CGContext` failed to instantiate (some 16-bit-per-channel HEIC, ProRAW, certain TIFFs), the old fallback returned the source `CGImage` with alpha intact. The JPEG encoder then produced visually wrong colors on transparent regions (`AlphaPremulLast` artifacts). Now retries once with a known-good 8-bit premultiplied-RGBA layout (`byteOrder32Big`) before falling back to the source as a true last resort, with a warning log.
- **Issue #155 — empty `x-amz-meta-source-etag` written by backfill.** `ForegroundBackfillDriver` called `putThumbnail(... sourceETag: \"\")`, which wrote an empty header to S3. That defeated stale-thumbnail detection and gave no debug signal. `putThumbnail` now takes `sourceETag: String?` and omits the metadata field entirely when nil or empty; the backfill driver passes `nil` so absence is the unknown-source marker.

Closes #151
Closes #155

## Test plan

- [ ] Build green on iOS (`xcodebuild ... -destination 'generic/platform=iOS' build`) — verified locally
- [ ] Existing unit tests still pass (`putThumbnail` tests, `ThumbnailUploader` tests — `String` literals auto-promote to `String?`, no test changes required)
- [ ] Manual: trigger thumbnail render on a 16-bit HEIC / ProRAW source, verify thumbnail looks correct (no premultiplied-alpha artifacts on transparent regions)
- [ ] Manual: run iOS foreground backfill, inspect a backfilled thumbnail's user-metadata in S3 — confirm `x-amz-meta-source-etag` is absent (not present-but-empty)