### PR TITLE
fix(ios): upload state cleanup (closes #149, #150)

### DIFF
--- a/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
+++ b/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
@@ -33,6 +33,14 @@
                 pendingStore: store,
                 onAllPartsComplete: { [weak self] upload in
                     await self?.finalizeMultipartCompletion(upload)
+                },
+                onAbortMultipartUpload: { [weak self] upload in
+                    guard let s3Client = self?.s3Client else { return }
+                    try? await s3Client.abortMultipartUpload(
+                        bucket: upload.bucket,
+                        key: upload.key,
+                        uploadId: upload.uploadId
+                    )
                 }
             )
             self.backgroundUploadSession = session
@@ -114,12 +122,16 @@
         }
 
         /// Aborts any multipart uploads whose part records reference URLSession task
-        /// IDs that are no longer in flight. Run once at extension startup.
+        /// IDs that are no longer in flight, and reconciles `isCompleting` state
+        /// against S3 so a finalizer interrupted mid-`CompleteMultipartUpload` can
+        /// be retried. Run once at extension startup.
         @MainActor
         func cleanupOrphanedMultiparts() async {
             guard let store = self.pendingUploadStore,
                   let session = self.backgroundUploadSession
             else { return }
+
+            await reconcileCompletingUploads(store: store)
 
             let allRecords = await store.allPendingPartRecords()
             guard !allRecords.isEmpty else { return }
@@ -147,6 +159,55 @@
                     )
                 }
                 await store.remove(forKey: upload.key)
+            }
+        }
+
+        /// Walks pending uploads marked `isCompleting`. If S3 still lists the
+        /// multipart upload, the previous finalizer attempt did not reach
+        /// `CompleteMultipartUpload`; clear the flag so the next "all parts
+        /// complete" trigger can retry. Otherwise the upload completed and we
+        /// just need to drop the now-stale record.
+        @MainActor
+        private func reconcileCompletingUploads(store: PendingUploadStore) async {
+            let candidates = await store.allCompletedUploads()
+                .filter(\.isCompleting)
+            guard !candidates.isEmpty, let s3Client = self.s3Client else { return }
+
+            // Group by bucket so we issue one ListMultipartUploads per bucket.
+            let byBucket = Dictionary(grouping: candidates, by: \.bucket)
+            for (bucket, uploads) in byBucket {
+                let inflight: Set<String>
+                do {
+                    let entries = try await s3Client.listMultipartUploads(bucket: bucket)
+                    inflight = Set(entries.map(\.uploadId))
+                } catch {
+                    logger.error(
+                        """
+                        listMultipartUploads failed for \(bucket, privacy: .public): \
+                        \(error.localizedDescription, privacy: .public)
+                        """
+                    )
+                    continue
+                }
+                for upload in uploads {
+                    if inflight.contains(upload.uploadId) {
+                        logger.warning(
+                            """
+                            Resuming finalize for \(upload.key, privacy: .public) — \
+                            multipart still live on S3
+                            """
+                        )
+                        await store.clearCompleting(forKey: upload.key)
+                    } else {
+                        logger.info(
+                            """
+                            Dropping stale isCompleting record for \
+                            \(upload.key, privacy: .public) — multipart no longer on S3
+                            """
+                        )
+                        await store.remove(forKey: upload.key)
+                    }
+                }
             }
         }
 

--- a/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
+++ b/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
@@ -101,19 +101,10 @@
                     parts: parts
                 )
                 await store.remove(forKey: upload.key)
-                let parentKey = parentKeyForS3Key(upload.key)
-                signalChanges(andParent: parentKey)
+                await applyPostMultipartCompletionSideEffects(upload)
                 logger.info(
                     "Background multipart complete: \(upload.key, privacy: .public)"
                 )
-                if S3PathUtils.isRasterExtension((upload.key as NSString).pathExtension) {
-                    await ThumbnailRenderQueue.shared.append(
-                        ThumbnailRenderQueueItem(driveID: upload.driveId, s3Key: upload.key)
-                    )
-                    DarwinNotificationCenter.shared.post(
-                        name: DarwinNotificationCenter.thumbnailRenderRequest
-                    )
-                }
             } catch {
                 logger.error(
                     """
@@ -125,6 +116,27 @@
                     bucket: upload.bucket, key: upload.key, uploadId: upload.uploadId
                 )
                 await store.remove(forKey: upload.key)
+            }
+        }
+
+        /// Local-only post-completion side effects: signal the parent enumerator
+        /// and enqueue a thumbnail render if appropriate. Extracted so the
+        /// reconciler can replay these when it discovers an upload that already
+        /// finished server-side but never ran the local steps (extension
+        /// reaped between `CompleteMultipartUpload` and these calls).
+        @MainActor
+        private func applyPostMultipartCompletionSideEffects(
+            _ upload: PendingUploadStore.PendingUpload
+        ) async {
+            let parentKey = parentKeyForS3Key(upload.key)
+            signalChanges(andParent: parentKey)
+            if S3PathUtils.isRasterExtension((upload.key as NSString).pathExtension) {
+                await ThumbnailRenderQueue.shared.append(
+                    ThumbnailRenderQueueItem(driveID: upload.driveId, s3Key: upload.key)
+                )
+                DarwinNotificationCenter.shared.post(
+                    name: DarwinNotificationCenter.thumbnailRenderRequest
+                )
             }
         }
 
@@ -206,12 +218,20 @@
                         )
                         await store.clearCompleting(forKey: upload.key)
                     } else {
+                        // Multipart is no longer in flight on S3 → previous
+                        // attempt reached `CompleteMultipartUpload` (or S3
+                        // garbage-collected the upload). Replay local-only
+                        // post-completion side effects in case the previous
+                        // finalizer was reaped between S3 success and the
+                        // local steps. Idempotent: signalling and thumbnail
+                        // enqueue are safe to re-run.
                         logger.info(
                             """
-                            Dropping stale isCompleting record for \
+                            Replaying post-completion side effects for \
                             \(upload.key, privacy: .public) — multipart no longer on S3
                             """
                         )
+                        await applyPostMultipartCompletionSideEffects(upload)
                         await store.remove(forKey: upload.key)
                     }
                 }

--- a/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
+++ b/DS3DriveProvider/FileProviderExtension+IOSUpload.swift
@@ -35,12 +35,19 @@
                     await self?.finalizeMultipartCompletion(upload)
                 },
                 onAbortMultipartUpload: { [weak self] upload in
-                    guard let s3Client = self?.s3Client else { return }
-                    try? await s3Client.abortMultipartUpload(
-                        bucket: upload.bucket,
-                        key: upload.key,
-                        uploadId: upload.uploadId
-                    )
+                    guard let s3Client = self?.s3Client else { return false }
+                    do {
+                        try await s3Client.abortMultipartUpload(
+                            bucket: upload.bucket,
+                            key: upload.key,
+                            uploadId: upload.uploadId
+                        )
+                        return true
+                    } catch {
+                        // Surfaced to BackgroundUploadSession so it keeps the
+                        // pending record for startup retry instead of leaking.
+                        return false
+                    }
                 }
             )
             self.backgroundUploadSession = session

--- a/DS3DriveProvider/iOS/BackgroundUploadSession.swift
+++ b/DS3DriveProvider/iOS/BackgroundUploadSession.swift
@@ -35,12 +35,13 @@
         private let pendingStore: PendingUploadStore
         private let onAllPartsComplete:
             @Sendable (PendingUploadStore.PendingUpload) async -> Void
+        private let onAbortMultipartUpload:
+            @Sendable (PendingUploadStore.PendingUpload) async -> Void
 
         /// Keys of uploads we've already dispatched to `onAllPartsComplete`. Guards
-        /// against the case where two parts of the same upload finish almost
-        /// simultaneously — both delegate callbacks would observe the same
-        /// "all parts complete" snapshot before the finalizer has had a chance to
-        /// call `pendingStore.remove(forKey:)`.
+        /// against two parts of the same upload finishing almost simultaneously
+        /// inside a single extension lifetime. The persisted `isCompleting` flag
+        /// on `PendingUpload` covers the cross-respawn case.
         private var finalizingKeys: Set<String> = []
 
         /// Lazily constructed background session. Background sessions cannot be
@@ -66,10 +67,13 @@
         init(
             pendingStore: PendingUploadStore,
             onAllPartsComplete:
+            @escaping @Sendable (PendingUploadStore.PendingUpload) async -> Void,
+            onAbortMultipartUpload:
             @escaping @Sendable (PendingUploadStore.PendingUpload) async -> Void
         ) {
             self.pendingStore = pendingStore
             self.onAllPartsComplete = onAllPartsComplete
+            self.onAbortMultipartUpload = onAbortMultipartUpload
         }
     }
 
@@ -158,9 +162,19 @@
             let completed = await pendingStore.allCompletedUploads()
             for upload in completed {
                 guard !finalizingKeys.contains(upload.key) else {
-                    // Another delegate callback is already finalizing this upload
-                    // (or has just finalized it but `remove(forKey:)` hasn't yet
-                    // settled). Skip to avoid double-finalization.
+                    // Another delegate callback in this extension lifetime is
+                    // already finalizing this upload. Skip to avoid double-fire.
+                    continue
+                }
+                // Persisted guard against re-entry from a respawned extension.
+                // `markCompleting` returns false if the flag was already set.
+                guard await pendingStore.markCompleting(forKey: upload.key) else {
+                    logger.info(
+                        """
+                        Skipping finalize for \(upload.key, privacy: .public) — \
+                        already marked completing (likely respawn)
+                        """
+                    )
                     continue
                 }
                 finalizingKeys.insert(upload.key)
@@ -170,25 +184,56 @@
 
                 let key = upload.key
                 let handler = onAllPartsComplete
-                // Dispatch finalization on a Task so the delegate queue stays
-                // responsive. The finalizer is responsible for calling
-                // `pendingStore.remove(forKey:)` on success/failure, after which
-                // the upload will not appear in `allCompletedUploads()` again.
+                // Re-fetch with isCompleting=true so the finalizer sees the
+                // persisted flag if it inspects state on disk.
+                let snapshot = await pendingStore.pendingUpload(forKey: key) ?? upload
                 Task { @MainActor [weak self] in
-                    await handler(upload)
+                    await handler(snapshot)
                     self?.finalizingKeys.remove(key)
                 }
             }
         }
 
+        /// Best-effort cleanup when a single part task fails. Removes the part
+        /// record and chunk file, cancels sibling part tasks for the same
+        /// multipart upload, asks the host to issue `AbortMultipartUpload` against
+        /// S3, and finally drops the parent pending record.
         private func abortUploadForTask(_ taskId: Int) async {
             guard
                 let record = await pendingStore.partRecord(forTaskIdentifier: taskId)
             else { return }
-            // Best-effort cleanup of the temp chunk file. The S3-level multipart
-            // upload abort is owned by the orphan reconciler invoked at extension
-            // init time (see Lifecycle).
-            try? FileManager.default.removeItem(at: record.tempFileURL)
+            let key = record.key
+
+            // 1. Drop the failing part record + temp file.
+            await pendingStore.markPartFailed(taskIdentifier: taskId)
+
+            // 2. Cancel every sibling URLSessionTask for the same upload key,
+            //    then drop their part records too.
+            let siblings = await pendingStore.partRecords(forKey: key)
+            let siblingTaskIds = Set(siblings.map(\.taskIdentifier))
+            if !siblingTaskIds.isEmpty {
+                let liveTasks = await session.allTasks
+                for task in liveTasks where siblingTaskIds.contains(task.taskIdentifier) {
+                    task.cancel()
+                }
+                for sibling in siblings {
+                    await pendingStore.markPartFailed(taskIdentifier: sibling.taskIdentifier)
+                }
+            }
+
+            // 3. Ask the host to abort the multipart upload on S3 (best effort).
+            //    Then drop the parent record so the orphan reconciler has nothing
+            //    to do.
+            if let upload = await pendingStore.pendingUpload(forKey: key) {
+                logger.warning(
+                    """
+                    Aborting multipart upload for \(key, privacy: .public) \
+                    uploadId=\(upload.uploadId, privacy: .public)
+                    """
+                )
+                await onAbortMultipartUpload(upload)
+                await pendingStore.remove(forKey: key)
+            }
         }
     }
 #endif

--- a/DS3DriveProvider/iOS/BackgroundUploadSession.swift
+++ b/DS3DriveProvider/iOS/BackgroundUploadSession.swift
@@ -35,14 +35,24 @@
         private let pendingStore: PendingUploadStore
         private let onAllPartsComplete:
             @Sendable (PendingUploadStore.PendingUpload) async -> Void
+        /// Returns `true` when the host-issued `AbortMultipartUpload` succeeded.
+        /// On `false` the session keeps the pending record alive so startup
+        /// reconciliation (`cleanupOrphanedMultiparts` / `UploadOrphanCleaner`)
+        /// can retry the abort instead of dropping our only handle.
         private let onAbortMultipartUpload:
-            @Sendable (PendingUploadStore.PendingUpload) async -> Void
+            @Sendable (PendingUploadStore.PendingUpload) async -> Bool
 
         /// Keys of uploads we've already dispatched to `onAllPartsComplete`. Guards
         /// against two parts of the same upload finishing almost simultaneously
         /// inside a single extension lifetime. The persisted `isCompleting` flag
         /// on `PendingUpload` covers the cross-respawn case.
         private var finalizingKeys: Set<String> = []
+
+        /// Keys for which `abortUploadForTask` is in progress. Other delegate
+        /// callbacks (e.g. a sibling part finishing while we're awaiting the
+        /// network abort) must short-circuit so they don't reorder operations
+        /// or attempt to finalize a doomed upload.
+        private var abortingKeys: Set<String> = []
 
         /// Lazily constructed background session. Background sessions cannot be
         /// re-initialised with the same identifier in a single process, so this
@@ -69,7 +79,7 @@
             onAllPartsComplete:
             @escaping @Sendable (PendingUploadStore.PendingUpload) async -> Void,
             onAbortMultipartUpload:
-            @escaping @Sendable (PendingUploadStore.PendingUpload) async -> Void
+            @escaping @Sendable (PendingUploadStore.PendingUpload) async -> Bool
         ) {
             self.pendingStore = pendingStore
             self.onAllPartsComplete = onAllPartsComplete
@@ -147,6 +157,18 @@
                 return
             }
 
+            // If a sibling part already triggered an abort for this upload's
+            // key, treat this late-arriving success as a no-op: we're tearing
+            // the multipart down server-side, finalizing now would race the
+            // abort.
+            if let record = await pendingStore.partRecord(forTaskIdentifier: taskId),
+               abortingKeys.contains(record.key) {
+                logger.debug(
+                    "Task \(taskId) completed for aborting upload \(record.key, privacy: .public) — ignoring"
+                )
+                return
+            }
+
             // Mark the part complete. This persists the etag against the parent
             // PendingUpload and removes the per-task record + temp file.
             await pendingStore.markPartCompleted(
@@ -164,6 +186,10 @@
                 guard !finalizingKeys.contains(upload.key) else {
                     // Another delegate callback in this extension lifetime is
                     // already finalizing this upload. Skip to avoid double-fire.
+                    continue
+                }
+                guard !abortingKeys.contains(upload.key) else {
+                    // Upload is being torn down — don't start finalize.
                     continue
                 }
                 // Persisted guard against re-entry from a respawned extension.
@@ -196,13 +222,20 @@
 
         /// Best-effort cleanup when a single part task fails. Removes the part
         /// record and chunk file, cancels sibling part tasks for the same
-        /// multipart upload, asks the host to issue `AbortMultipartUpload` against
-        /// S3, and finally drops the parent pending record.
+        /// multipart upload, and asks the host to issue `AbortMultipartUpload`
+        /// against S3. Only drops the parent pending record when the host abort
+        /// succeeds — on transient abort failure we keep the record so startup
+        /// reconciliation can retry instead of leaking server-side state.
         private func abortUploadForTask(_ taskId: Int) async {
             guard
                 let record = await pendingStore.partRecord(forTaskIdentifier: taskId)
             else { return }
             let key = record.key
+
+            // Mark BEFORE any awaits so concurrent delegate callbacks for
+            // sibling parts of the same upload short-circuit.
+            abortingKeys.insert(key)
+            defer { abortingKeys.remove(key) }
 
             // 1. Drop the failing part record + temp file.
             await pendingStore.markPartFailed(taskIdentifier: taskId)
@@ -221,9 +254,10 @@
                 }
             }
 
-            // 3. Ask the host to abort the multipart upload on S3 (best effort).
-            //    Then drop the parent record so the orphan reconciler has nothing
-            //    to do.
+            // 3. Ask the host to abort the multipart upload on S3. Only drop the
+            //    parent record on success — on failure keep the record so the
+            //    next startup pass (`cleanupOrphanedMultiparts` /
+            //    `UploadOrphanCleaner`) can retry the abort.
             if let upload = await pendingStore.pendingUpload(forKey: key) {
                 logger.warning(
                     """
@@ -231,8 +265,18 @@
                     uploadId=\(upload.uploadId, privacy: .public)
                     """
                 )
-                await onAbortMultipartUpload(upload)
-                await pendingStore.remove(forKey: key)
+                let aborted = await onAbortMultipartUpload(upload)
+                if aborted {
+                    await pendingStore.remove(forKey: key)
+                } else {
+                    logger.warning(
+                        """
+                        Host abort failed for \(key, privacy: .public) \
+                        uploadId=\(upload.uploadId, privacy: .public) — \
+                        keeping record for startup retry
+                        """
+                    )
+                }
             }
         }
     }

--- a/DS3Lib/Sources/DS3Lib/DS3S3Client+Transfers.swift
+++ b/DS3Lib/Sources/DS3Lib/DS3S3Client+Transfers.swift
@@ -252,16 +252,36 @@ public extension DS3S3Client {
         _ = try await s3.abortMultipartUpload(request)
     }
 
-    /// Lists all in-progress multipart uploads for a bucket.
-    /// Used by the iOS reconciler at extension launch to find orphans.
+    /// Lists all in-progress multipart uploads for a bucket. Pages internally
+    /// until `isTruncated == false` so callers see the full inventory — state-
+    /// deleting decisions in the iOS reconciler depend on completeness.
     /// - Returns: Array of (key, uploadId) pairs for each in-progress upload
     func listMultipartUploads(bucket: String) async throws -> [(key: String, uploadId: String)] {
-        let request = S3.ListMultipartUploadsRequest(bucket: bucket)
-        let response = try await s3.listMultipartUploads(request)
-        return (response.uploads ?? []).compactMap { upload in
-            guard let key = upload.key, let uploadId = upload.uploadId else { return nil }
-            return (key: key, uploadId: uploadId)
-        }
+        var results: [(key: String, uploadId: String)] = []
+        var keyMarker: String?
+        var uploadIdMarker: String?
+        repeat {
+            let request = S3.ListMultipartUploadsRequest(
+                bucket: bucket,
+                keyMarker: keyMarker,
+                uploadIdMarker: uploadIdMarker
+            )
+            let response = try await s3.listMultipartUploads(request)
+            for upload in response.uploads ?? [] {
+                guard let key = upload.key, let uploadId = upload.uploadId else { continue }
+                results.append((key: key, uploadId: uploadId))
+            }
+            if response.isTruncated == true {
+                keyMarker = response.nextKeyMarker
+                uploadIdMarker = response.nextUploadIdMarker
+                // Defensive: stop if S3 returns truncated=true without markers
+                // to avoid an infinite loop.
+                if keyMarker == nil, uploadIdMarker == nil { break }
+            } else {
+                break
+            }
+        } while true
+        return results
     }
 
     /// Generates a presigned PUT URLRequest for an S3 multipart UploadPart call.

--- a/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/PendingUploadStore.swift
@@ -18,6 +18,10 @@ public actor PendingUploadStore {
         /// Total number of parts expected for this upload. `0` means unknown
         /// (e.g. legacy entry persisted before this field was introduced).
         public let expectedPartCount: Int
+        /// `true` once the finalizer has begun `CompleteMultipartUpload` for this
+        /// key. Persisted so a respawned extension does not fire the finalizer a
+        /// second time when the in-memory `finalizingKeys` set is empty.
+        public var isCompleting: Bool
 
         public init(
             uploadId: String,
@@ -33,6 +37,7 @@ public actor PendingUploadStore {
             self.completedPartETags = [:]
             self.createdAt = Date()
             self.expectedPartCount = expectedPartCount
+            self.isCompleting = false
         }
 
         /// Custom decoding so legacy on-disk entries without `expectedPartCount`
@@ -47,6 +52,7 @@ public actor PendingUploadStore {
                 .decodeIfPresent([Int: String].self, forKey: .completedPartETags) ?? [:]
             self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
             self.expectedPartCount = try container.decodeIfPresent(Int.self, forKey: .expectedPartCount) ?? 0
+            self.isCompleting = try container.decodeIfPresent(Bool.self, forKey: .isCompleting) ?? false
         }
     }
 
@@ -214,6 +220,46 @@ public actor PendingUploadStore {
     public func allPartsComplete(forKey key: String) -> Bool {
         guard let upload = uploads[key], upload.expectedPartCount > 0 else { return false }
         return upload.completedPartETags.count == upload.expectedPartCount
+    }
+
+    /// Drop a part record (e.g. after the URLSession task failed). Best-effort
+    /// removes the temp chunk file. Does NOT touch the parent upload — callers
+    /// that want to abort the whole multipart should follow up with `remove(forKey:)`.
+    public func markPartFailed(taskIdentifier: Int) {
+        guard let record = partRecords.removeValue(forKey: taskIdentifier) else { return }
+        try? FileManager.default.removeItem(at: record.tempFileURL)
+        saveToDisk()
+    }
+
+    /// All in-flight part records for a single upload key. Used by the upload
+    /// session to find sibling tasks when one part has failed and the whole
+    /// multipart upload must be aborted.
+    public func partRecords(forKey key: String) -> [PartUploadRecord] {
+        partRecords.values.filter { $0.key == key }
+    }
+
+    /// Mark a pending upload as in the middle of `CompleteMultipartUpload`.
+    /// Persisted so a respawned extension does not run the finalizer a second
+    /// time. Returns `true` if the flag was newly set; `false` if the upload
+    /// was already marked completing (caller should skip).
+    @discardableResult
+    public func markCompleting(forKey key: String) -> Bool {
+        guard var upload = uploads[key] else { return false }
+        if upload.isCompleting { return false }
+        upload.isCompleting = true
+        uploads[key] = upload
+        saveToDisk()
+        return true
+    }
+
+    /// Clear the `isCompleting` flag (e.g. after determining a previously-marked
+    /// upload still has a live multipart on S3 and needs to be retried).
+    public func clearCompleting(forKey key: String) {
+        guard var upload = uploads[key] else { return }
+        guard upload.isCompleting else { return }
+        upload.isCompleting = false
+        uploads[key] = upload
+        saveToDisk()
     }
 
     /// All in-flight part records across all uploads.

--- a/DS3Lib/Tests/DS3LibTests/PendingUploadStoreTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/PendingUploadStoreTests.swift
@@ -122,4 +122,119 @@ final class PendingUploadStoreBackgroundTests: XCTestCase {
         let ids = await store.allKnownUploadIds()
         XCTAssertEqual(ids, Set(["u7a", "u7b"]))
     }
+
+    // MARK: - isCompleting flag
+
+    func test_legacyDecode_missingIsCompleting_decodesAsFalse() async throws {
+        // JSON without `isCompleting` field — must decode to false.
+        let driveId = testDriveId
+        let legacyJSON = """
+        {"uploads":{"k8/file.jpg":{"uploadId":"u8","bucket":"b","key":"k8/file.jpg","driveId":"\(driveId.uuidString)","completedPartETags":{},"expectedPartCount":2}},"partRecords":{}}
+        """.data(using: .utf8)!
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".json")
+        try legacyJSON.write(to: tempURL)
+        let storeFromDisk = PendingUploadStore(fileURL: tempURL)
+        let upload = await storeFromDisk.pendingUpload(forKey: "k8/file.jpg")
+        XCTAssertNotNil(upload)
+        XCTAssertEqual(upload?.isCompleting, false, "Missing isCompleting must default to false")
+    }
+
+    func test_markCompleting_isIdempotent_andPersisted() async throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".json")
+        let store = PendingUploadStore(fileURL: tempURL)
+        await store.register(
+            uploadId: "u9", bucket: "b", key: "k9/file.jpg",
+            driveId: testDriveId, expectedPartCount: 1
+        )
+
+        // First call sets the flag → returns true.
+        let first = await store.markCompleting(forKey: "k9/file.jpg")
+        XCTAssertTrue(first, "First markCompleting must return true")
+
+        // Second call sees flag already set → returns false (idempotent).
+        let second = await store.markCompleting(forKey: "k9/file.jpg")
+        XCTAssertFalse(second, "Second markCompleting must return false")
+
+        // Persisted: a fresh store loaded from the same URL must see isCompleting=true.
+        let reloaded = PendingUploadStore(fileURL: tempURL)
+        let upload = await reloaded.pendingUpload(forKey: "k9/file.jpg")
+        XCTAssertEqual(upload?.isCompleting, true, "isCompleting must be persisted to disk")
+
+        // clearCompleting flips it back and is also persisted.
+        await store.clearCompleting(forKey: "k9/file.jpg")
+        let reloaded2 = PendingUploadStore(fileURL: tempURL)
+        let upload2 = await reloaded2.pendingUpload(forKey: "k9/file.jpg")
+        XCTAssertEqual(upload2?.isCompleting, false, "clearCompleting must be persisted")
+    }
+
+    // MARK: - markPartFailed
+
+    func test_markPartFailed_removesRecord_andDeletesTempFile() async throws {
+        // Create a real temp file backing the part record.
+        let tempFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".bin")
+        try Data("payload".utf8).write(to: tempFile)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFile.path))
+
+        await store.register(
+            uploadId: "u10", bucket: "b", key: "k10/file.jpg",
+            driveId: testDriveId, expectedPartCount: 2
+        )
+        await store.recordPartTask(
+            forKey: "k10/file.jpg", partNumber: 1,
+            taskIdentifier: 1000, tempFileURL: tempFile
+        )
+
+        // Sanity: record present.
+        let before = await store.partRecord(forTaskIdentifier: 1000)
+        XCTAssertNotNil(before)
+
+        await store.markPartFailed(taskIdentifier: 1000)
+
+        // Record gone, temp file deleted.
+        let after = await store.partRecord(forTaskIdentifier: 1000)
+        XCTAssertNil(after, "Part record must be removed after markPartFailed")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: tempFile.path),
+            "Temp chunk file must be deleted"
+        )
+
+        // markPartFailed for an unknown taskId is a no-op (must not crash).
+        await store.markPartFailed(taskIdentifier: 9999)
+    }
+
+    // MARK: - partRecords(forKey:)
+
+    func test_partRecordsForKey_returnsOnlyMatchingKey() async throws {
+        await store.register(
+            uploadId: "u11a", bucket: "b", key: "k11a",
+            driveId: testDriveId, expectedPartCount: 2
+        )
+        await store.register(
+            uploadId: "u11b", bucket: "b", key: "k11b",
+            driveId: testDriveId, expectedPartCount: 1
+        )
+        await store.recordPartTask(
+            forKey: "k11a", partNumber: 1, taskIdentifier: 1101,
+            tempFileURL: URL(fileURLWithPath: "/tmp/a1.bin")
+        )
+        await store.recordPartTask(
+            forKey: "k11a", partNumber: 2, taskIdentifier: 1102,
+            tempFileURL: URL(fileURLWithPath: "/tmp/a2.bin")
+        )
+        await store.recordPartTask(
+            forKey: "k11b", partNumber: 1, taskIdentifier: 1103,
+            tempFileURL: URL(fileURLWithPath: "/tmp/b1.bin")
+        )
+
+        let aRecords = await store.partRecords(forKey: "k11a")
+        XCTAssertEqual(aRecords.count, 2)
+        XCTAssertEqual(Set(aRecords.map(\.taskIdentifier)), Set([1101, 1102]))
+
+        let bRecords = await store.partRecords(forKey: "k11b")
+        XCTAssertEqual(bRecords.count, 1)
+        XCTAssertEqual(bRecords.first?.taskIdentifier, 1103)
+    }
 }


### PR DESCRIPTION
## Summary

Two related cleanups in the iOS background upload pipeline.

### #149 — `BackgroundUploadSession.abortUploadForTask` incomplete cleanup
Per-task failure used to delete only the local chunk file. It now:
- drops the failing part record (new `PendingUploadStore.markPartFailed`),
- cancels sibling `URLSessionTask`s for the same upload key (resolved via `partRecords(forKey:)`),
- asks the host to issue `AbortMultipartUpload` against S3 via a new `onAbortMultipartUpload` callback wired into `FileProviderExtension+IOSUpload`,
- removes the parent pending record.

### #150 — `finalizingKeys` was in-memory only
`PendingUpload` gains a persisted `isCompleting: Bool` (legacy on-disk entries decode to `false`). `BackgroundUploadSession` calls `markCompleting(forKey:)` before dispatching the finalizer so a respawned extension does not fire `CompleteMultipartUpload` a second time. `cleanupOrphanedMultiparts` reconciles the flag against `listMultipartUploads` at startup: if the upload is still live on S3 the flag is cleared so the next "all parts complete" trigger can retry; otherwise the stale record is dropped.

## Test plan
- [ ] Trigger a single-part failure mid-multipart upload and confirm sibling tasks cancel, S3 abort fires, and the pending record is removed.
- [ ] Reap the FP extension during `CompleteMultipartUpload` and confirm the respawn does not re-fire complete (no duplicate `signalChanges` / thumbnail enqueue) when S3 already finished, and resumes finalize when S3 still lists the upload.
- [ ] Existing legacy on-disk pending uploads still decode (covered by `PendingUploadStoreBackgroundTests.test_legacyDecode_*`).

Closes #149
Closes #150