### PR TITLE
fix(ios): invalidate Files.app thumbnail cache after backfill (closes #153)

### DIFF
--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -31,9 +31,12 @@
 
         /// MetadataStore handle, used by `renderOne` to stamp
         /// `thumbnailReadyAt` on the row after each sidecar PUT (issue #153).
-        /// Failure to construct the store is logged once and the field is left
-        /// nil — backfill still completes; only the Files.app cache invalidation
-        /// degrades to "wait until next etag drift / user tap".
+        /// Set asynchronously by `setupMetadataStore()` after init returns —
+        /// `ModelContainer` creation/migration touches disk, so we keep it
+        /// off the main thread at app launch. Until setup completes (or if
+        /// it fails), `markThumbnailReady` no-ops; backfill still completes
+        /// and the Files.app cache invalidation degrades to "wait until next
+        /// etag drift / user tap".
         ///
         /// `@ObservationIgnored` because this is private state never consumed
         /// by SwiftUI views; skipping accessor synthesis avoids spurious
@@ -42,22 +45,32 @@
 
         init(driveManager: DS3DriveManager) {
             self.driveManager = driveManager
-            do {
-                let container = try MetadataStore.createContainer()
-                self.metadataStore = MetadataStore(modelContainer: container)
-            } catch {
-                self.metadataStore = nil
-                let logger = Logger(subsystem: LogSubsystem.app, category: LogCategory.thumbnail.rawValue)
-                logger.warning(
-                    // swiftlint:disable:next line_length
-                    "Backfill: MetadataStore unavailable, thumbnailReadyAt signalling disabled: \(error.localizedDescription, privacy: .public)"
-                )
-            }
             darwinObservation = DarwinNotificationCenter.shared.addObserver(
                 name: DarwinNotificationCenter.thumbnailRenderRequest
             ) { [weak self] in
                 Task { @MainActor in self?.wakeIfIdle() }
             }
+            // Build the SwiftData container off the main thread — schema
+            // migration and disk I/O can block on cold launch. The store is
+            // optional, so until this completes `markThumbnailReady` no-ops
+            // (the call site already tolerates a nil store).
+            Task.detached(priority: .utility) { [weak self] in
+                let logger = Logger(subsystem: LogSubsystem.app, category: LogCategory.thumbnail.rawValue)
+                do {
+                    let container = try MetadataStore.createContainer()
+                    let store = MetadataStore(modelContainer: container)
+                    await self?.assignMetadataStore(store)
+                } catch {
+                    logger.warning(
+                        // swiftlint:disable:next line_length
+                        "Backfill: MetadataStore unavailable, thumbnailReadyAt signalling disabled: \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+            }
+        }
+
+        private func assignMetadataStore(_ store: MetadataStore) {
+            metadataStore = store
         }
 
         /// Call from scenePhase onChange in the app root.

--- a/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
+++ b/DS3DriveApp/ViewModels/ForegroundBackfillDriver.swift
@@ -29,8 +29,30 @@
         /// Call `invalidateS3Client(for:)` when a drive is disconnected to release the event loop.
         private var ds3ClientCache: [UUID: DS3Client] = [:]
 
+        /// MetadataStore handle, used by `renderOne` to stamp
+        /// `thumbnailReadyAt` on the row after each sidecar PUT (issue #153).
+        /// Failure to construct the store is logged once and the field is left
+        /// nil — backfill still completes; only the Files.app cache invalidation
+        /// degrades to "wait until next etag drift / user tap".
+        ///
+        /// `@ObservationIgnored` because this is private state never consumed
+        /// by SwiftUI views; skipping accessor synthesis avoids spurious
+        /// re-renders on the main app's drives list every time backfill writes.
+        @ObservationIgnored private var metadataStore: MetadataStore?
+
         init(driveManager: DS3DriveManager) {
             self.driveManager = driveManager
+            do {
+                let container = try MetadataStore.createContainer()
+                self.metadataStore = MetadataStore(modelContainer: container)
+            } catch {
+                self.metadataStore = nil
+                let logger = Logger(subsystem: LogSubsystem.app, category: LogCategory.thumbnail.rawValue)
+                logger.warning(
+                    // swiftlint:disable:next line_length
+                    "Backfill: MetadataStore unavailable, thumbnailReadyAt signalling disabled: \(error.localizedDescription, privacy: .public)"
+                )
+            }
             darwinObservation = DarwinNotificationCenter.shared.addObserver(
                 name: DarwinNotificationCenter.thumbnailRenderRequest
             ) { [weak self] in
@@ -265,6 +287,23 @@
                 )
                 await queue.fail(item)
                 return
+            }
+
+            // 6.5. Stamp `thumbnailReadyAt` on the MetadataStore row so
+            //      `WorkingSetEnumerator.enumerateChanges` re-emits the item
+            //      and Files.app invalidates its per-item thumbnail cache
+            //      (issue #153). Errors logged + swallowed: the working-set
+            //      signal below is still useful as a fallback for items
+            //      whose row was purged between enqueue and PUT.
+            if let metadataStore {
+                do {
+                    try await metadataStore.markThumbnailReady(s3Key: item.s3Key, driveId: drive.id)
+                } catch {
+                    logger.warning(
+                        // swiftlint:disable:next line_length
+                        "Backfill: markThumbnailReady failed for \(item.s3Key, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
+                }
             }
 
             // 7. Signal File Provider so iOS Files re-fetches thumbnails for this drive.

--- a/DS3DriveProvider/S3Enumerator.swift
+++ b/DS3DriveProvider/S3Enumerator.swift
@@ -64,7 +64,11 @@ class S3Enumerator: NSObject, NSFileProviderEnumerator, @unchecked Sendable {
         completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void
     ) {
         guard let metadataStore = self.metadataStore else {
-            completionHandler(NSFileProviderSyncAnchor(SyncAnchorHash.compute(over: [])))
+            completionHandler(
+                NSFileProviderSyncAnchor(
+                    SyncAnchorHash.compute(over: [] as [(key: String, etag: String?)])
+                )
+            )
             return
         }
 

--- a/DS3DriveProvider/WorkingSetEnumerator.swift
+++ b/DS3DriveProvider/WorkingSetEnumerator.swift
@@ -46,10 +46,23 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator, @unchecked
         Task {
             let members = await (try? metadataStore?.fetchWorkingSetMembers(driveId: driveId)) ?? []
             let anchor = NSFileProviderSyncAnchor(
-                SyncAnchorHash.compute(over: members.map { ($0.s3Key, $0.etag) })
+                SyncAnchorHash.compute(over: members.map(WorkingSetEnumerator.entry(from:)))
             )
             boxedCb.value(anchor)
         }
+    }
+
+    /// Maps a cached working-set member to the Sendable struct expected by
+    /// `SyncAnchorHash.compute(over:)`. Extracted so anchor sites stay
+    /// one-liners and SwiftLint's large-tuple rule never fires.
+    fileprivate static func entry(
+        from member: MetadataStore.CachedChildItem
+    ) -> SyncAnchorHash.WorkingSetEntry {
+        SyncAnchorHash.WorkingSetEntry(
+            key: member.s3Key,
+            etag: member.etag,
+            thumbnailReadyAt: member.thumbnailReadyAt
+        )
     }
 
     // MARK: - enumerateItems
@@ -116,57 +129,23 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator, @unchecked
                 let members = try await metadataStore.fetchWorkingSetMembers(driveId: self.drive.id)
                 guard !members.isEmpty else {
                     let emptyAnchor = NSFileProviderSyncAnchor(
-                        SyncAnchorHash.compute(over: [])
+                        SyncAnchorHash.compute(over: [SyncAnchorHash.WorkingSetEntry]())
                     )
                     observer.finishEnumeratingChanges(upTo: emptyAnchor, moreComing: false)
                     return
                 }
 
                 let refreshed = await self.refreshMembers(members)
-
-                let updatedItems = refreshed.updated.map { remote in
-                    S3Item(
-                        identifier: NSFileProviderItemIdentifier(remote.itemIdentifier.rawValue),
-                        drive: self.drive,
-                        objectMetadata: remote.metadata
-                    )
-                }
-                if !updatedItems.isEmpty {
-                    let upsertData = updatedItems.map { MetadataStore.ItemUpsertData(from: $0) }
-                    do {
-                        try await metadataStore.batchUpsertItems(upsertData)
-                    } catch {
-                        self.logger.warning(
-                            "WorkingSetEnumerator: failed to persist updated items: \(error.localizedDescription, privacy: .public)"
-                        )
-                    }
-                    observer.didUpdate(updatedItems)
-                }
-                if !refreshed.deleted.isEmpty {
-                    // Remove rows from MetadataStore BEFORE notifying the
-                    // observer so the post-refresh anchor below excludes them.
-                    // Without this cleanup, the next 30s cycle re-HEADs the
-                    // same gone-forever keys and re-reports `didDeleteItems`
-                    // indefinitely.
-                    let driveId = self.drive.id
-                    let deletedKeys = refreshed.deleted
-                    do {
-                        try await metadataStore.batchDeleteItems(
-                            deletedKeys.map { (s3Key: $0, driveId: driveId) }
-                        )
-                    } catch {
-                        self.logger.error(
-                            "WorkingSetEnumerator: failed to remove deleted keys from store: \(error.localizedDescription, privacy: .public)"
-                        )
-                    }
-                    observer.didDeleteItems(
-                        withIdentifiers: deletedKeys.map { NSFileProviderItemIdentifier($0) }
-                    )
-                }
+                await self.applyEtagDrift(refreshed: refreshed, observer: observer, store: metadataStore)
+                await self.applyThumbnailReady(
+                    members: members, refreshed: refreshed,
+                    observer: observer, store: metadataStore
+                )
+                await self.applyDeletions(refreshed: refreshed, observer: observer, store: metadataStore)
 
                 let postRefresh = await (try? metadataStore.fetchWorkingSetMembers(driveId: self.drive.id)) ?? []
                 let newAnchor = NSFileProviderSyncAnchor(
-                    SyncAnchorHash.compute(over: postRefresh.map { ($0.s3Key, $0.etag) })
+                    SyncAnchorHash.compute(over: postRefresh.map(WorkingSetEnumerator.entry(from:)))
                 )
                 observer.finishEnumeratingChanges(upTo: newAnchor, moreComing: false)
             } catch {
@@ -176,6 +155,102 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator, @unchecked
                 observer.finishEnumeratingWithError(NSFileProviderError(.cannotSynchronize) as NSError)
             }
         }
+    }
+
+    /// Persist + emit items whose remote ETag has drifted from our cache.
+    private func applyEtagDrift(
+        refreshed: (updated: [S3Item], deleted: [String]),
+        observer: NSFileProviderChangeObserver,
+        store: MetadataStore
+    ) async {
+        let updatedItems = refreshed.updated.map { remote in
+            S3Item(
+                identifier: NSFileProviderItemIdentifier(remote.itemIdentifier.rawValue),
+                drive: self.drive,
+                objectMetadata: remote.metadata
+            )
+        }
+        guard !updatedItems.isEmpty else { return }
+        let upsertData = updatedItems.map { MetadataStore.ItemUpsertData(from: $0) }
+        do {
+            try await store.batchUpsertItems(upsertData)
+        } catch {
+            self.logger.warning(
+                "WorkingSetEnumerator: failed to persist updated items: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        observer.didUpdate(updatedItems)
+    }
+
+    /// Issue #153: re-emit rows whose `thumbnailReadyAt` was set by the iOS
+    /// foreground backfill driver after a sidecar PUT, so Files.app
+    /// invalidates its per-item thumbnail cache. The HEAD-driven `applyEtagDrift`
+    /// path only fires when the original's etag drifts; sidecar landings
+    /// don't change the original, so this side-channel is required.
+    /// After emitting, clears the one-shot flag.
+    private func applyThumbnailReady(
+        members: [MetadataStore.CachedChildItem],
+        refreshed: (updated: [S3Item], deleted: [String]),
+        observer: NSFileProviderChangeObserver,
+        store: MetadataStore
+    ) async {
+        let updatedKeys = Set(refreshed.updated.map(\.itemIdentifier.rawValue))
+        let readyMembers = members.filter {
+            $0.thumbnailReadyAt != nil && !updatedKeys.contains($0.s3Key)
+        }
+        guard !readyMembers.isEmpty else { return }
+        let readyItems = readyMembers.map { member in
+            S3Item(
+                identifier: NSFileProviderItemIdentifier(member.s3Key),
+                drive: self.drive,
+                objectMetadata: S3Item.Metadata(
+                    etag: member.etag,
+                    contentType: member.contentType,
+                    lastModified: member.lastModified,
+                    size: NSNumber(value: member.size),
+                    syncStatus: member.syncStatus
+                )
+            )
+        }
+        observer.didUpdate(readyItems)
+        self.logger.info(
+            "WorkingSetEnumerator: re-emitted \(readyItems.count, privacy: .public) after sidecar render (#153)"
+        )
+        let driveId = self.drive.id
+        let clearedKeys = readyMembers.map(\.s3Key)
+        do {
+            try await store.clearThumbnailReady(forKeys: clearedKeys, driveId: driveId)
+        } catch {
+            self.logger.warning(
+                "WorkingSetEnumerator: failed to clear thumbnailReadyAt: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Persist + emit deletions for keys that returned 404 to HEAD. Removes
+    /// rows from the metadata store BEFORE notifying so the post-refresh
+    /// anchor excludes them; otherwise the next 30 s tick re-HEADs the same
+    /// gone-forever keys and re-reports `didDeleteItems` indefinitely.
+    private func applyDeletions(
+        refreshed: (updated: [S3Item], deleted: [String]),
+        observer: NSFileProviderChangeObserver,
+        store: MetadataStore
+    ) async {
+        guard !refreshed.deleted.isEmpty else { return }
+        let driveId = self.drive.id
+        let deletedKeys = refreshed.deleted
+        do {
+            try await store.batchDeleteItems(
+                deletedKeys.map { (s3Key: $0, driveId: driveId) }
+            )
+        } catch {
+            self.logger.error(
+                "WorkingSetEnumerator: failed to remove deleted keys from store: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        observer.didDeleteItems(
+            withIdentifiers: deletedKeys.map { NSFileProviderItemIdentifier($0) }
+        )
     }
 
     /// Per-member HEAD against S3 to detect remote ETag drift or deletion.

--- a/DS3DriveProvider/WorkingSetEnumerator.swift
+++ b/DS3DriveProvider/WorkingSetEnumerator.swift
@@ -46,15 +46,15 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator, @unchecked
         Task {
             let members = await (try? metadataStore?.fetchWorkingSetMembers(driveId: driveId)) ?? []
             let anchor = NSFileProviderSyncAnchor(
-                SyncAnchorHash.compute(over: members.map(WorkingSetEnumerator.entry(from:)))
+                SyncAnchorHash.computeWorkingSet(over: members.map(WorkingSetEnumerator.entry(from:)))
             )
             boxedCb.value(anchor)
         }
     }
 
     /// Maps a cached working-set member to the Sendable struct expected by
-    /// `SyncAnchorHash.compute(over:)`. Extracted so anchor sites stay
-    /// one-liners and SwiftLint's large-tuple rule never fires.
+    /// `SyncAnchorHash.computeWorkingSet(over:)`. Extracted so anchor sites
+    /// stay one-liners and SwiftLint's large-tuple rule never fires.
     fileprivate static func entry(
         from member: MetadataStore.CachedChildItem
     ) -> SyncAnchorHash.WorkingSetEntry {
@@ -129,7 +129,7 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator, @unchecked
                 let members = try await metadataStore.fetchWorkingSetMembers(driveId: self.drive.id)
                 guard !members.isEmpty else {
                     let emptyAnchor = NSFileProviderSyncAnchor(
-                        SyncAnchorHash.compute(over: [SyncAnchorHash.WorkingSetEntry]())
+                        SyncAnchorHash.computeWorkingSet(over: [])
                     )
                     observer.finishEnumeratingChanges(upTo: emptyAnchor, moreComing: false)
                     return
@@ -145,7 +145,7 @@ final class WorkingSetEnumerator: NSObject, NSFileProviderEnumerator, @unchecked
 
                 let postRefresh = await (try? metadataStore.fetchWorkingSetMembers(driveId: self.drive.id)) ?? []
                 let newAnchor = NSFileProviderSyncAnchor(
-                    SyncAnchorHash.compute(over: postRefresh.map(WorkingSetEnumerator.entry(from:)))
+                    SyncAnchorHash.computeWorkingSet(over: postRefresh.map(WorkingSetEnumerator.entry(from:)))
                 )
                 observer.finishEnumeratingChanges(upTo: newAnchor, moreComing: false)
             } catch {

--- a/DS3Lib/Sources/DS3Lib/Enumeration/SyncAnchorHash.swift
+++ b/DS3Lib/Sources/DS3Lib/Enumeration/SyncAnchorHash.swift
@@ -61,7 +61,11 @@ public enum SyncAnchorHash {
     /// form: per-folder thumbnail signalling is handled by the explicit
     /// `signalEnumerator(for: parentId)` call in the backfill driver, not
     /// by anchor drift.
-    public static func compute(over entries: [WorkingSetEntry]) -> Data {
+    ///
+    /// Named distinctly from the 2-tuple `compute(over:)` so call sites with
+    /// `[]` are unambiguous (Swift can't infer between the tuple-array and
+    /// `[WorkingSetEntry]` overloads otherwise).
+    public static func computeWorkingSet(over entries: [WorkingSetEntry]) -> Data {
         let sorted = entries
             .map { entry in
                 let stamp = entry.thumbnailReadyAt.map { String($0.timeIntervalSince1970) } ?? ""

--- a/DS3Lib/Sources/DS3Lib/Enumeration/SyncAnchorHash.swift
+++ b/DS3Lib/Sources/DS3Lib/Enumeration/SyncAnchorHash.swift
@@ -34,4 +34,43 @@ public enum SyncAnchorHash {
         let hex = digest.map { String(format: "%02x", $0) }.joined()
         return Data((formatPrefix + hex).utf8)
     }
+
+    /// Sendable input record for the working-set anchor variant.
+    /// Carries the per-row data folded into the hash: S3 key, etag, and the
+    /// `thumbnailReadyAt` one-shot stamp (issue #153).
+    public struct WorkingSetEntry: Sendable {
+        public let key: String
+        public let etag: String?
+        public let thumbnailReadyAt: Date?
+
+        public init(key: String, etag: String?, thumbnailReadyAt: Date?) {
+            self.key = key
+            self.etag = etag
+            self.thumbnailReadyAt = thumbnailReadyAt
+        }
+    }
+
+    /// Variant that also folds an optional `thumbnailReadyAt` timestamp into
+    /// the hash. Used by `WorkingSetEnumerator` (issue #153): when the iOS
+    /// backfill driver stamps `thumbnailReadyAt` on a row after its sidecar
+    /// PUT lands, the working-set anchor changes — Apple then calls
+    /// `enumerateChanges`, which re-emits those rows as `didUpdate` so
+    /// Files.app invalidates its per-item thumbnail cache.
+    ///
+    /// Folder-level (`S3Enumerator`) anchors continue to use the 2-tuple
+    /// form: per-folder thumbnail signalling is handled by the explicit
+    /// `signalEnumerator(for: parentId)` call in the backfill driver, not
+    /// by anchor drift.
+    public static func compute(over entries: [WorkingSetEntry]) -> Data {
+        let sorted = entries
+            .map { entry in
+                let stamp = entry.thumbnailReadyAt.map { String($0.timeIntervalSince1970) } ?? ""
+                return "\(entry.key)\t\(entry.etag ?? "")\t\(stamp)"
+            }
+            .sorted()
+        let joined = sorted.joined(separator: "\n")
+        let digest = SHA256.hash(data: Data(joined.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return Data((formatPrefix + hex).utf8)
+    }
 }

--- a/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore+Queries.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore+Queries.swift
@@ -45,6 +45,31 @@ public extension MetadataStore {
         public let size: Int64
         public let syncStatus: String?
         public let isMaterialized: Bool
+        /// Set by the iOS foreground backfill driver after a sidecar PUT;
+        /// consumed by `WorkingSetEnumerator.enumerateChanges` to invalidate
+        /// the Files.app per-item thumbnail cache (issue #153). Always nil
+        /// for non-iOS or pre-V7 stores.
+        public let thumbnailReadyAt: Date?
+
+        public init(
+            s3Key: String,
+            etag: String?,
+            lastModified: Date?,
+            contentType: String?,
+            size: Int64,
+            syncStatus: String?,
+            isMaterialized: Bool,
+            thumbnailReadyAt: Date? = nil
+        ) {
+            self.s3Key = s3Key
+            self.etag = etag
+            self.lastModified = lastModified
+            self.contentType = contentType
+            self.size = size
+            self.syncStatus = syncStatus
+            self.isMaterialized = isMaterialized
+            self.thumbnailReadyAt = thumbnailReadyAt
+        }
     }
 
     /// Fetch all children of a given parent key within a drive.
@@ -79,7 +104,8 @@ public extension MetadataStore {
                 contentType: $0.contentType,
                 size: $0.size,
                 syncStatus: $0.syncStatus,
-                isMaterialized: $0.isMaterialized
+                isMaterialized: $0.isMaterialized,
+                thumbnailReadyAt: $0.thumbnailReadyAt
             )
         }
     }
@@ -193,7 +219,8 @@ public extension MetadataStore {
                 contentType: $0.contentType,
                 size: $0.size,
                 syncStatus: $0.syncStatus,
-                isMaterialized: $0.isMaterialized
+                isMaterialized: $0.isMaterialized,
+                thumbnailReadyAt: $0.thumbnailReadyAt
             )
         }
     }
@@ -214,6 +241,42 @@ public extension MetadataStore {
         }
         if changed {
             try modelExecutor.modelContext.save()
+        }
+    }
+
+    // MARK: - Thumbnail Cache Invalidation (issue #153)
+
+    /// Stamp `thumbnailReadyAt = at` on the row for `s3Key`. Called by the iOS
+    /// foreground backfill driver right after a sidecar PUT lands. The row
+    /// must already exist; if it doesn't (extension purged it between the
+    /// enqueue and the PUT), this is a no-op so we don't materialise empty
+    /// rows just for thumbnail signalling.
+    ///
+    /// Read by `WorkingSetEnumerator.enumerateChanges`, which re-emits the
+    /// item as `didUpdate` so Files.app invalidates its per-item thumbnail
+    /// cache. After reporting, the enumerator clears the field via
+    /// `clearThumbnailReady` to keep the flag one-shot.
+    func markThumbnailReady(s3Key: String, driveId: UUID, at: Date = Date()) throws {
+        guard let item = try findItem(byKey: s3Key, driveId: driveId) else { return }
+        item.thumbnailReadyAt = at
+        try modelExecutor.modelContext.save()
+    }
+
+    /// Clear `thumbnailReadyAt` for a batch of keys after they have been
+    /// reported via `enumerateChanges`. Counterpart to `markThumbnailReady`.
+    func clearThumbnailReady(forKeys keys: [String], driveId: UUID) throws {
+        guard !keys.isEmpty else { return }
+        let context = modelExecutor.modelContext
+        let keySet = Set(keys)
+        let predicate = #Predicate<SyncedItem> { $0.driveId == driveId }
+        let rows = try context.fetch(FetchDescriptor<SyncedItem>(predicate: predicate))
+        var changed = false
+        for row in rows where keySet.contains(row.s3Key) && row.thumbnailReadyAt != nil {
+            row.thumbnailReadyAt = nil
+            changed = true
+        }
+        if changed {
+            try context.save()
         }
     }
 

--- a/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore+Queries.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore+Queries.swift
@@ -264,19 +264,22 @@ public extension MetadataStore {
 
     /// Clear `thumbnailReadyAt` for a batch of keys after they have been
     /// reported via `enumerateChanges`. Counterpart to `markThumbnailReady`.
+    ///
+    /// Fetches each row by key (mirrors `batchDeleteItems`) instead of
+    /// scanning every `SyncedItem` for the drive — this runs on every
+    /// `enumerateChanges` tick (~30s) and the working set can be large.
     func clearThumbnailReady(forKeys keys: [String], driveId: UUID) throws {
         guard !keys.isEmpty else { return }
-        let context = modelExecutor.modelContext
-        let keySet = Set(keys)
-        let predicate = #Predicate<SyncedItem> { $0.driveId == driveId }
-        let rows = try context.fetch(FetchDescriptor<SyncedItem>(predicate: predicate))
         var changed = false
-        for row in rows where keySet.contains(row.s3Key) && row.thumbnailReadyAt != nil {
+        for key in keys {
+            guard let row = try findItem(byKey: key, driveId: driveId),
+                  row.thumbnailReadyAt != nil
+            else { continue }
             row.thumbnailReadyAt = nil
             changed = true
         }
         if changed {
-            try context.save()
+            try modelExecutor.modelContext.save()
         }
     }
 

--- a/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/MetadataStore.swift
@@ -13,7 +13,7 @@ public actor MetadataStore {
     /// previous build that used a different versioned schema), the store is
     /// deleted and recreated — metadata is ephemeral cache, not user data.
     public static func createContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(
             "SyncedItems",
             schema: schema,

--- a/DS3Lib/Sources/DS3Lib/Metadata/SyncedItem.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/SyncedItem.swift
@@ -511,6 +511,9 @@ public enum SyncedItemSchemaV6: VersionedSchema {
     }
 }
 
+// SyncedItemSchemaV7 lives in `SyncedItemSchemaV7.swift` so this file stays
+// under SwiftLint's file_length ceiling.
+
 /// Migration plan for SyncedItem schema versions.
 public enum SyncedItemMigrationPlan: SchemaMigrationPlan {
     public static var schemas: [any VersionedSchema.Type] {
@@ -520,12 +523,13 @@ public enum SyncedItemMigrationPlan: SchemaMigrationPlan {
             SyncedItemSchemaV3.self,
             SyncedItemSchemaV4.self,
             SyncedItemSchemaV5.self,
-            SyncedItemSchemaV6.self
+            SyncedItemSchemaV6.self,
+            SyncedItemSchemaV7.self
         ]
     }
 
     public static var stages: [MigrationStage] {
-        [migrateV1toV2, migrateV2toV3, migrateV3toV4, migrateV4toV5, migrateV5toV6]
+        [migrateV1toV2, migrateV2toV3, migrateV3toV4, migrateV4toV5, migrateV5toV6, migrateV6toV7]
     }
 
     /// Lightweight migration from V1 to V2:
@@ -567,8 +571,17 @@ public enum SyncedItemMigrationPlan: SchemaMigrationPlan {
         fromVersion: SyncedItemSchemaV5.self,
         toVersion: SyncedItemSchemaV6.self
     )
+
+    /// Lightweight migration from V6 to V7 (issue #153):
+    /// - Adds `thumbnailReadyAt: Date?` to SyncedItem (default nil).
+    /// Existing rows migrate cleanly with nil, which is the correct semantic
+    /// for "thumbnail not yet renewed".
+    nonisolated static let migrateV6toV7 = MigrationStage.lightweight(
+        fromVersion: SyncedItemSchemaV6.self,
+        toVersion: SyncedItemSchemaV7.self
+    )
 }
 
 /// Type alias for the current schema version's SyncedItem.
 /// (`SyncAnchorRecord` typealias lives in `SyncAnchorRecord.swift`.)
-public typealias SyncedItem = SyncedItemSchemaV6.SyncedItem
+public typealias SyncedItem = SyncedItemSchemaV7.SyncedItem

--- a/DS3Lib/Sources/DS3Lib/Metadata/SyncedItemSchemaV7.swift
+++ b/DS3Lib/Sources/DS3Lib/Metadata/SyncedItemSchemaV7.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftData
+
+/// Schema version 7. Adds `thumbnailReadyAt: Date?` to SyncedItem so the
+/// iOS foreground backfill driver can mark a row when its sidecar lands.
+/// `WorkingSetEnumerator.enumerateChanges` re-emits those rows as `didUpdate`,
+/// which forces Files.app to invalidate its per-item thumbnail cache and
+/// re-fetch (issue #153).
+///
+/// Extracted from `SyncedItem.swift` (which is at SwiftLint's file_length
+/// ceiling). New schema versions should land here or in their own files.
+///
+/// SyncAnchorRecord is unchanged from V2/V3/V4/V5/V6.
+public enum SyncedItemSchemaV7: VersionedSchema {
+    public nonisolated static let versionIdentifier = Schema.Version(7, 0, 0)
+    public static var models: [any PersistentModel.Type] {
+        [SyncedItem.self, SyncAnchorRecord.self]
+    }
+
+    public typealias SyncAnchorRecord = SyncedItemSchemaV2.SyncAnchorRecord
+
+    @Model
+    public final class SyncedItem {
+        /// `hashModifier: "v7"` forces a distinct schema checksum because V7
+        /// adds a new optional field (`thumbnailReadyAt`) that SwiftData
+        /// otherwise hashes identically to V6 if the column is added without
+        /// the modifier — mirrors V5/V6 patterns (Pitfall 6).
+        @Attribute(hashModifier: "v7") public var s3Key: String
+        public var driveId: UUID
+        @Attribute(.unique) public var uniqueKey: String
+        public var etag: String?
+        public var lastModified: Date?
+        public var localFileHash: String?
+        public var syncStatus: String
+        @Transient public var status: SyncStatus {
+            get { SyncStatus(rawValue: syncStatus) ?? .pending }
+            set { syncStatus = newValue.rawValue }
+        }
+        public var parentKey: String?
+        public var contentType: String?
+        public var size: Int64
+        public var isMaterialized: Bool = false
+        public var originalKey: String?
+
+        /// Set by the iOS foreground backfill driver after a sidecar PUT
+        /// succeeds. Read by `WorkingSetEnumerator.enumerateChanges` to
+        /// re-emit the item as `didUpdate` and trigger Files.app to
+        /// invalidate its per-item thumbnail cache. Cleared back to nil
+        /// after the change is reported, so the field acts as a one-shot
+        /// flag rather than a permanent timestamp. Issue #153.
+        public var thumbnailReadyAt: Date?
+
+        public init(
+            s3Key: String,
+            driveId: UUID,
+            size: Int64 = 0,
+            syncStatus: String = SyncStatus.pending.rawValue
+        ) {
+            self.s3Key = s3Key
+            self.driveId = driveId
+            self.uniqueKey = "\(driveId.uuidString):\(s3Key)"
+            self.size = size
+            self.syncStatus = syncStatus
+        }
+    }
+}

--- a/DS3Lib/Tests/DS3LibTests/ConflictDetectionTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ConflictDetectionTests.swift
@@ -10,7 +10,7 @@ final class ConflictDetectionTests: XCTestCase {
     private let testDriveId = UUID()
 
     override func setUp() async throws {
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(
             "TestConflictDetection",
             schema: schema,

--- a/DS3Lib/Tests/DS3LibTests/MetadataStoreMaterializationTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/MetadataStoreMaterializationTests.swift
@@ -13,7 +13,7 @@ final class MetadataStoreMaterializationTests: XCTestCase {
     private let driveId = UUID()
 
     override func setUp() async throws {
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         container = try ModelContainer(for: schema, configurations: [config])
         store = MetadataStore(modelContainer: container)

--- a/DS3Lib/Tests/DS3LibTests/MetadataStoreMigrationTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/MetadataStoreMigrationTests.swift
@@ -7,7 +7,7 @@ import SwiftData
 final class MetadataStoreMigrationTests: XCTestCase {
     func testCurrentSchemaHasIsMaterializedField() throws {
         // Verify SyncedItem in the current schema has isMaterialized with default false
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: [config])
         let context = ModelContext(container)
@@ -24,7 +24,7 @@ final class MetadataStoreMigrationTests: XCTestCase {
 
     func testSchemaIncludesSyncAnchorRecord() throws {
         // Verify SyncAnchorRecord can be persisted in the current schema
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: [config])
         let context = ModelContext(container)
@@ -46,7 +46,7 @@ final class MetadataStoreMigrationTests: XCTestCase {
         // Verify MetadataStore is usable from async context (not @MainActor).
         // Note: SyncedItem and SyncAnchorRecord are @Model classes (not Sendable),
         // so we test actor isolation via methods that return Sendable types (Void, Int, Date).
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: [config])
         let store = MetadataStore(modelContainer: container)

--- a/DS3Lib/Tests/DS3LibTests/MetadataStorePurgeTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/MetadataStorePurgeTests.swift
@@ -19,7 +19,7 @@ final class MetadataStorePurgeTests: XCTestCase {
     private let rootSentinel = "NSFileProviderRootContainerItemIdentifier"
 
     override func setUp() async throws {
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         container = try ModelContainer(for: schema, configurations: [config])
         store = MetadataStore(modelContainer: container)

--- a/DS3Lib/Tests/DS3LibTests/MetadataStoreTransientStatusTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/MetadataStoreTransientStatusTests.swift
@@ -10,7 +10,7 @@ final class MetadataStoreTransientStatusTests: XCTestCase {
     private let driveId = UUID()
 
     override func setUp() async throws {
-        let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+        let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         container = try ModelContainer(for: schema, configurations: [config])
         store = MetadataStore(modelContainer: container)

--- a/DS3Lib/Tests/DS3LibTests/Phase13IntegrationSmokeTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/Phase13IntegrationSmokeTests.swift
@@ -258,7 +258,7 @@ import XCTest
 
         override func setUp() async throws {
             // V6 schema (Phase 13.2 Plan 09 dropped `thumbnailStatus`).
-            let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+            let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
             let config = ModelConfiguration(isStoredInMemoryOnly: true)
             container = try ModelContainer(for: schema, configurations: [config])
             metadataStore = MetadataStore(modelContainer: container)

--- a/DS3Lib/Tests/DS3LibTests/SyncAnchorHashTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/SyncAnchorHashTests.swift
@@ -9,8 +9,8 @@ final class SyncAnchorHashTests: XCTestCase {
     }
 
     func testEmptyInputProducesStableAnchor() {
-        let a = SyncAnchorHash.compute(over: [])
-        let b = SyncAnchorHash.compute(over: [])
+        let a = SyncAnchorHash.compute(over: [(key: String, etag: String?)]())
+        let b = SyncAnchorHash.compute(over: [(key: String, etag: String?)]())
         XCTAssertEqual(a, b)
     }
 

--- a/DS3Lib/Tests/DS3LibTests/SyncAnchorHashTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/SyncAnchorHashTests.swift
@@ -9,8 +9,8 @@ final class SyncAnchorHashTests: XCTestCase {
     }
 
     func testEmptyInputProducesStableAnchor() {
-        let a = SyncAnchorHash.compute(over: [(key: String, etag: String?)]())
-        let b = SyncAnchorHash.compute(over: [(key: String, etag: String?)]())
+        let a = SyncAnchorHash.compute(over: [])
+        let b = SyncAnchorHash.compute(over: [])
         XCTAssertEqual(a, b)
     }
 

--- a/DS3Lib/Tests/DS3LibTests/ThumbnailUploaderTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/ThumbnailUploaderTests.swift
@@ -39,8 +39,8 @@ import XCTest
         override func setUp() async throws {
             // In-memory MetadataStore bound to V6 (Phase 13.2 Plan 09 dropped
             // `thumbnailStatus`). `SyncedItem` resolves to
-            // `SyncedItemSchemaV6.SyncedItem`.
-            let schema = Schema(versionedSchema: SyncedItemSchemaV6.self)
+            // `SyncedItemSchemaV7.SyncedItem`.
+            let schema = Schema(versionedSchema: SyncedItemSchemaV7.self)
             let config = ModelConfiguration(isStoredInMemoryOnly: true)
             container = try ModelContainer(for: schema, configurations: [config])
             metadataStore = MetadataStore(modelContainer: container)


### PR DESCRIPTION
## Summary

Files.app caches per-item thumbnail responses. When the FP extension returns `.serverUnreachable` for a `fetchThumbnails` miss (item was enumerated before its sidecar landed), Files.app caches that response. The foreground backfill driver later renders the sidecar and signals the enumerator, but Files.app never invalidates the per-item cache — the thumbnail stays stuck on a generic icon until either the original's etag drifts or the user taps to download.

This PR threads a one-shot ` thumbnailReadyAt` flag through the metadata store so `WorkingSetEnumerator.enumerateChanges` can re-emit those items as `didUpdate`, which forces Files.app to refetch.

- **Schema V7** adds `thumbnailReadyAt: Date?` to `SyncedItem` via lightweight migration (default nil for existing rows). New file `SyncedItemSchemaV7.swift` keeps `SyncedItem.swift` under SwiftLint's file_length ceiling.
- **`MetadataStore.markThumbnailReady` / `clearThumbnailReady`** APIs (Sendable-safe, gated on row existence so we don't materialise empty rows).
- **`ForegroundBackfillDriver`** stamps `thumbnailReadyAt` immediately after each successful sidecar PUT, before the `signalEnumerator` calls.
- **`WorkingSetEnumerator.enumerateChanges`** picks up stamped rows, emits `didUpdate`, then clears the flag (so we don't churn on every 30 s tick). The working-set anchor hash now folds `thumbnailReadyAt` via a new `SyncAnchorHash.WorkingSetEntry` struct, so anchor drift kicks off the change cycle. `S3Enumerator` (folder anchors) is unchanged — folder thumbnails are still nudged via the explicit `signalEnumerator(for: parentId)` call.

## Migration

- V6 → V7 lightweight migration; existing rows get `thumbnailReadyAt = nil`. SwiftData `hashModifier: \"v7\"` follows the V5/V6 pattern. If migration fails the store self-heals (existing recovery path in `MetadataStore.createContainer`).
- All test fixtures bumped from `SyncedItemSchemaV6` to `V7` except the dedicated `SchemaV5MigrationTests` / `SchemaV6MigrationTests` historical guards.

## Test plan

- [ ] Fresh install on iOS: thumbnails appear after backfill without scrubbing
- [ ] In-place upgrade (V6 store): no migration crash, existing rows usable, new uploads stamp `thumbnailReadyAt`
- [ ] macOS extension build path unaffected (no `thumbnailReadyAt` writes; `WorkingSetEnumerator` still works)
- [ ] Verify Files.app re-fetches thumbnail when `enumerateChanges` reports `didUpdate` for a backfilled item

Closes #153