### PR TITLE
fix(provider): return stable folder mtime instead of nil (closes #166)

### DIFF
--- a/DS3DriveProvider/S3Item.swift
+++ b/DS3DriveProvider/S3Item.swift
@@ -159,22 +159,14 @@ class S3Item: NSObject, NSFileProviderItem, NSFileProviderItemDecorating, @unche
         return String(identifier.rawValue.split(separator: separator).last ?? "")
     }
 
-    /// Stable fallback date for folders whose S3 listing carries no
-    /// `lastModified` (CommonPrefixes, synthesized virtual folders).
-    /// Using `nil` caused iOS Files.app to render "01/01/1970" (epoch 0).
-    /// The sentinel must be constant so every enumeration returns the same
-    /// value — otherwise Finder re-processes the item and breaks icons.
-    /// January 1 2001 00:00:00 UTC (Cocoa reference date) is recognisable
-    /// as a placeholder and avoids the epoch-zero display bug.
+    /// Stable fallback date for folders whose S3 listing carries no `lastModified`
+    /// (CommonPrefixes, synthesized virtual folders). Returning `nil` caused iOS
+    /// Files.app to render "01/01/1970" (epoch 0), and a non-constant value makes
+    /// Finder re-process the item each enumeration, breaking icons.
     static let folderFallbackDate = Date(timeIntervalSinceReferenceDate: 0)
 
     var contentModificationDate: Date? {
         if isFolder {
-            // Return lastModified when available (S3 marker objects,
-            // HeadObject). Fall back to a fixed sentinel so every
-            // enumeration cycle produces the same value — a changing
-            // date across enumerations would make Finder re-process
-            // items and break their icons.
             return metadata.lastModified ?? Self.folderFallbackDate
         }
         return metadata.lastModified

--- a/DS3DriveProvider/S3Item.swift
+++ b/DS3DriveProvider/S3Item.swift
@@ -159,13 +159,23 @@ class S3Item: NSObject, NSFileProviderItem, NSFileProviderItemDecorating, @unche
         return String(identifier.rawValue.split(separator: separator).last ?? "")
     }
 
+    /// Stable fallback date for folders whose S3 listing carries no
+    /// `lastModified` (CommonPrefixes, synthesized virtual folders).
+    /// Using `nil` caused iOS Files.app to render "01/01/1970" (epoch 0).
+    /// The sentinel must be constant so every enumeration returns the same
+    /// value — otherwise Finder re-processes the item and breaks icons.
+    /// January 1 2001 00:00:00 UTC (Cocoa reference date) is recognisable
+    /// as a placeholder and avoids the epoch-zero display bug.
+    static let folderFallbackDate = Date(timeIntervalSinceReferenceDate: 0)
+
     var contentModificationDate: Date? {
         if isFolder {
-            // Always nil for folders. Some code paths carry a real lastModified
-            // (S3 marker objects, HeadObject) while others don't (common prefixes,
-            // virtual folders). Returning a date only when available makes the
-            // system see property changes each enumeration, breaking Finder icons.
-            return nil
+            // Return lastModified when available (S3 marker objects,
+            // HeadObject). Fall back to a fixed sentinel so every
+            // enumeration cycle produces the same value — a changing
+            // date across enumerations would make Finder re-process
+            // items and break their icons.
+            return metadata.lastModified ?? Self.folderFallbackDate
         }
         return metadata.lastModified
     }

--- a/DS3DriveProviderTests/S3ItemTests.swift
+++ b/DS3DriveProviderTests/S3ItemTests.swift
@@ -168,14 +168,6 @@ final class S3ItemTests: XCTestCase {
         )
     }
 
-    func testContentModificationDateForFolderIsNotNil() {
-        let item = makeItem(key: "prefix/docs/")
-        XCTAssertNotNil(
-            item.contentModificationDate,
-            "Folder contentModificationDate must never be nil (iOS shows epoch 0)"
-        )
-    }
-
     func testContentModificationDateForFolderIsStable() {
         let item1 = makeItem(key: "prefix/docs/")
         let item2 = makeItem(key: "prefix/docs/")

--- a/DS3DriveProviderTests/S3ItemTests.swift
+++ b/DS3DriveProviderTests/S3ItemTests.swift
@@ -9,9 +9,12 @@ final class S3ItemTests: XCTestCase {
 
     private func makeItem(
         key: String, drive: DS3Drive? = nil, etag: String? = nil,
-        size: Int64 = 0, syncStatus: String? = nil
+        lastModified: Date? = nil, size: Int64 = 0, syncStatus: String? = nil
     ) -> S3Item {
-        ProviderTestFixtures.makeItem(key: key, drive: drive, etag: etag, size: size, syncStatus: syncStatus)
+        ProviderTestFixtures.makeItem(
+            key: key, drive: drive, etag: etag,
+            lastModified: lastModified, size: size, syncStatus: syncStatus
+        )
     }
 
     // MARK: - Identifier Mapping
@@ -133,6 +136,62 @@ final class S3ItemTests: XCTestCase {
     func testDocumentSizeForFolder() {
         let item = makeItem(key: "prefix/docs/")
         XCTAssertNil(item.documentSize, "Folders should have nil documentSize")
+    }
+
+    // MARK: - Content Modification Date
+
+    func testContentModificationDateForFile() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let item = makeItem(key: "prefix/file.txt", lastModified: date)
+        XCTAssertEqual(item.contentModificationDate, date)
+    }
+
+    func testContentModificationDateForFileWithoutLastModified() {
+        let item = makeItem(key: "prefix/file.txt")
+        XCTAssertNil(item.contentModificationDate)
+    }
+
+    func testContentModificationDateForFolderWithLastModified() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let item = makeItem(key: "prefix/docs/", lastModified: date)
+        XCTAssertEqual(
+            item.contentModificationDate, date,
+            "Folders with lastModified from S3 should use that date"
+        )
+    }
+
+    func testContentModificationDateForFolderWithoutLastModified() {
+        let item = makeItem(key: "prefix/docs/")
+        XCTAssertEqual(
+            item.contentModificationDate, S3Item.folderFallbackDate,
+            "Folders without lastModified should return the stable fallback date, not nil"
+        )
+    }
+
+    func testContentModificationDateForFolderIsNotNil() {
+        let item = makeItem(key: "prefix/docs/")
+        XCTAssertNotNil(
+            item.contentModificationDate,
+            "Folder contentModificationDate must never be nil (iOS shows epoch 0)"
+        )
+    }
+
+    func testContentModificationDateForFolderIsStable() {
+        let item1 = makeItem(key: "prefix/docs/")
+        let item2 = makeItem(key: "prefix/docs/")
+        XCTAssertEqual(
+            item1.contentModificationDate,
+            item2.contentModificationDate,
+            "Folder fallback date must be identical across instances"
+        )
+    }
+
+    func testFolderFallbackDateIsCocoaReferenceDate() {
+        XCTAssertEqual(
+            S3Item.folderFallbackDate,
+            Date(timeIntervalSinceReferenceDate: 0),
+            "Fallback should be Jan 1 2001 (Cocoa reference date)"
+        )
     }
 
     // MARK: - Item Version

--- a/DS3DriveProviderTests/TestFixtures.swift
+++ b/DS3DriveProviderTests/TestFixtures.swift
@@ -34,6 +34,7 @@ enum ProviderTestFixtures {
         key: String,
         drive: DS3Drive? = nil,
         etag: String? = nil,
+        lastModified: Date? = nil,
         size: Int64 = 0,
         syncStatus: String? = nil
     ) -> S3Item {
@@ -43,6 +44,7 @@ enum ProviderTestFixtures {
             drive: resolvedDrive,
             objectMetadata: S3Item.Metadata(
                 etag: etag,
+                lastModified: lastModified,
                 size: NSNumber(value: size),
                 syncStatus: syncStatus
             )


### PR DESCRIPTION
## Summary
- iOS Files.app showed all folders dated 01/01/1970 because `S3Item.contentModificationDate` returned `nil` for folders
- Now returns `lastModified` from S3 when available (marker objects, HeadObject)
- Falls back to a stable sentinel date (Cocoa reference date, Jan 1 2001) for folders without S3 metadata (CommonPrefixes)
- Sentinel is constant across enumeration cycles — no Finder icon glitching

## Test plan
- [ ] 7 new unit tests covering file/folder dates, nil handling, stability, sentinel value
- [ ] Build macOS + iOS targets
- [ ] Verify iOS Files.app shows reasonable folder dates instead of 1970
- [ ] Verify macOS Finder icons don't glitch on enumeration