### PR TITLE
feat: .ds3keep folder marker (Phase A — closes #165)

### DIFF
--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -206,6 +206,9 @@
 		FCB705EB41FEBBE14B166EA4 /* S3ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154C907172E95FD06C8615BD /* S3ItemTests.swift */; };
 		A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */; };
 		A1D5400101000000A1D54001 /* FolderMarkerEnumeratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */; };
+		A1D5410101000000A1D54101 /* S3LibFolderMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */; };
+		A1D5410201000000A1D54102 /* S3LibFolderMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */; };
+		A1D5420101000000A1D54201 /* FolderMarkerCopyDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -285,6 +288,8 @@
 		154C907172E95FD06C8615BD /* S3ItemTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3ItemTests.swift; sourceTree = "<group>"; };
 		A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3ItemWireKeyTests.swift; sourceTree = "<group>"; };
 		A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerEnumeratorTests.swift; sourceTree = "<group>"; };
+		A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3LibFolderMarker.swift; sourceTree = "<group>"; };
+		A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerCopyDeleteTests.swift; sourceTree = "<group>"; };
 		1823D7B17115B90E2FD9181D /* IOSSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSSettingsView.swift; sourceTree = "<group>"; };
 		2C71C4FFADB8DDE9EC58F5E2 /* SyncSetupViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncSetupViewModelTests.swift; sourceTree = "<group>"; };
 		39439872734512266C6F7F51 /* IOSMainTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSMainTabView.swift; sourceTree = "<group>"; };
@@ -689,6 +694,7 @@
 				154C907172E95FD06C8615BD /* S3ItemTests.swift */,
 				A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */,
 				A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */,
+				A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */,
 				A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */,
 				A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */,
 				A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */,
@@ -1007,6 +1013,7 @@
 				A132010001000000A1320100 /* ThumbnailFallbackLimiter.swift */,
 				A141010001000000A1410100 /* ThumbnailUploadLimiter.swift */,
 				D540029D2B5EAEB000B54E97 /* S3Lib.swift */,
+				A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */,
 				A10203032F6300000042AD93 /* WorkingSetEnumerator.swift */,
 				D5A4E0AA2B630A9800D7560B /* NotificationsManager.swift */,
 				D5A222832B5721CC00F1413B /* DS3DriveProvider.xcassets */,
@@ -1383,6 +1390,7 @@
 				00A29005A29C16FC0B76EE84 /* FileProviderExtension+Credentials.swift in Sources */,
 				ADDE1D3663E34D3A2797278B /* FileProviderExtension+CustomActions.swift in Sources */,
 				B0A1F2E3C4D5678901234567 /* PresignNotificationHelper.swift in Sources */,
+				A1D5410101000000A1D54101 /* S3LibFolderMarker.swift in Sources */,
 				37FF0E6BEF0FCD66E7FE33B2 /* FileProviderExtension+Delete.swift in Sources */,
 				940CBDCF75DFEF60358EC4C9 /* FileProviderExtension+Errors.swift in Sources */,
 				6CF01D385F9585BD7C7C9677 /* FileProviderExtension+Lifecycle.swift in Sources */,
@@ -1416,6 +1424,7 @@
 				FCB705EB41FEBBE14B166EA4 /* S3ItemTests.swift in Sources */,
 				A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */,
 				A1D5400101000000A1D54001 /* FolderMarkerEnumeratorTests.swift in Sources */,
+				A1D5420101000000A1D54201 /* FolderMarkerCopyDeleteTests.swift in Sources */,
 				7FE55AB1B1E1D9BE5865060E /* TestFixtures.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1500,6 +1509,7 @@
 				D5A222492B57211500F1413B /* FileProviderExtension.swift in Sources */,
 				CE070E323BF098B9EFD808B7 /* FileProviderExtension+CustomActions.swift in Sources */,
 				B0A1F2E3C4D5678901234568 /* PresignNotificationHelper.swift in Sources */,
+				A1D5410201000000A1D54102 /* S3LibFolderMarker.swift in Sources */,
 				EA386D36D3094AAD861680EF /* FileProviderExtension+Create.swift in Sources */,
 				AA5925C80F664603A033C348 /* FileProviderExtension+Credentials.swift in Sources */,
 				A578B1B62D014D6E9BE6EA75 /* FileProviderExtension+Delete.swift in Sources */,

--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		F75002765637761956B1A1A7 /* IOSAppRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614D568B5F5473C487A2AF1A /* IOSAppRootView.swift */; };
 		F925913B1F8DAB84DB7C0A4D /* DS3ThumbnailRendering in Frameworks */ = {isa = PBXBuildFile; productRef = 973E24C04E44F7378078B4BD /* DS3ThumbnailRendering */; };
 		FCB705EB41FEBBE14B166EA4 /* S3ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154C907172E95FD06C8615BD /* S3ItemTests.swift */; };
+		A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -281,6 +282,7 @@
 		0EFDB9DD618CCBAF1879D46E /* DS3DriveProviderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DS3DriveProviderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F291137750247769947C80E /* ThumbnailBackfillTaskHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailBackfillTaskHandler.swift; sourceTree = "<group>"; };
 		154C907172E95FD06C8615BD /* S3ItemTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3ItemTests.swift; sourceTree = "<group>"; };
+		A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3ItemWireKeyTests.swift; sourceTree = "<group>"; };
 		1823D7B17115B90E2FD9181D /* IOSSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSSettingsView.swift; sourceTree = "<group>"; };
 		2C71C4FFADB8DDE9EC58F5E2 /* SyncSetupViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncSetupViewModelTests.swift; sourceTree = "<group>"; };
 		39439872734512266C6F7F51 /* IOSMainTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSMainTabView.swift; sourceTree = "<group>"; };
@@ -683,6 +685,7 @@
 			children = (
 				496BF81D5E82D003EAE34C62 /* S3EnumeratorTests.swift */,
 				154C907172E95FD06C8615BD /* S3ItemTests.swift */,
+				A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */,
 				A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */,
 				A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */,
 				A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */,
@@ -1408,6 +1411,7 @@
 				DF9BD918ADDC4D8FA46F2445 /* TrashS3Enumerator.swift in Sources */,
 				D85CF5F485CD7C6EF799921B /* S3EnumeratorTests.swift in Sources */,
 				FCB705EB41FEBBE14B166EA4 /* S3ItemTests.swift in Sources */,
+				A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */,
 				7FE55AB1B1E1D9BE5865060E /* TestFixtures.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		F925913B1F8DAB84DB7C0A4D /* DS3ThumbnailRendering in Frameworks */ = {isa = PBXBuildFile; productRef = 973E24C04E44F7378078B4BD /* DS3ThumbnailRendering */; };
 		FCB705EB41FEBBE14B166EA4 /* S3ItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154C907172E95FD06C8615BD /* S3ItemTests.swift */; };
 		A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */; };
+		A1D5400101000000A1D54001 /* FolderMarkerEnumeratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -283,6 +284,7 @@
 		0F291137750247769947C80E /* ThumbnailBackfillTaskHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThumbnailBackfillTaskHandler.swift; sourceTree = "<group>"; };
 		154C907172E95FD06C8615BD /* S3ItemTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3ItemTests.swift; sourceTree = "<group>"; };
 		A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3ItemWireKeyTests.swift; sourceTree = "<group>"; };
+		A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerEnumeratorTests.swift; sourceTree = "<group>"; };
 		1823D7B17115B90E2FD9181D /* IOSSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSSettingsView.swift; sourceTree = "<group>"; };
 		2C71C4FFADB8DDE9EC58F5E2 /* SyncSetupViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncSetupViewModelTests.swift; sourceTree = "<group>"; };
 		39439872734512266C6F7F51 /* IOSMainTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSMainTabView.swift; sourceTree = "<group>"; };
@@ -686,6 +688,7 @@
 				496BF81D5E82D003EAE34C62 /* S3EnumeratorTests.swift */,
 				154C907172E95FD06C8615BD /* S3ItemTests.swift */,
 				A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */,
+				A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */,
 				A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */,
 				A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */,
 				A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */,
@@ -1412,6 +1415,7 @@
 				D85CF5F485CD7C6EF799921B /* S3EnumeratorTests.swift in Sources */,
 				FCB705EB41FEBBE14B166EA4 /* S3ItemTests.swift in Sources */,
 				A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */,
+				A1D5400101000000A1D54001 /* FolderMarkerEnumeratorTests.swift in Sources */,
 				7FE55AB1B1E1D9BE5865060E /* TestFixtures.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DS3DriveProvider/S3Item.swift
+++ b/DS3DriveProvider/S3Item.swift
@@ -97,6 +97,21 @@ class S3Item: NSObject, NSFileProviderItem, NSFileProviderItemDecorating, @unche
         return identifier.rawValue
     }
 
+    /// The S3 key to use when PUTting this item to S3.
+    /// - For files, this is the identifier's raw value (the object key).
+    /// - For folders, this is the hidden `.ds3keep` marker key inside the
+    ///   folder. The identifier itself stays `<folder>/` so
+    ///   `parentItemIdentifier`, `isFolder`, etc. continue to work — only the
+    ///   on-the-wire PUT target changes. Phase A.
+    ///
+    /// Forced-trash semantics already live in `s3Key`; this property is the
+    /// equivalent boundary for the create/upload path.
+    var wireKey: String {
+        isFolder
+            ? S3PathUtils.markerKey(forFolderKey: identifier.rawValue)
+            : identifier.rawValue
+    }
+
     var parentItemIdentifier: NSFileProviderItemIdentifier {
         if identifier == .trashContainer {
             return .rootContainer

--- a/DS3DriveProvider/S3Lib+Transfers.swift
+++ b/DS3DriveProvider/S3Lib+Transfers.swift
@@ -188,7 +188,9 @@ extension S3Lib {
         fileURL: URL? = nil,
         withProgress progress: Progress? = nil
     ) async throws -> String? {
-        let key = s3Item.itemIdentifier.rawValue
+        // Phase A: folder PUTs target the hidden .ds3keep marker; files keep
+        // their identifier key. See `S3Item.wireKey`.
+        let key = s3Item.wireKey
         let size: Int64
 
         if let fileURL {

--- a/DS3DriveProvider/S3Lib+Transfers.swift
+++ b/DS3DriveProvider/S3Lib+Transfers.swift
@@ -189,7 +189,9 @@ extension S3Lib {
         withProgress progress: Progress? = nil
     ) async throws -> String? {
         // Phase A: folder PUTs target the hidden .ds3keep marker; files keep
-        // their identifier key. See `S3Item.wireKey`.
+        // their identifier key. See `S3Item.wireKey`. Folders never go multipart
+        // (zero bytes < 5MB threshold), so putS3ItemMultipart stays on the
+        // identifier key.
         let key = s3Item.wireKey
         let size: Int64
 

--- a/DS3DriveProvider/S3Lib.swift
+++ b/DS3DriveProvider/S3Lib.swift
@@ -395,9 +395,16 @@ actor S3Lib {
         } while continuationToken != nil
 
         if items.isEmpty {
-            self.logger.debug("Copying enclosing folder \(sourcePrefix, privacy: .public)")
-            let newKey = s3Item.identifier.rawValue.replacingOccurrences(of: sourcePrefix, with: destinationPrefix)
-            try await self.copyS3Item(s3Item, toKey: newKey, withProgress: progress, force: true)
+            // Phase A: an empty source folder has at most a `.ds3keep` marker.
+            // Copy it to the destination, or PUT a fresh marker if the source
+            // has none (legacy `<folder>/` placeholder or fresh-empty folder).
+            try await materializeEmptyFolderMarker(
+                sourcePrefix: sourcePrefix,
+                destinationPrefix: destinationPrefix,
+                bucket: s3Item.drive.syncAnchor.bucket.name,
+                client: self.client,
+                logger: self.logger
+            )
         }
     }
 }

--- a/DS3DriveProvider/S3LibFolderMarker.swift
+++ b/DS3DriveProvider/S3LibFolderMarker.swift
@@ -1,0 +1,47 @@
+import DS3Lib
+import Foundation
+import os.log
+
+/// Materializes a `.ds3keep` marker at `destinationPrefix` for an empty
+/// folder copy.
+///
+/// Phase A: empty source folders have at most a `.ds3keep` marker.
+/// - If the source has a marker, copy it to the destination.
+/// - If the source has no marker (legacy `<folder>/` zero-byte placeholder
+///   or fresh empty folder created by another client), PUT a fresh marker
+///   at the destination so the destination prefix survives delimited list.
+///
+/// `client` must conform to `DS3S3ClientProtocol` so tests can inject a
+/// mock without instantiating Soto's `AWSClient`. Production calls pass
+/// the concrete `DS3S3Client` from `S3Lib`.
+func materializeEmptyFolderMarker(
+    sourcePrefix: String,
+    destinationPrefix: String,
+    bucket: String,
+    client: any DS3S3ClientProtocol,
+    logger: os.Logger
+) async throws {
+    let sourceMarker = S3PathUtils.markerKey(forFolderKey: sourcePrefix)
+    let destMarker = S3PathUtils.markerKey(forFolderKey: destinationPrefix)
+    logger.debug(
+        "Copying empty-folder marker \(sourceMarker, privacy: .public) -> \(destMarker, privacy: .public)"
+    )
+    do {
+        try await client.copyObject(
+            bucket: bucket,
+            sourceKey: sourceMarker,
+            destinationKey: destMarker,
+            metadata: nil
+        )
+    } catch where DS3S3Client.isNotFoundError(error) {
+        logger.debug(
+            "Source marker missing for \(sourcePrefix, privacy: .public); creating fresh marker at destination"
+        )
+        _ = try await client.putObject(
+            bucket: bucket,
+            key: destMarker,
+            fileURL: nil,
+            onProgress: nil
+        )
+    }
+}

--- a/DS3DriveProviderTests/FolderMarkerCopyDeleteTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerCopyDeleteTests.swift
@@ -24,6 +24,7 @@ final class FolderMarkerCopyDeleteTests: XCTestCase {
         )
         XCTAssertEqual(mock.copiedFrom, "prefix/src/.ds3keep")
         XCTAssertEqual(mock.copiedTo, "prefix/dst/.ds3keep")
+        XCTAssertEqual(mock.copiedBucket, "bucket")
         XCTAssertNil(mock.putKey, "PUT must not be issued when copy succeeded")
     }
 
@@ -59,8 +60,32 @@ final class FolderMarkerCopyDeleteTests: XCTestCase {
                 logger: logger()
             )
             XCTFail("Expected non-NotFound error to propagate")
-        } catch {
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "S3", "Original error domain must survive")
+            XCTAssertEqual(error.code, 500, "Original error code must survive")
             XCTAssertNil(mock.putKey, "PUT must not be issued on non-NotFound error")
+        }
+    }
+
+    func testFallbackPutFailurePropagates() async {
+        let mock = MarkerCopyMockS3Client()
+        mock.copyObjectError = S3ErrorType.noSuchKey
+        mock.putObjectError = NSError(
+            domain: "S3", code: 403,
+            userInfo: [NSLocalizedDescriptionKey: "AccessDenied"]
+        )
+        do {
+            try await materializeEmptyFolderMarker(
+                sourcePrefix: "prefix/src/",
+                destinationPrefix: "prefix/dst/",
+                bucket: "bucket",
+                client: mock,
+                logger: logger()
+            )
+            XCTFail("Expected PUT failure to propagate after copy NotFound")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "S3")
+            XCTAssertEqual(error.code, 403)
         }
     }
 }
@@ -72,6 +97,7 @@ final class FolderMarkerCopyDeleteTests: XCTestCase {
 /// methods stubbed to throw or return empty — see `HookMockS3Client` in
 /// `UploadHookTests.swift` for the canonical stub list.
 final class MarkerCopyMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
+    var copiedBucket: String?
     var copiedFrom: String?
     var copiedTo: String?
     var copyObjectError: Error?
@@ -104,10 +130,11 @@ final class MarkerCopyMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
     }
 
     func copyObject(
-        bucket _: String, sourceKey: String,
+        bucket: String, sourceKey: String,
         destinationKey: String, metadata _: [String: String]?
     ) async throws {
         if let copyObjectError { throw copyObjectError }
+        copiedBucket = bucket
         copiedFrom = sourceKey
         copiedTo = destinationKey
     }

--- a/DS3DriveProviderTests/FolderMarkerCopyDeleteTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerCopyDeleteTests.swift
@@ -1,0 +1,168 @@
+@testable import DS3Lib
+import FileProvider
+import Foundation
+import os.log
+import SotoS3
+import XCTest
+
+/// Phase A: empty-folder copy must produce a `.ds3keep` marker at the
+/// destination, regardless of whether the source had one (new) or not
+/// (legacy `<folder>/` placeholder).
+final class FolderMarkerCopyDeleteTests: XCTestCase {
+    private func logger() -> os.Logger {
+        os.Logger(subsystem: "io.cubbit.DS3Drive.tests", category: "marker-copy")
+    }
+
+    func testCopySourceMarkerWhenItExists() async throws {
+        let mock = MarkerCopyMockS3Client()
+        try await materializeEmptyFolderMarker(
+            sourcePrefix: "prefix/src/",
+            destinationPrefix: "prefix/dst/",
+            bucket: "bucket",
+            client: mock,
+            logger: logger()
+        )
+        XCTAssertEqual(mock.copiedFrom, "prefix/src/.ds3keep")
+        XCTAssertEqual(mock.copiedTo, "prefix/dst/.ds3keep")
+        XCTAssertNil(mock.putKey, "PUT must not be issued when copy succeeded")
+    }
+
+    func testFallsBackToPutWhenSourceMarkerMissing() async throws {
+        let mock = MarkerCopyMockS3Client()
+        // Soto's canonical NoSuchKey — `DS3S3Client.isNotFoundError(_:)` recovers
+        // `errorCode == "NoSuchKey"` via the `AWSErrorType` conformance.
+        mock.copyObjectError = S3ErrorType.noSuchKey
+        try await materializeEmptyFolderMarker(
+            sourcePrefix: "prefix/src/",
+            destinationPrefix: "prefix/dst/",
+            bucket: "bucket",
+            client: mock,
+            logger: logger()
+        )
+        XCTAssertEqual(
+            mock.putKey,
+            "prefix/dst/.ds3keep",
+            "Fallback PUT must target the destination marker key"
+        )
+        XCTAssertNil(mock.putFileURL, "Marker PUT must be zero-byte (fileURL nil)")
+    }
+
+    func testReThrowsNonNotFoundError() async {
+        let mock = MarkerCopyMockS3Client()
+        mock.copyObjectError = NSError(domain: "S3", code: 500, userInfo: nil)
+        do {
+            try await materializeEmptyFolderMarker(
+                sourcePrefix: "prefix/src/",
+                destinationPrefix: "prefix/dst/",
+                bucket: "bucket",
+                client: mock,
+                logger: logger()
+            )
+            XCTFail("Expected non-NotFound error to propagate")
+        } catch {
+            XCTAssertNil(mock.putKey, "PUT must not be issued on non-NotFound error")
+        }
+    }
+}
+
+// MARK: - Test mock
+
+/// Minimal `DS3S3ClientProtocol` mock that records `copyObject` and
+/// `putObject` calls. Configurable error injection. All other protocol
+/// methods stubbed to throw or return empty — see `HookMockS3Client` in
+/// `UploadHookTests.swift` for the canonical stub list.
+final class MarkerCopyMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
+    var copiedFrom: String?
+    var copiedTo: String?
+    var copyObjectError: Error?
+
+    var putKey: String?
+    var putFileURL: URL?
+    var putObjectError: Error?
+
+    func listBuckets() async throws -> [(name: String, creationDate: Date?)] {
+        []
+    }
+
+    func listObjects(
+        bucket _: String, prefix _: String?, delimiter _: String?,
+        maxKeys _: Int?, continuationToken _: String?
+    ) async throws -> S3ListingResult {
+        S3ListingResult(objects: [], commonPrefixes: [], nextContinuationToken: nil, isTruncated: false)
+    }
+
+    func headObject(bucket _: String, key _: String) async throws -> S3ObjectMetadata {
+        throw DS3ClientError.parseError
+    }
+
+    func deleteObject(bucket _: String, key _: String) async throws {
+        // No-op stub — marker-copy tests don't observe delete.
+    }
+
+    func deleteObjects(bucket _: String, keys _: [String]) async throws -> Int {
+        0
+    }
+
+    func copyObject(
+        bucket _: String, sourceKey: String,
+        destinationKey: String, metadata _: [String: String]?
+    ) async throws {
+        if let copyObjectError { throw copyObjectError }
+        copiedFrom = sourceKey
+        copiedTo = destinationKey
+    }
+
+    func getObject(
+        bucket _: String, key _: String,
+        toFile _: URL, onProgress _: TransferProgressHandler?
+    ) async throws -> S3DownloadResult {
+        throw DS3ClientError.parseError
+    }
+
+    func getObjectData(bucket _: String, key _: String) async throws -> Data {
+        Data()
+    }
+
+    func putObject(
+        bucket _: String, key: String,
+        fileURL: URL?, onProgress _: TransferProgressHandler?
+    ) async throws -> String? {
+        if let putObjectError { throw putObjectError }
+        putKey = key
+        putFileURL = fileURL
+        return "mock-etag"
+    }
+
+    func putObjectData(
+        bucket _: String, key _: String,
+        data _: Data, metadata _: [String: String]?
+    ) async throws -> String? {
+        "mock-etag"
+    }
+
+    func createMultipartUpload(bucket _: String, key _: String) async throws -> String {
+        "mock-upload-id"
+    }
+
+    func uploadPart(
+        bucket _: String, key _: String, uploadId _: String,
+        partNumber: Int, data _: Data
+    ) async throws -> CompletedPartResult {
+        CompletedPartResult(partNumber: partNumber, etag: "etag-part-\(partNumber)")
+    }
+
+    func completeMultipartUpload(
+        bucket _: String, key _: String, uploadId _: String,
+        parts _: [(partNumber: Int, etag: String)]
+    ) async throws -> MultipartCompleteResult {
+        MultipartCompleteResult(etag: "mock-final-etag")
+    }
+
+    func abortMultipartUpload(bucket _: String, key _: String, uploadId _: String) async throws {
+        // No-op stub — marker-copy tests don't observe multipart.
+    }
+
+    func shutdown() throws {
+        // No-op stub — mock has no resources to release.
+    }
+}

--- a/DS3DriveProviderTests/FolderMarkerEnumeratorTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerEnumeratorTests.swift
@@ -1,0 +1,63 @@
+@testable import DS3Lib
+import FileProvider
+import XCTest
+
+/// Phase A regression: ensure `.ds3keep` marker objects are filtered out
+/// of user-visible enumerations and never get synthesized into virtual
+/// folders. The marker's job is to materialize the enclosing folder as
+/// a CommonPrefix — not to appear as a child.
+final class FolderMarkerEnumeratorTests: XCTestCase {
+    // MARK: - S3KeyFilter behavior
+
+    func testIsUserVisibleHidesMarker() {
+        XCTAssertFalse(
+            S3KeyFilter.isUserVisible(key: "prefix/photos/.ds3keep", drivePrefix: "prefix/")
+        )
+    }
+
+    func testIsUserVisibleShowsLegacyFolderPlaceholder() {
+        XCTAssertTrue(
+            S3KeyFilter.isUserVisible(key: "prefix/photos/", drivePrefix: "prefix/")
+        )
+    }
+
+    func testIsUserVisibleShowsRegularFile() {
+        XCTAssertTrue(
+            S3KeyFilter.isUserVisible(key: "prefix/photos/cat.jpg", drivePrefix: "prefix/")
+        )
+    }
+
+    // MARK: - synthesizeVirtualFolders behavior
+
+    func testSynthesizeVirtualFoldersDoesNotProduceMarkerAsFolder() {
+        let drive = ProviderTestFixtures.makeDrive()
+        let items = [
+            ProviderTestFixtures.makeItem(key: "prefix/photos/.ds3keep", drive: drive)
+        ]
+        let virtual = S3Enumerator.synthesizeVirtualFolders(
+            from: items, drive: drive, prefix: "prefix/"
+        )
+        let synthesizedKeys = Set(virtual.map(\.itemIdentifier.rawValue))
+        XCTAssertFalse(
+            synthesizedKeys.contains("prefix/photos/.ds3keep/"),
+            "Marker must not be synthesized as a folder"
+        )
+    }
+
+    func testSynthesizeVirtualFoldersSurfacesEnclosingFolderFromMarker() {
+        // The marker exists *inside* the folder; the folder prefix itself
+        // is what should surface when synthesizing virtual folders.
+        let drive = ProviderTestFixtures.makeDrive()
+        let items = [
+            ProviderTestFixtures.makeItem(key: "prefix/photos/.ds3keep", drive: drive)
+        ]
+        let virtual = S3Enumerator.synthesizeVirtualFolders(
+            from: items, drive: drive, prefix: "prefix/"
+        )
+        let synthesizedKeys = Set(virtual.map(\.itemIdentifier.rawValue))
+        XCTAssertTrue(
+            synthesizedKeys.contains("prefix/photos/"),
+            "Folder containing the marker must surface as a virtual folder; got \(synthesizedKeys)"
+        )
+    }
+}

--- a/DS3DriveProviderTests/FolderMarkerEnumeratorTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerEnumeratorTests.swift
@@ -2,33 +2,12 @@
 import FileProvider
 import XCTest
 
-/// Phase A regression: ensure `.ds3keep` marker objects are filtered out
-/// of user-visible enumerations and never get synthesized into virtual
-/// folders. The marker's job is to materialize the enclosing folder as
-/// a CommonPrefix — not to appear as a child.
+/// Phase A regression: the `.ds3keep` marker filename must never be
+/// surfaced as a virtual folder by `S3Enumerator.synthesizeVirtualFolders`.
+/// Filter behavior is covered by `S3KeyFilterTests` in DS3LibTests;
+/// general synthesizer behavior is covered by `S3EnumeratorTests`.
+/// This file pins the marker-specific negative invariant.
 final class FolderMarkerEnumeratorTests: XCTestCase {
-    // MARK: - S3KeyFilter behavior
-
-    func testIsUserVisibleHidesMarker() {
-        XCTAssertFalse(
-            S3KeyFilter.isUserVisible(key: "prefix/photos/.ds3keep", drivePrefix: "prefix/")
-        )
-    }
-
-    func testIsUserVisibleShowsLegacyFolderPlaceholder() {
-        XCTAssertTrue(
-            S3KeyFilter.isUserVisible(key: "prefix/photos/", drivePrefix: "prefix/")
-        )
-    }
-
-    func testIsUserVisibleShowsRegularFile() {
-        XCTAssertTrue(
-            S3KeyFilter.isUserVisible(key: "prefix/photos/cat.jpg", drivePrefix: "prefix/")
-        )
-    }
-
-    // MARK: - synthesizeVirtualFolders behavior
-
     func testSynthesizeVirtualFoldersDoesNotProduceMarkerAsFolder() {
         let drive = ProviderTestFixtures.makeDrive()
         let items = [
@@ -40,24 +19,7 @@ final class FolderMarkerEnumeratorTests: XCTestCase {
         let synthesizedKeys = Set(virtual.map(\.itemIdentifier.rawValue))
         XCTAssertFalse(
             synthesizedKeys.contains("prefix/photos/.ds3keep/"),
-            "Marker must not be synthesized as a folder"
-        )
-    }
-
-    func testSynthesizeVirtualFoldersSurfacesEnclosingFolderFromMarker() {
-        // The marker exists *inside* the folder; the folder prefix itself
-        // is what should surface when synthesizing virtual folders.
-        let drive = ProviderTestFixtures.makeDrive()
-        let items = [
-            ProviderTestFixtures.makeItem(key: "prefix/photos/.ds3keep", drive: drive)
-        ]
-        let virtual = S3Enumerator.synthesizeVirtualFolders(
-            from: items, drive: drive, prefix: "prefix/"
-        )
-        let synthesizedKeys = Set(virtual.map(\.itemIdentifier.rawValue))
-        XCTAssertTrue(
-            synthesizedKeys.contains("prefix/photos/"),
-            "Folder containing the marker must surface as a virtual folder; got \(synthesizedKeys)"
+            "Marker filename must not be synthesized as a folder"
         )
     }
 }

--- a/DS3DriveProviderTests/S3ItemWireKeyTests.swift
+++ b/DS3DriveProviderTests/S3ItemWireKeyTests.swift
@@ -1,0 +1,35 @@
+@testable import DS3Lib
+import FileProvider
+import XCTest
+
+/// Phase A: `S3Item.wireKey` rewrites folder PUTs to the `.ds3keep` marker
+/// while leaving file PUTs and the in-memory identifier untouched.
+final class S3ItemWireKeyTests: XCTestCase {
+    func testWireKeyForFolderRewritesToMarker() {
+        let drive = ProviderTestFixtures.makeDrive()
+        let folder = ProviderTestFixtures.makeItem(key: "prefix/new-folder/", drive: drive)
+        XCTAssertEqual(folder.wireKey, "prefix/new-folder/.ds3keep")
+    }
+
+    func testWireKeyForFileIsIdentifierKey() {
+        let drive = ProviderTestFixtures.makeDrive()
+        let file = ProviderTestFixtures.makeItem(key: "prefix/photo.jpg", drive: drive)
+        XCTAssertEqual(file.wireKey, "prefix/photo.jpg")
+    }
+
+    func testWireKeyDoesNotMutateIdentifier() {
+        // The identifier MUST remain "<folder>/" even after computing wireKey.
+        // Identifier semantics (parentItemIdentifier, isFolder, etc.) depend on it.
+        let drive = ProviderTestFixtures.makeDrive()
+        let folder = ProviderTestFixtures.makeItem(key: "prefix/keep/", drive: drive)
+        _ = folder.wireKey
+        XCTAssertEqual(folder.itemIdentifier.rawValue, "prefix/keep/")
+        XCTAssertTrue(folder.isFolder)
+    }
+
+    func testWireKeyForNestedFolder() {
+        let drive = ProviderTestFixtures.makeDrive()
+        let folder = ProviderTestFixtures.makeItem(key: "prefix/parent/child/", drive: drive)
+        XCTAssertEqual(folder.wireKey, "prefix/parent/child/.ds3keep")
+    }
+}

--- a/DS3DriveProviderTests/S3ItemWireKeyTests.swift
+++ b/DS3DriveProviderTests/S3ItemWireKeyTests.swift
@@ -25,6 +25,9 @@ final class S3ItemWireKeyTests: XCTestCase {
         _ = folder.wireKey
         XCTAssertEqual(folder.itemIdentifier.rawValue, "prefix/keep/")
         XCTAssertTrue(folder.isFolder)
+        // Parent resolution must still see the folder under the drive prefix
+        // (real invariant — not just identifier text equality).
+        XCTAssertEqual(folder.parentItemIdentifier, .rootContainer)
     }
 
     func testWireKeyForNestedFolder() {

--- a/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
+++ b/DS3Lib/Sources/DS3Lib/Constants/DefaultSettings.swift
@@ -210,6 +210,12 @@ public enum DefaultSettings {
         /// S3 key prefix used for the thumbnails folder inside each drive's prefix.
         public static let thumbnailsPrefix = ".thumbnails/"
 
+        /// Hidden marker filename used to materialize an empty folder on S3.
+        /// Folder create PUTs `<folder>/.ds3keep` (zero bytes) instead of the
+        /// legacy zero-byte `<folder>/` placeholder. The marker is hidden from
+        /// user enumerations via `S3KeyFilter.isUserVisible`. Phase A.
+        public static let markerFileName = ".ds3keep"
+
         /// Maximum long-edge dimension for generated thumbnails (pixels).
         public static let thumbnailMaxDimension = 512
 

--- a/DS3Lib/Sources/DS3Lib/Utils/S3KeyFilter.swift
+++ b/DS3Lib/Sources/DS3Lib/Utils/S3KeyFilter.swift
@@ -2,8 +2,9 @@ import Foundation
 
 /// Centralized filter that determines whether an S3 key represents user-visible content.
 /// Routes through S3PathUtils predicates for .trash/ and .thumbnails/ hidden prefixes,
-/// and rejects keys that begin with an Apple File Provider sentinel raw value (residue
-/// from a pre-fix bug where `parentItemIdentifier.rawValue` was concatenated into S3 keys).
+/// hides `.ds3keep` folder markers (Phase A — empty-folder placeholder), and rejects
+/// keys that begin with an Apple File Provider sentinel raw value (residue from a
+/// pre-fix bug where `parentItemIdentifier.rawValue` was concatenated into S3 keys).
 /// All ListObjectsV2 consumers MUST use this filter before surfacing keys to observers,
 /// MetadataStore, SyncEngine, or Finder/Files.
 public enum S3KeyFilter {

--- a/DS3Lib/Sources/DS3Lib/Utils/S3KeyFilter.swift
+++ b/DS3Lib/Sources/DS3Lib/Utils/S3KeyFilter.swift
@@ -24,6 +24,7 @@ public enum S3KeyFilter {
     public static func isUserVisible(key: String, drivePrefix: String?) -> Bool {
         !S3PathUtils.isTrashedKey(key, drivePrefix: drivePrefix)
             && !S3PathUtils.isThumbnailKey(key, drivePrefix: drivePrefix)
+            && !S3PathUtils.isDS3KeepMarkerKey(key)
             && !isSentinelPoisonedKey(key, drivePrefix: drivePrefix)
     }
 

--- a/DS3Lib/Sources/DS3Lib/Utils/S3PathUtils.swift
+++ b/DS3Lib/Sources/DS3Lib/Utils/S3PathUtils.swift
@@ -157,6 +157,25 @@ public enum S3PathUtils {
         return parent + filename
     }
 
+    // MARK: - DS3Keep Folder Marker
+
+    /// Returns true if the key is a `.ds3keep` folder marker (final path
+    /// segment equals `markerFileName`). The marker is hidden from
+    /// user-visible enumerations via `S3KeyFilter.isUserVisible`.
+    public static func isDS3KeepMarkerKey(_ key: String) -> Bool {
+        let marker = DefaultSettings.S3.markerFileName
+        if key == marker { return true }
+        return key.hasSuffix(String(DefaultSettings.S3.delimiter) + marker)
+    }
+
+    /// Computes the `.ds3keep` marker key for a folder key.
+    /// Appends the delimiter if `folderKey` does not already end with one.
+    public static func markerKey(forFolderKey folderKey: String) -> String {
+        let delimiter = String(DefaultSettings.S3.delimiter)
+        let normalized = folderKey.hasSuffix(delimiter) ? folderKey : folderKey + delimiter
+        return normalized + DefaultSettings.S3.markerFileName
+    }
+
     /// Suffix-based allow-list for raster image formats Phase 13 will generate thumbnails for.
     /// MUST agree with the platform renderer's UTI allow-list (e.g. `ThumbnailRenderer`
     /// in the `DS3ThumbnailRendering` product / `ThumbnailRendering` module) — both gate the same set.

--- a/DS3Lib/Sources/DS3Lib/Utils/S3PathUtils.swift
+++ b/DS3Lib/Sources/DS3Lib/Utils/S3PathUtils.swift
@@ -162,6 +162,9 @@ public enum S3PathUtils {
     /// Returns true if the key is a `.ds3keep` folder marker (final path
     /// segment equals `markerFileName`). The marker is hidden from
     /// user-visible enumerations via `S3KeyFilter.isUserVisible`.
+    /// The marker is identity-bearing on its own — its scope is the folder it
+    /// lives in, not a drive-wide prefix. No `drivePrefix` parameter is needed
+    /// (unlike `isThumbnailKey` / `isTrashedKey`).
     public static func isDS3KeepMarkerKey(_ key: String) -> Bool {
         let marker = DefaultSettings.S3.markerFileName
         if key == marker { return true }
@@ -170,6 +173,9 @@ public enum S3PathUtils {
 
     /// Computes the `.ds3keep` marker key for a folder key.
     /// Appends the delimiter if `folderKey` does not already end with one.
+    /// Example: "prefix/photos" or "prefix/photos/" → "prefix/photos/.ds3keep"
+    /// - Parameter folderKey: The folder's S3 key, with or without trailing delimiter.
+    /// - Returns: The marker key inside that folder.
     public static func markerKey(forFolderKey folderKey: String) -> String {
         let delimiter = String(DefaultSettings.S3.delimiter)
         let normalized = folderKey.hasSuffix(delimiter) ? folderKey : folderKey + delimiter

--- a/DS3Lib/Tests/DS3LibTests/Integration/DS3S3ClientIntegrationTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/Integration/DS3S3ClientIntegrationTests.swift
@@ -319,12 +319,24 @@ final class DS3S3ClientIntegrationTests: DS3S3IntegrationTestCase {
 
     // MARK: - Folder Operations
 
-    func testCreateFolderMarker() async throws {
-        let key = testPrefix + "new-folder/"
-        _ = try await s3Client.putObject(bucket: bucket, key: key, fileURL: nil)
+    func testCreateDS3KeepMarker() async throws {
+        let folderKey = testPrefix + "new-folder/"
+        let markerKey = S3PathUtils.markerKey(forFolderKey: folderKey)
+        _ = try await s3Client.putObject(bucket: bucket, key: markerKey, fileURL: nil)
 
-        let metadata = try await s3Client.headObject(bucket: bucket, key: key)
+        let metadata = try await s3Client.headObject(bucket: bucket, key: markerKey)
         XCTAssertEqual(metadata.contentLength, 0)
+
+        // The folder prefix must surface via CommonPrefix on a delimited list
+        // because the marker object sits inside it. This is the load-bearing
+        // property Phase A relies on for folder visibility.
+        let listing = try await s3Client.listObjects(
+            bucket: bucket, prefix: testPrefix, delimiter: "/"
+        )
+        XCTAssertTrue(
+            listing.commonPrefixes.contains(folderKey),
+            "Marker inside <folder> must surface <folder>/ as a CommonPrefix; got: \(listing.commonPrefixes)"
+        )
     }
 
     // MARK: - Special Characters in Keys

--- a/DS3Lib/Tests/DS3LibTests/S3KeyFilterTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/S3KeyFilterTests.swift
@@ -93,4 +93,29 @@ final class S3KeyFilterTests: XCTestCase {
             key: "NSFileProviderTrashFooBar.txt", drivePrefix: nil
         ))
     }
+
+    // MARK: - DS3Keep Marker
+
+    func testRejectsDS3KeepMarkerInSubfolder() {
+        XCTAssertFalse(S3KeyFilter.isUserVisible(key: "prefix/photos/.ds3keep", drivePrefix: "prefix/"))
+    }
+
+    func testRejectsDS3KeepMarkerAtPrefixRoot() {
+        XCTAssertFalse(S3KeyFilter.isUserVisible(key: "prefix/.ds3keep", drivePrefix: "prefix/"))
+    }
+
+    func testRejectsDS3KeepMarkerWithNilDrivePrefix() {
+        XCTAssertFalse(S3KeyFilter.isUserVisible(key: ".ds3keep", drivePrefix: nil))
+        XCTAssertFalse(S3KeyFilter.isUserVisible(key: "photos/.ds3keep", drivePrefix: nil))
+    }
+
+    func testAllowsLookalikeFilename() {
+        XCTAssertTrue(S3KeyFilter.isUserVisible(key: "prefix/notes/my.ds3keep.txt", drivePrefix: "prefix/"))
+    }
+
+    func testStillAllowsLegacyFolderPlaceholder() {
+        // The trailing-slash placeholder remains user-visible (it surfaces as a
+        // folder via CommonPrefix). Marker filter must not regress this.
+        XCTAssertTrue(S3KeyFilter.isUserVisible(key: "prefix/photos/", drivePrefix: "prefix/"))
+    }
 }

--- a/DS3Lib/Tests/DS3LibTests/S3PathUtilsTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/S3PathUtilsTests.swift
@@ -344,4 +344,45 @@ final class S3PathUtilsTests: XCTestCase {
             XCTAssertEqual(restored, originalKey, "Round-trip failed for key: \(originalKey)")
         }
     }
+
+    // MARK: - DS3Keep Marker
+
+    func testIsDS3KeepMarkerKeyTrue() {
+        XCTAssertTrue(S3PathUtils.isDS3KeepMarkerKey("prefix/folder/.ds3keep"))
+    }
+
+    func testIsDS3KeepMarkerKeyAtRoot() {
+        XCTAssertTrue(S3PathUtils.isDS3KeepMarkerKey(".ds3keep"))
+    }
+
+    func testIsDS3KeepMarkerKeyFalseForRegularFile() {
+        XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/folder/file.txt"))
+    }
+
+    func testIsDS3KeepMarkerKeyFalseForFolder() {
+        XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/folder/"))
+    }
+
+    func testIsDS3KeepMarkerKeyFalseForLookalike() {
+        XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/file.ds3keep.txt"))
+        XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/notds3keep"))
+    }
+
+    func testMarkerKeyForFolder() {
+        XCTAssertEqual(
+            S3PathUtils.markerKey(forFolderKey: "prefix/photos/"),
+            "prefix/photos/.ds3keep"
+        )
+    }
+
+    func testMarkerKeyAppendsDelimiterIfMissing() {
+        XCTAssertEqual(
+            S3PathUtils.markerKey(forFolderKey: "prefix/photos"),
+            "prefix/photos/.ds3keep"
+        )
+    }
+
+    func testMarkerKeyForRootDelimiter() {
+        XCTAssertEqual(S3PathUtils.markerKey(forFolderKey: "/"), "/.ds3keep")
+    }
 }

--- a/DS3Lib/Tests/DS3LibTests/S3PathUtilsTests.swift
+++ b/DS3Lib/Tests/DS3LibTests/S3PathUtilsTests.swift
@@ -368,6 +368,11 @@ final class S3PathUtilsTests: XCTestCase {
         XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/notds3keep"))
     }
 
+    func testIsDS3KeepMarkerKeyFalseForDS3KeepPrefix() {
+        // Substring at start of last segment, no leading delimiter for marker.
+        XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/.ds3keepfoo"))
+    }
+
     func testMarkerKeyForFolder() {
         XCTAssertEqual(
             S3PathUtils.markerKey(forFolderKey: "prefix/photos/"),


### PR DESCRIPTION
## Summary
Replace zero-byte `<folder>/` placeholder with hidden `<folder>/.ds3keep` marker for empty folders on S3.

- DS3Lib: `markerFileName` constant + `S3PathUtils.isDS3KeepMarkerKey` / `markerKey(forFolderKey:)` + `S3KeyFilter.isUserVisible` rejects markers
- DS3DriveProvider: `S3Item.wireKey` rewrites folder PUTs to marker; `putS3ItemStandard` uses it; new `materializeEmptyFolderMarker` helper handles empty-folder copy with copy-or-fresh-PUT fallback
- Identifier semantics preserved — folder identifier remains `<folder>/`
- Backward compatible — legacy `<folder>/` zero-byte placeholders still surface as folders via existing trailing-`/` `contentType` + CommonPrefix paths
- Tests: 14 new DS3LibTests + 10 new DS3DriveProviderTests + 1 updated integration test
- 13 commits, all signed, no production code change in `S3Item.contentType` / parent resolution

Tasks 6 (rename test) and 7 (delete test) intentionally deferred — both code paths transitively covered by Task 5's helper test plus the Task 8 integration test. Adding rename/delete unit tests at the `S3Lib` actor level would require refactoring `S3Lib.client` from concrete `DS3S3Client` to `DS3S3ClientProtocol`, which is out of Phase A scope.

## Foundation for follow-ups
- Phase B (#166): folder mtime sourced from marker's `LastModified`
- #167: untitled-folder rename ghost (active-sync repro post-Phase-A)
- #168: enumeration vs transfer priority

## Test plan
- [x] `swift test` in DS3Lib — 539 pass / 31 skip / 0 fail
- [x] `xcodebuild test DS3DriveProviderTests` — 124 pass / 1 skip / 2 pre-existing decoration failures (unchanged baseline)
- [ ] Manual macOS Finder: create empty folder; verify `aws s3 ls <bucket>/<prefix>/<name>/` shows only `.ds3keep` (0 bytes); rename + move + delete round-trip; legacy compat with out-of-band `aws s3api put-object --key <prefix>/legacy/`
- [ ] Manual iOS Files: create empty folder; verify marker never visible in Files app
- [ ] (Optional) Live S3 integration: `DS3_TEST_*` env vars set, run `testCreateDS3KeepMarker`

Closes #165