### PR TITLE
fix(thumbnails): flock ThumbnailRenderQueue ops to close cross-process race

### DIFF
--- a/DS3Lib/Sources/ThumbnailQueue/ThumbnailRenderQueue.swift
+++ b/DS3Lib/Sources/ThumbnailQueue/ThumbnailRenderQueue.swift
@@ -75,7 +75,7 @@ public actor ThumbnailRenderQueue {
     /// transient conditions may have changed. Within cooldown, the duplicate is
     /// a no-op so a busy folder browse does not thrash known-failing items.
     public func append(_ item: ThumbnailRenderQueueItem) {
-        withFileLock {
+        withWriteLock {
             loadIfNeeded()
             if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
                 let existing = items[idx]
@@ -103,7 +103,7 @@ public actor ThumbnailRenderQueue {
     /// Returns up to `maxItems` pending items (attempts < maxAttempts).
     /// Does NOT remove them — call `complete` or `fail` after processing.
     public func dequeue(maxItems: Int) -> [ThumbnailRenderQueueItem] {
-        withFileLock {
+        withReadLock {
             loadIfNeeded()
             return Array(items.filter { $0.attempts < Self.maxAttempts }.prefix(maxItems))
         }
@@ -111,7 +111,7 @@ public actor ThumbnailRenderQueue {
 
     /// Removes a successfully processed item from the queue.
     public func complete(_ item: ThumbnailRenderQueueItem) {
-        withFileLock {
+        withWriteLock {
             loadIfNeeded()
             items.removeAll { $0.driveID == item.driveID && $0.s3Key == item.s3Key }
             persist()
@@ -120,7 +120,7 @@ public actor ThumbnailRenderQueue {
 
     /// Bumps attempts. Items reaching `maxAttempts` are poisoned (excluded from future dequeues).
     public func fail(_ item: ThumbnailRenderQueueItem) {
-        withFileLock {
+        withWriteLock {
             loadIfNeeded()
             if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
                 items[idx].attempts += 1
@@ -131,7 +131,7 @@ public actor ThumbnailRenderQueue {
 
     /// Returns (pending, poison) counts for a specific drive.
     public func count(driveID: UUID) -> (pending: Int, poison: Int) {
-        withFileLock {
+        withReadLock {
             loadIfNeeded()
             let driveItems = items.filter { $0.driveID == driveID }
             let pending = driveItems.count(where: { $0.attempts < Self.maxAttempts })
@@ -142,7 +142,7 @@ public actor ThumbnailRenderQueue {
 
     /// Removes all items for a drive (Settings "Reset" and drive deletion).
     public func clearAll(driveID: UUID) {
-        withFileLock {
+        withWriteLock {
             loadIfNeeded()
             items.removeAll { $0.driveID == driveID }
             persist()
@@ -151,7 +151,7 @@ public actor ThumbnailRenderQueue {
 
     /// Total pending items across all drives.
     public var pendingCount: Int {
-        withFileLock {
+        withReadLock {
             loadIfNeeded()
             return items.count(where: { $0.attempts < Self.maxAttempts })
         }
@@ -196,29 +196,54 @@ public actor ThumbnailRenderQueue {
         }
     }
 
-    /// Cross-process exclusion via `flock(LOCK_EX)` on a sidecar lockfile. The
-    /// lockfile is created lazily next to the queue JSON. Without this, the
-    /// extension's append could load `[A,B]`, the main app could load+complete A
-    /// and write `[B]`, then the extension persists its stale `[A,B,C]` and
-    /// silently revives the completed item (and loses the completion record).
-    /// If the lockfile cannot be opened (no App Group container in tests, etc.)
-    /// the body still runs — actor serialization at least preserves single-process
-    /// correctness.
-    private func withFileLock<T>(_ body: () -> T) -> T {
-        guard let lockURL else { return body() }
-        let lockFD = open(lockURL.path, O_RDWR | O_CREAT, 0o644)
+    /// Cross-process exclusion for mutating ops. The lockfile is created lazily
+    /// next to the queue JSON. Without the lock, the extension's append could
+    /// load `[A,B]`, the main app could load+complete A and write `[B]`, then
+    /// the extension persists its stale `[A,B,C]` — silently reviving the
+    /// completed item.
+    ///
+    /// Fail-closed: if the lockfile cannot be opened or `flock` fails, the body
+    /// is **not** executed. Dropping a write is preferable to corrupting the
+    /// on-disk state by running unlocked.
+    private func withWriteLock(_ body: () -> Void) {
+        guard let lockFD = acquireExclusiveLock() else { return }
+        defer { releaseLock(lockFD) }
+        body()
+    }
+
+    /// Read variant. On lock failure the body still runs unlocked — readers can
+    /// tolerate a slightly stale snapshot, and `.atomic` writes guarantee they
+    /// never see a half-written file. The lock just keeps readers from observing
+    /// state that a concurrent writer is about to overwrite anyway.
+    private func withReadLock<T>(_ body: () -> T) -> T {
+        guard let lockFD = acquireExclusiveLock() else { return body() }
+        defer { releaseLock(lockFD) }
+        return body()
+    }
+
+    /// Opens the sidecar lockfile with `O_CLOEXEC` (so the fd does not leak into
+    /// any child process across `exec`) and calls `flock(LOCK_EX)`. Returns the
+    /// fd on success, or `nil` on any failure (caller decides whether that means
+    /// skip-the-write or run-unlocked).
+    private func acquireExclusiveLock() -> Int32? {
+        guard let lockURL else { return nil }
+        let lockFD = open(lockURL.path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
         guard lockFD >= 0 else {
             queueLogger.error(
                 "Queue.lock: open failed errno=\(errno, privacy: .public) path=\(lockURL.path, privacy: .public)"
             )
-            return body()
+            return nil
         }
-        defer { close(lockFD) }
         if flock(lockFD, LOCK_EX) != 0 {
             queueLogger.error("Queue.lock: flock(LOCK_EX) failed errno=\(errno, privacy: .public)")
-            return body()
+            close(lockFD)
+            return nil
         }
-        defer { _ = flock(lockFD, LOCK_UN) }
-        return body()
+        return lockFD
+    }
+
+    private func releaseLock(_ lockFD: Int32) {
+        _ = flock(lockFD, LOCK_UN)
+        close(lockFD)
     }
 }

--- a/DS3Lib/Sources/ThumbnailQueue/ThumbnailRenderQueue.swift
+++ b/DS3Lib/Sources/ThumbnailQueue/ThumbnailRenderQueue.swift
@@ -1,3 +1,4 @@
+import Darwin
 import DS3Lib
 import Foundation
 import os.log
@@ -27,9 +28,9 @@ public struct ThumbnailRenderQueueItem: Codable, Sendable, Equatable {
 /// JSON-backed persistent queue for iOS thumbnail render requests.
 ///
 /// Extension writes via `append`; main app drains via `dequeue`/`complete`/`fail`.
-/// Actor serializes within-process; `.atomic` write makes cross-process writes safe
-/// (extension appends while main app is in background; drain only runs in foreground
-/// so the two processes don't write simultaneously).
+/// Actor serializes within-process; a sidecar `flock(LOCK_EX)` lockfile serializes
+/// across processes so the extension cannot revive a completed item by writing its
+/// stale in-memory snapshot over the main app's just-persisted state.
 ///
 /// Deduplication: `append` is a no-op if (driveID, s3Key) already exists.
 /// Poison: items with `attempts >= maxAttempts` are excluded from `dequeue` results
@@ -49,16 +50,20 @@ public actor ThumbnailRenderQueue {
 
     private var items: [ThumbnailRenderQueueItem] = []
     private let fileURL: URL?
+    private let lockURL: URL?
 
     private init() {
-        fileURL = FileManager.default
+        let url = FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: DefaultSettings.appGroup)?
             .appendingPathComponent(DefaultSettings.FileNames.thumbnailRenderQueueFileName)
+        fileURL = url
+        lockURL = url?.appendingPathExtension("lock")
     }
 
     /// For testing only: backed by the given URL instead of the App Group container.
     public init(testFileURL: URL) {
         fileURL = testFileURL
+        lockURL = testFileURL.appendingPathExtension("lock")
     }
 
     // MARK: - Queue Operations
@@ -70,72 +75,86 @@ public actor ThumbnailRenderQueue {
     /// transient conditions may have changed. Within cooldown, the duplicate is
     /// a no-op so a busy folder browse does not thrash known-failing items.
     public func append(_ item: ThumbnailRenderQueueItem) {
-        loadIfNeeded()
-        if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
-            let existing = items[idx]
-            let age = Date().timeIntervalSince(existing.addedAt)
-            if existing.attempts >= Self.maxAttempts, age >= Self.revivalCooldownSeconds {
-                items[idx].attempts = 0
-                items[idx].addedAt = Date()
-                persist()
-                queueLogger.info(
-                    "Queue.append: revived poisoned \(item.s3Key, privacy: .public) — attempts reset"
-                )
-            } else {
-                queueLogger.info("Queue.append: duplicate \(item.s3Key, privacy: .public) — skip")
+        withFileLock {
+            loadIfNeeded()
+            if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
+                let existing = items[idx]
+                let age = Date().timeIntervalSince(existing.addedAt)
+                if existing.attempts >= Self.maxAttempts, age >= Self.revivalCooldownSeconds {
+                    items[idx].attempts = 0
+                    items[idx].addedAt = Date()
+                    persist()
+                    queueLogger.info(
+                        "Queue.append: revived poisoned \(item.s3Key, privacy: .public) — attempts reset"
+                    )
+                } else {
+                    queueLogger.info("Queue.append: duplicate \(item.s3Key, privacy: .public) — skip")
+                }
+                return
             }
-            return
+            items.append(item)
+            persist()
+            queueLogger.info(
+                "Queue.append: \(item.s3Key, privacy: .public) → total=\(self.items.count, privacy: .public) file=\(self.fileURL?.path ?? "nil", privacy: .public)"
+            )
         }
-        items.append(item)
-        persist()
-        queueLogger.info(
-            "Queue.append: \(item.s3Key, privacy: .public) → total=\(self.items.count, privacy: .public) file=\(self.fileURL?.path ?? "nil", privacy: .public)"
-        )
     }
 
     /// Returns up to `maxItems` pending items (attempts < maxAttempts).
     /// Does NOT remove them — call `complete` or `fail` after processing.
     public func dequeue(maxItems: Int) -> [ThumbnailRenderQueueItem] {
-        loadIfNeeded()
-        return Array(items.filter { $0.attempts < Self.maxAttempts }.prefix(maxItems))
+        withFileLock {
+            loadIfNeeded()
+            return Array(items.filter { $0.attempts < Self.maxAttempts }.prefix(maxItems))
+        }
     }
 
     /// Removes a successfully processed item from the queue.
     public func complete(_ item: ThumbnailRenderQueueItem) {
-        loadIfNeeded()
-        items.removeAll { $0.driveID == item.driveID && $0.s3Key == item.s3Key }
-        persist()
+        withFileLock {
+            loadIfNeeded()
+            items.removeAll { $0.driveID == item.driveID && $0.s3Key == item.s3Key }
+            persist()
+        }
     }
 
     /// Bumps attempts. Items reaching `maxAttempts` are poisoned (excluded from future dequeues).
     public func fail(_ item: ThumbnailRenderQueueItem) {
-        loadIfNeeded()
-        if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
-            items[idx].attempts += 1
+        withFileLock {
+            loadIfNeeded()
+            if let idx = items.firstIndex(where: { $0.driveID == item.driveID && $0.s3Key == item.s3Key }) {
+                items[idx].attempts += 1
+            }
+            persist()
         }
-        persist()
     }
 
     /// Returns (pending, poison) counts for a specific drive.
     public func count(driveID: UUID) -> (pending: Int, poison: Int) {
-        loadIfNeeded()
-        let driveItems = items.filter { $0.driveID == driveID }
-        let pending = driveItems.count(where: { $0.attempts < Self.maxAttempts })
-        let poison = driveItems.count(where: { $0.attempts >= Self.maxAttempts })
-        return (pending, poison)
+        withFileLock {
+            loadIfNeeded()
+            let driveItems = items.filter { $0.driveID == driveID }
+            let pending = driveItems.count(where: { $0.attempts < Self.maxAttempts })
+            let poison = driveItems.count(where: { $0.attempts >= Self.maxAttempts })
+            return (pending, poison)
+        }
     }
 
     /// Removes all items for a drive (Settings "Reset" and drive deletion).
     public func clearAll(driveID: UUID) {
-        loadIfNeeded()
-        items.removeAll { $0.driveID == driveID }
-        persist()
+        withFileLock {
+            loadIfNeeded()
+            items.removeAll { $0.driveID == driveID }
+            persist()
+        }
     }
 
     /// Total pending items across all drives.
     public var pendingCount: Int {
-        loadIfNeeded()
-        return items.count(where: { $0.attempts < Self.maxAttempts })
+        withFileLock {
+            loadIfNeeded()
+            return items.count(where: { $0.attempts < Self.maxAttempts })
+        }
     }
 
     // MARK: - Private
@@ -175,5 +194,31 @@ public actor ThumbnailRenderQueue {
                 "ThumbnailRenderQueue: persist failed (\(error.localizedDescription, privacy: .public))"
             )
         }
+    }
+
+    /// Cross-process exclusion via `flock(LOCK_EX)` on a sidecar lockfile. The
+    /// lockfile is created lazily next to the queue JSON. Without this, the
+    /// extension's append could load `[A,B]`, the main app could load+complete A
+    /// and write `[B]`, then the extension persists its stale `[A,B,C]` and
+    /// silently revives the completed item (and loses the completion record).
+    /// If the lockfile cannot be opened (no App Group container in tests, etc.)
+    /// the body still runs — actor serialization at least preserves single-process
+    /// correctness.
+    private func withFileLock<T>(_ body: () -> T) -> T {
+        guard let lockURL else { return body() }
+        let lockFD = open(lockURL.path, O_RDWR | O_CREAT, 0o644)
+        guard lockFD >= 0 else {
+            queueLogger.error(
+                "Queue.lock: open failed errno=\(errno, privacy: .public) path=\(lockURL.path, privacy: .public)"
+            )
+            return body()
+        }
+        defer { close(lockFD) }
+        if flock(lockFD, LOCK_EX) != 0 {
+            queueLogger.error("Queue.lock: flock(LOCK_EX) failed errno=\(errno, privacy: .public)")
+            return body()
+        }
+        defer { _ = flock(lockFD, LOCK_UN) }
+        return body()
     }
 }

--- a/DS3Lib/Tests/ThumbnailQueueTests/ThumbnailRenderQueueTests.swift
+++ b/DS3Lib/Tests/ThumbnailQueueTests/ThumbnailRenderQueueTests.swift
@@ -2,10 +2,21 @@ import ThumbnailQueue
 import XCTest
 
 final class ThumbnailRenderQueueTests: XCTestCase {
-    func testCrossProcessAppendIsVisibleToSecondInstance() async throws {
+    /// Test helper: temp queue JSON URL plus a cleanup closure that removes both
+    /// the JSON file and its `.lock` sidecar. Centralizing this prevents the
+    /// `*.json.lock` artifacts from polluting the temp directory across runs.
+    private func makeTempQueueURL() -> (url: URL, cleanup: () -> Void) {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("queue-\(UUID().uuidString).json")
-        defer { try? FileManager.default.removeItem(at: url) }
+        return (url, {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
+        })
+    }
+
+    func testCrossProcessAppendIsVisibleToSecondInstance() async throws {
+        let (url, cleanup) = makeTempQueueURL()
+        defer { cleanup() }
 
         let producer = ThumbnailRenderQueue(testFileURL: url)
         let consumer = ThumbnailRenderQueue(testFileURL: url)
@@ -26,9 +37,8 @@ final class ThumbnailRenderQueueTests: XCTestCase {
     }
 
     func testAppendRevivesPoisonedItemAfterCooldown() async throws {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("queue-\(UUID().uuidString).json")
-        defer { try? FileManager.default.removeItem(at: url) }
+        let (url, cleanup) = makeTempQueueURL()
+        defer { cleanup() }
 
         let queue = ThumbnailRenderQueue(testFileURL: url)
         let driveID = UUID()
@@ -49,9 +59,8 @@ final class ThumbnailRenderQueueTests: XCTestCase {
     }
 
     func testAppendDoesNotRevivePoisonedItemWithinCooldown() async throws {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("queue-\(UUID().uuidString).json")
-        defer { try? FileManager.default.removeItem(at: url) }
+        let (url, cleanup) = makeTempQueueURL()
+        defer { cleanup() }
 
         let queue = ThumbnailRenderQueue(testFileURL: url)
         let driveID = UUID()
@@ -75,43 +84,42 @@ final class ThumbnailRenderQueueTests: XCTestCase {
     ///   app.complete(A)    -> [] on disk
     ///   ext.append(B)      -> persists [A, B] from stale snapshot
     ///
-    /// With the lock, ext's append cannot interleave between app's load+persist,
-    /// so the append re-reads `[]` and persists `[B]`.
+    /// Single-shot `async let` only proves the lock holds for one scheduling
+    /// outcome. Loop the race many times so a regression that depends on
+    /// scheduler luck is forced to manifest.
     func testAppendDoesNotResurrectCompletedItem() async throws {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("queue-\(UUID().uuidString).json")
-        defer {
-            try? FileManager.default.removeItem(at: url)
-            try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
+        let iterations = 100
+        for _ in 0..<iterations {
+            let (url, cleanup) = makeTempQueueURL()
+            defer { cleanup() }
+
+            let ext = ThumbnailRenderQueue(testFileURL: url)
+            let app = ThumbnailRenderQueue(testFileURL: url)
+            let driveID = UUID()
+            let itemA = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/a.JPG")
+            let itemB = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/b.JPG")
+
+            // Seed disk with [A] and warm both instances' in-memory state.
+            await ext.append(itemA)
+            _ = await ext.dequeue(maxItems: 10)
+            _ = await app.dequeue(maxItems: 10)
+
+            // Race: main app completes A, extension appends B concurrently.
+            async let completeTask: Void = app.complete(itemA)
+            async let appendTask: Void = ext.append(itemB)
+            _ = await (completeTask, appendTask)
+
+            // Final state on disk must be [B]. A fresh instance ensures we read
+            // the on-disk JSON, not a cached `items` snapshot.
+            let verifier = ThumbnailRenderQueue(testFileURL: url)
+            let final = await verifier.dequeue(maxItems: 10).map(\.s3Key).sorted()
+            XCTAssertEqual(final, ["Foo/b.JPG"], "completed item must not be resurrected")
         }
-
-        let ext = ThumbnailRenderQueue(testFileURL: url)
-        let app = ThumbnailRenderQueue(testFileURL: url)
-        let driveID = UUID()
-        let itemA = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/a.JPG")
-        let itemB = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/b.JPG")
-
-        // Seed disk with [A] and warm both instances' in-memory state to [A].
-        await ext.append(itemA)
-        _ = await ext.dequeue(maxItems: 10)
-        _ = await app.dequeue(maxItems: 10)
-
-        // Race: main app completes A, extension appends B from its snapshot.
-        async let completeTask: Void = app.complete(itemA)
-        async let appendTask: Void = ext.append(itemB)
-        _ = await (completeTask, appendTask)
-
-        // Final state on disk must be [B]. Read from a fresh instance so we
-        // exercise the on-disk JSON, not any cached `items`.
-        let verifier = ThumbnailRenderQueue(testFileURL: url)
-        let final = await verifier.dequeue(maxItems: 10)
-        XCTAssertEqual(final.map(\.s3Key), ["Foo/b.JPG"], "completed item must not be resurrected")
     }
 
     func testCompleteFromOneInstanceVisibleToOther() async throws {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("queue-\(UUID().uuidString).json")
-        defer { try? FileManager.default.removeItem(at: url) }
+        let (url, cleanup) = makeTempQueueURL()
+        defer { cleanup() }
 
         let a = ThumbnailRenderQueue(testFileURL: url)
         let b = ThumbnailRenderQueue(testFileURL: url)

--- a/DS3Lib/Tests/ThumbnailQueueTests/ThumbnailRenderQueueTests.swift
+++ b/DS3Lib/Tests/ThumbnailQueueTests/ThumbnailRenderQueueTests.swift
@@ -67,6 +67,47 @@ final class ThumbnailRenderQueueTests: XCTestCase {
         XCTAssertTrue(dequeued.isEmpty, "poisoned item still within cooldown should remain poisoned")
     }
 
+    /// Regression for #152: extension's stale in-memory snapshot must not
+    /// resurrect an item the main app already completed.
+    ///
+    /// Before the flock fix, this sequence would leave A in the queue:
+    ///   ext.loadIfNeeded() -> [A]
+    ///   app.complete(A)    -> [] on disk
+    ///   ext.append(B)      -> persists [A, B] from stale snapshot
+    ///
+    /// With the lock, ext's append cannot interleave between app's load+persist,
+    /// so the append re-reads `[]` and persists `[B]`.
+    func testAppendDoesNotResurrectCompletedItem() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("queue-\(UUID().uuidString).json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: url.appendingPathExtension("lock"))
+        }
+
+        let ext = ThumbnailRenderQueue(testFileURL: url)
+        let app = ThumbnailRenderQueue(testFileURL: url)
+        let driveID = UUID()
+        let itemA = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/a.JPG")
+        let itemB = ThumbnailRenderQueueItem(driveID: driveID, s3Key: "Foo/b.JPG")
+
+        // Seed disk with [A] and warm both instances' in-memory state to [A].
+        await ext.append(itemA)
+        _ = await ext.dequeue(maxItems: 10)
+        _ = await app.dequeue(maxItems: 10)
+
+        // Race: main app completes A, extension appends B from its snapshot.
+        async let completeTask: Void = app.complete(itemA)
+        async let appendTask: Void = ext.append(itemB)
+        _ = await (completeTask, appendTask)
+
+        // Final state on disk must be [B]. Read from a fresh instance so we
+        // exercise the on-disk JSON, not any cached `items`.
+        let verifier = ThumbnailRenderQueue(testFileURL: url)
+        let final = await verifier.dequeue(maxItems: 10)
+        XCTAssertEqual(final.map(\.s3Key), ["Foo/b.JPG"], "completed item must not be resurrected")
+    }
+
     func testCompleteFromOneInstanceVisibleToOther() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("queue-\(UUID().uuidString).json")


### PR DESCRIPTION
Closes #152.

## Summary
- Cross-process race in `ThumbnailRenderQueue`: extension's `append` could revive an item the main app just `complete`d, because actor serialization + `.atomic` write don't prevent two-process read-then-write interleave.
- Each public op now wraps load+mutate+persist in `flock(LOCK_EX)` on sidecar lockfile (`<queue>.lock`) next to the queue JSON in the App Group container.
- Lock helper degrades gracefully: if the lockfile cannot be opened, body still runs — actor serialization preserves single-process correctness.

## Race scenario fixed
1. ext `loadIfNeeded()` → `[A]`
2. app `complete(A)` → persists `[]`
3. ext `append(B)` → would persist `[A, B]` from stale snapshot — silently revives A, loses completion

With flock, ext's append cannot interleave between app's load and persist.

## Test plan
- [x] Added `testAppendDoesNotResurrectCompletedItem` regression covering the exact race.
- [x] All 5 `ThumbnailRenderQueueTests` pass (4 existing + 1 new).
- [x] `swift build --target ThumbnailQueue` clean.
- [x] swiftlint: only pre-existing line-length warnings.