### PR TITLE
fix(provider): HEAD .ds3keep marker key on folder reimport (closes #170)

### DIFF
--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		A1D5410101000000A1D54101 /* S3LibFolderMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */; };
 		A1D5410201000000A1D54102 /* S3LibFolderMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */; };
 		A1D5420101000000A1D54201 /* FolderMarkerCopyDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */; };
+		A1D5430101000000A1D54301 /* FolderMarkerProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5430001000000A1D54300 /* FolderMarkerProbeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -290,6 +291,7 @@
 		A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerEnumeratorTests.swift; sourceTree = "<group>"; };
 		A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3LibFolderMarker.swift; sourceTree = "<group>"; };
 		A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerCopyDeleteTests.swift; sourceTree = "<group>"; };
+		A1D5430001000000A1D54300 /* FolderMarkerProbeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerProbeTests.swift; sourceTree = "<group>"; };
 		1823D7B17115B90E2FD9181D /* IOSSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSSettingsView.swift; sourceTree = "<group>"; };
 		2C71C4FFADB8DDE9EC58F5E2 /* SyncSetupViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncSetupViewModelTests.swift; sourceTree = "<group>"; };
 		39439872734512266C6F7F51 /* IOSMainTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSMainTabView.swift; sourceTree = "<group>"; };
@@ -695,6 +697,7 @@
 				A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */,
 				A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */,
 				A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */,
+				A1D5430001000000A1D54300 /* FolderMarkerProbeTests.swift */,
 				A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */,
 				A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */,
 				A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */,
@@ -1425,6 +1428,7 @@
 				A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */,
 				A1D5400101000000A1D54001 /* FolderMarkerEnumeratorTests.swift in Sources */,
 				A1D5420101000000A1D54201 /* FolderMarkerCopyDeleteTests.swift in Sources */,
+				A1D5430101000000A1D54301 /* FolderMarkerProbeTests.swift in Sources */,
 				7FE55AB1B1E1D9BE5865060E /* TestFixtures.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DS3DriveProvider/FileProviderExtension+Create.swift
+++ b/DS3DriveProvider/FileProviderExtension+Create.swift
@@ -101,25 +101,56 @@ extension FileProviderExtension {
             Task {
                 let completionHandler = boxedCb.value
                 do {
-                    let existingItem = try await s3Lib.remoteS3Item(
-                        for: s3Item.itemIdentifier, drive: drive
-                    )
+                    // Folders: probe .ds3keep marker first, then legacy key (#170).
+                    // Files: HEAD the identifier key directly (unchanged).
+                    var existingItem: S3Item?
 
-                    try? await self.metadataStore?.upsertItem(
-                        s3Key: key,
-                        driveId: drive.id,
-                        etag: existingItem.metadata.etag,
-                        lastModified: existingItem.metadata.lastModified,
-                        syncStatus: .synced,
-                        parentKey: parentKey,
-                        contentType: existingItem.isFolder ? "folder" : nil,
-                        size: Int64(truncating: existingItem.metadata.size)
-                    )
+                    if s3Item.isFolder {
+                        if let metadata = try await probeFolderExists(
+                            folderKey: s3Item.itemIdentifier.rawValue,
+                            bucket: drive.syncAnchor.bucket.name,
+                            client: s3Lib.client,
+                            logger: self.logger
+                        ) {
+                            existingItem = S3Item(
+                                identifier: s3Item.itemIdentifier,
+                                drive: drive,
+                                objectMetadata: S3Item.Metadata(
+                                    etag: metadata.etag,
+                                    contentType: metadata.contentType,
+                                    lastModified: metadata.lastModified,
+                                    versionId: metadata.versionId,
+                                    size: NSNumber(value: metadata.contentLength)
+                                )
+                            )
+                        }
+                    } else {
+                        do {
+                            existingItem = try await s3Lib.remoteS3Item(
+                                for: s3Item.itemIdentifier, drive: drive
+                            )
+                        } catch let s3Error as AWSErrorType where s3Error.isNotFound {
+                            // 404 — file doesn't exist, will proceed to upload
+                        }
+                    }
 
-                    progress.completedUnitCount = numParts
-                    completionHandler(existingItem, NSFileProviderItemFields(), false, nil)
-                } catch let s3Error as AWSErrorType
-                    where s3Error.errorCode == "NotFound" || s3Error.errorCode == "NoSuchKey" {
+                    if let existingItem {
+                        try? await self.metadataStore?.upsertItem(
+                            s3Key: key,
+                            driveId: drive.id,
+                            etag: existingItem.metadata.etag,
+                            lastModified: existingItem.metadata.lastModified,
+                            syncStatus: .synced,
+                            parentKey: parentKey,
+                            contentType: existingItem.isFolder ? "folder" : nil,
+                            size: Int64(truncating: existingItem.metadata.size)
+                        )
+
+                        progress.completedUnitCount = numParts
+                        completionHandler(existingItem, NSFileProviderItemFields(), false, nil)
+                        return
+                    }
+
                     // Item doesn't exist remotely — proceed with normal upload
                     self.logger.debug("Item not found remotely (.mayAlreadyExist), proceeding with upload")
                     do {

--- a/DS3DriveProvider/FileProviderExtension+Create.swift
+++ b/DS3DriveProvider/FileProviderExtension+Create.swift
@@ -101,18 +101,16 @@ extension FileProviderExtension {
             Task {
                 let completionHandler = boxedCb.value
                 do {
-                    // Folders: probe .ds3keep marker first, then legacy key (#170).
-                    // Files: HEAD the identifier key directly (unchanged).
                     var existingItem: S3Item?
 
                     if s3Item.isFolder {
-                        if let metadata = try await probeFolderExists(
+                        existingItem = try await probeFolderExists(
                             folderKey: s3Item.itemIdentifier.rawValue,
                             bucket: drive.syncAnchor.bucket.name,
                             client: s3Lib.client,
                             logger: self.logger
-                        ) {
-                            existingItem = S3Item(
+                        ).map { metadata in
+                            S3Item(
                                 identifier: s3Item.itemIdentifier,
                                 drive: drive,
                                 objectMetadata: S3Item.Metadata(
@@ -130,7 +128,7 @@ extension FileProviderExtension {
                                 for: s3Item.itemIdentifier, drive: drive
                             )
                         } catch let s3Error as AWSErrorType where s3Error.isNotFound {
-                            // 404 — file doesn't exist, will proceed to upload
+                            // 404 -- file not found, will proceed to upload below
                         }
                     }
 

--- a/DS3DriveProvider/S3LibFolderMarker.swift
+++ b/DS3DriveProvider/S3LibFolderMarker.swift
@@ -45,3 +45,48 @@ func materializeEmptyFolderMarker(
         )
     }
 }
+
+/// Probes S3 to determine whether a folder already exists, checking
+/// the `.ds3keep` marker key first, then falling back to the legacy
+/// `<folder>/` zero-byte placeholder for backward compatibility.
+///
+/// Returns the `S3ObjectMetadata` from whichever HEAD succeeds, or
+/// `nil` when both return 404. Non-404 errors propagate immediately.
+///
+/// Phase A fix (#170): after `.ds3keep` adoption, reimported folders
+/// were silently re-PUT because `remoteS3Item` only HEAD'd the legacy
+/// key which no longer exists.
+func probeFolderExists(
+    folderKey: String,
+    bucket: String,
+    client: any DS3S3ClientProtocol,
+    logger: os.Logger
+) async throws -> S3ObjectMetadata? {
+    // 1. Probe the .ds3keep marker key (Phase A format).
+    let markerKey = S3PathUtils.markerKey(forFolderKey: folderKey)
+    do {
+        let metadata = try await client.headObject(bucket: bucket, key: markerKey)
+        logger.debug(
+            "probeFolderExists: marker key found at \(markerKey, privacy: .public)"
+        )
+        return metadata
+    } catch where DS3S3Client.isNotFoundError(error) {
+        logger.debug(
+            "probeFolderExists: marker key not found at \(markerKey, privacy: .public), trying legacy key"
+        )
+    }
+
+    // 2. Fallback: probe the legacy zero-byte folder key.
+    do {
+        let metadata = try await client.headObject(bucket: bucket, key: folderKey)
+        logger.debug(
+            "probeFolderExists: legacy key found at \(folderKey, privacy: .public)"
+        )
+        return metadata
+    } catch where DS3S3Client.isNotFoundError(error) {
+        logger.debug(
+            "probeFolderExists: neither marker nor legacy key found for \(folderKey, privacy: .public)"
+        )
+        return nil
+    }
+}

--- a/DS3DriveProvider/S3LibFolderMarker.swift
+++ b/DS3DriveProvider/S3LibFolderMarker.swift
@@ -46,47 +46,34 @@ func materializeEmptyFolderMarker(
     }
 }
 
-/// Probes S3 to determine whether a folder already exists, checking
-/// the `.ds3keep` marker key first, then falling back to the legacy
-/// `<folder>/` zero-byte placeholder for backward compatibility.
-///
-/// Returns the `S3ObjectMetadata` from whichever HEAD succeeds, or
+/// HEADs the `.ds3keep` marker key first, then the legacy `<folder>/`
+/// zero-byte placeholder. Returns metadata from whichever succeeds, or
 /// `nil` when both return 404. Non-404 errors propagate immediately.
 ///
-/// Phase A fix (#170): after `.ds3keep` adoption, reimported folders
-/// were silently re-PUT because `remoteS3Item` only HEAD'd the legacy
-/// key which no longer exists.
+/// Fix (#170): after `.ds3keep` adoption, reimported folders were
+/// silently re-PUT because `remoteS3Item` only HEAD'd the legacy key.
 func probeFolderExists(
     folderKey: String,
     bucket: String,
     client: any DS3S3ClientProtocol,
     logger: os.Logger
 ) async throws -> S3ObjectMetadata? {
-    // 1. Probe the .ds3keep marker key (Phase A format).
     let markerKey = S3PathUtils.markerKey(forFolderKey: folderKey)
+
     do {
         let metadata = try await client.headObject(bucket: bucket, key: markerKey)
-        logger.debug(
-            "probeFolderExists: marker key found at \(markerKey, privacy: .public)"
-        )
+        logger.debug("probeFolderExists: found marker at \(markerKey, privacy: .public)")
         return metadata
     } catch where DS3S3Client.isNotFoundError(error) {
-        logger.debug(
-            "probeFolderExists: marker key not found at \(markerKey, privacy: .public), trying legacy key"
-        )
+        logger.debug("probeFolderExists: no marker at \(markerKey, privacy: .public), trying legacy key")
     }
 
-    // 2. Fallback: probe the legacy zero-byte folder key.
     do {
         let metadata = try await client.headObject(bucket: bucket, key: folderKey)
-        logger.debug(
-            "probeFolderExists: legacy key found at \(folderKey, privacy: .public)"
-        )
+        logger.debug("probeFolderExists: found legacy key at \(folderKey, privacy: .public)")
         return metadata
     } catch where DS3S3Client.isNotFoundError(error) {
-        logger.debug(
-            "probeFolderExists: neither marker nor legacy key found for \(folderKey, privacy: .public)"
-        )
+        logger.debug("probeFolderExists: no key found for \(folderKey, privacy: .public)")
         return nil
     }
 }

--- a/DS3DriveProviderTests/FolderMarkerProbeTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerProbeTests.swift
@@ -4,14 +4,9 @@ import os.log
 import SotoS3
 import XCTest
 
-/// Tests for `probeFolderExists` — the two-step HEAD probe that checks the
-/// `.ds3keep` marker key first, then falls back to the legacy `<folder>/`
-/// zero-byte placeholder. Introduced by #170 to prevent reimported folders
-/// from being silently re-PUT after Phase A.
+/// Tests for `probeFolderExists` — the two-step HEAD probe (#170).
 final class FolderMarkerProbeTests: XCTestCase {
-    private func logger() -> os.Logger {
-        os.Logger(subsystem: "io.cubbit.DS3Drive.tests", category: "marker-probe")
-    }
+    private let testLogger = os.Logger(subsystem: "io.cubbit.DS3Drive.tests", category: "marker-probe")
 
     // MARK: - Marker key found
 
@@ -27,10 +22,9 @@ final class FolderMarkerProbeTests: XCTestCase {
             folderKey: "prefix/photos/",
             bucket: "test-bucket",
             client: mock,
-            logger: logger()
+            logger: testLogger
         )
 
-        XCTAssertNotNil(result, "Should return metadata when .ds3keep marker exists")
         XCTAssertEqual(result?.etag, "\"abc\"")
         XCTAssertEqual(
             mock.headedKeys, ["prefix/photos/.ds3keep"],
@@ -42,8 +36,6 @@ final class FolderMarkerProbeTests: XCTestCase {
 
     func testFallsBackToLegacyKeyWhenMarkerMissing() async throws {
         let mock = ProbeMockS3Client()
-        // No marker key — HEAD returns 404
-        // Legacy key exists
         mock.existingKeys["prefix/photos/"] = S3ObjectMetadata(
             etag: "\"legacy\"", contentType: nil,
             lastModified: Date(timeIntervalSince1970: 2_000_000),
@@ -54,10 +46,9 @@ final class FolderMarkerProbeTests: XCTestCase {
             folderKey: "prefix/photos/",
             bucket: "test-bucket",
             client: mock,
-            logger: logger()
+            logger: testLogger
         )
 
-        XCTAssertNotNil(result, "Should return metadata from legacy key")
         XCTAssertEqual(result?.etag, "\"legacy\"")
         XCTAssertEqual(
             mock.headedKeys,
@@ -70,16 +61,15 @@ final class FolderMarkerProbeTests: XCTestCase {
 
     func testReturnsNilWhenBothKeysMissing() async throws {
         let mock = ProbeMockS3Client()
-        // No keys exist
 
         let result = try await probeFolderExists(
             folderKey: "prefix/photos/",
             bucket: "test-bucket",
             client: mock,
-            logger: logger()
+            logger: testLogger
         )
 
-        XCTAssertNil(result, "Should return nil when neither key exists")
+        XCTAssertNil(result)
         XCTAssertEqual(
             mock.headedKeys,
             ["prefix/photos/.ds3keep", "prefix/photos/"],
@@ -101,7 +91,7 @@ final class FolderMarkerProbeTests: XCTestCase {
                 folderKey: "prefix/photos/",
                 bucket: "test-bucket",
                 client: mock,
-                logger: logger()
+                logger: testLogger
             )
             XCTFail("Expected non-404 error to propagate")
         } catch let error as NSError {
@@ -119,8 +109,6 @@ final class FolderMarkerProbeTests: XCTestCase {
 
     func testNonNotFoundErrorPropagatesFromLegacyHEAD() async throws {
         let mock = ProbeMockS3Client()
-        // Marker key → 404
-        // Legacy key → 500
         mock.legacyKeyError = NSError(
             domain: "S3", code: 500,
             userInfo: [NSLocalizedDescriptionKey: "InternalError"]
@@ -131,7 +119,7 @@ final class FolderMarkerProbeTests: XCTestCase {
                 folderKey: "prefix/photos/",
                 bucket: "test-bucket",
                 client: mock,
-                logger: logger()
+                logger: testLogger
             )
             XCTFail("Expected non-404 error to propagate from legacy HEAD")
         } catch let error as NSError {
@@ -159,10 +147,9 @@ final class FolderMarkerProbeTests: XCTestCase {
             folderKey: "docs/",
             bucket: "test-bucket",
             client: mock,
-            logger: logger()
+            logger: testLogger
         )
 
-        XCTAssertNotNil(result)
         XCTAssertEqual(result?.etag, "\"root-marker\"")
         XCTAssertEqual(mock.headedKeys, ["docs/.ds3keep"])
     }
@@ -170,25 +157,14 @@ final class FolderMarkerProbeTests: XCTestCase {
 
 // MARK: - Test mock
 
-/// Minimal `DS3S3ClientProtocol` mock that tracks `headObject` calls and
-/// returns metadata from a pre-configured key→metadata map. Keys not in
-/// the map produce a `S3ErrorType.noSuchKey` (404).
-///
-/// Supports optional error injection:
-/// - `headObjectError` — injected for ALL HEAD calls (simulates 403, 500, etc.)
-/// - `legacyKeyError` — injected only for non-marker HEAD calls (marker 404, legacy error)
+/// `DS3S3ClientProtocol` mock that tracks `headObject` calls and returns
+/// metadata from `existingKeys`. Missing keys throw `S3ErrorType.noSuchKey`.
 final class ProbeMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
-    /// Keys that "exist" on S3. HEAD returns the associated metadata.
     var existingKeys: [String: S3ObjectMetadata] = [:]
-
-    /// If set, ALL headObject calls throw this error.
+    /// Injected for ALL `headObject` calls (simulates 403, 500, etc.).
     var headObjectError: Error?
-
-    /// If set, headObject throws this error for non-marker keys (after
-    /// the marker key has already returned 404).
+    /// Injected only for non-marker keys (marker returns 404 first).
     var legacyKeyError: Error?
-
-    /// Records every key passed to `headObject` in order.
     private(set) var headedKeys: [String] = []
 
     func headObject(bucket _: String, key: String) async throws -> S3ObjectMetadata {
@@ -223,7 +199,7 @@ final class ProbeMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
     }
 
     func deleteObject(bucket _: String, key _: String) async throws {
-        // No-op stub
+        // Unused
     }
     func deleteObjects(bucket _: String, keys _: [String]) async throws -> Int {
         0
@@ -233,7 +209,7 @@ final class ProbeMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
         bucket _: String, sourceKey _: String,
         destinationKey _: String, metadata _: [String: String]?
     ) async throws {
-        // No-op stub
+        // Unused
     }
 
     func getObject(
@@ -280,10 +256,10 @@ final class ProbeMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
     }
 
     func abortMultipartUpload(bucket _: String, key _: String, uploadId _: String) async throws {
-        // No-op stub
+        // Unused
     }
 
     func shutdown() throws {
-        // No-op stub
+        // Unused
     }
 }

--- a/DS3DriveProviderTests/FolderMarkerProbeTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerProbeTests.swift
@@ -172,7 +172,7 @@ final class FolderMarkerProbeTests: XCTestCase {
 
 /// Minimal `DS3S3ClientProtocol` mock that tracks `headObject` calls and
 /// returns metadata from a pre-configured key→metadata map. Keys not in
-/// the map produce a `S3ErrorType.notFound` (404).
+/// the map produce a `S3ErrorType.noSuchKey` (404).
 ///
 /// Supports optional error injection:
 /// - `headObjectError` — injected for ALL HEAD calls (simulates 403, 500, etc.)
@@ -206,7 +206,7 @@ final class ProbeMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
             return metadata
         }
 
-        throw S3ErrorType.notFound
+        throw S3ErrorType.noSuchKey
     }
 
     // MARK: - Stubs (unused by probe tests)

--- a/DS3DriveProviderTests/FolderMarkerProbeTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerProbeTests.swift
@@ -1,0 +1,289 @@
+@testable import DS3Lib
+import Foundation
+import os.log
+import SotoS3
+import XCTest
+
+/// Tests for `probeFolderExists` — the two-step HEAD probe that checks the
+/// `.ds3keep` marker key first, then falls back to the legacy `<folder>/`
+/// zero-byte placeholder. Introduced by #170 to prevent reimported folders
+/// from being silently re-PUT after Phase A.
+final class FolderMarkerProbeTests: XCTestCase {
+    private func logger() -> os.Logger {
+        os.Logger(subsystem: "io.cubbit.DS3Drive.tests", category: "marker-probe")
+    }
+
+    // MARK: - Marker key found
+
+    func testReturnsMetadataWhenMarkerKeyExists() async throws {
+        let mock = ProbeMockS3Client()
+        mock.existingKeys["prefix/photos/.ds3keep"] = S3ObjectMetadata(
+            etag: "\"abc\"", contentType: nil,
+            lastModified: Date(timeIntervalSince1970: 1_000_000),
+            versionId: nil, contentLength: 0
+        )
+
+        let result = try await probeFolderExists(
+            folderKey: "prefix/photos/",
+            bucket: "test-bucket",
+            client: mock,
+            logger: logger()
+        )
+
+        XCTAssertNotNil(result, "Should return metadata when .ds3keep marker exists")
+        XCTAssertEqual(result?.etag, "\"abc\"")
+        XCTAssertEqual(
+            mock.headedKeys, ["prefix/photos/.ds3keep"],
+            "Should only HEAD the marker key, not the legacy key"
+        )
+    }
+
+    // MARK: - Marker key missing, legacy key found
+
+    func testFallsBackToLegacyKeyWhenMarkerMissing() async throws {
+        let mock = ProbeMockS3Client()
+        // No marker key — HEAD returns 404
+        // Legacy key exists
+        mock.existingKeys["prefix/photos/"] = S3ObjectMetadata(
+            etag: "\"legacy\"", contentType: nil,
+            lastModified: Date(timeIntervalSince1970: 2_000_000),
+            versionId: nil, contentLength: 0
+        )
+
+        let result = try await probeFolderExists(
+            folderKey: "prefix/photos/",
+            bucket: "test-bucket",
+            client: mock,
+            logger: logger()
+        )
+
+        XCTAssertNotNil(result, "Should return metadata from legacy key")
+        XCTAssertEqual(result?.etag, "\"legacy\"")
+        XCTAssertEqual(
+            mock.headedKeys,
+            ["prefix/photos/.ds3keep", "prefix/photos/"],
+            "Should HEAD marker first, then legacy key"
+        )
+    }
+
+    // MARK: - Both keys missing
+
+    func testReturnsNilWhenBothKeysMissing() async throws {
+        let mock = ProbeMockS3Client()
+        // No keys exist
+
+        let result = try await probeFolderExists(
+            folderKey: "prefix/photos/",
+            bucket: "test-bucket",
+            client: mock,
+            logger: logger()
+        )
+
+        XCTAssertNil(result, "Should return nil when neither key exists")
+        XCTAssertEqual(
+            mock.headedKeys,
+            ["prefix/photos/.ds3keep", "prefix/photos/"],
+            "Should HEAD both keys before returning nil"
+        )
+    }
+
+    // MARK: - Non-404 error propagates from marker HEAD
+
+    func testNonNotFoundErrorPropagatesFromMarkerHEAD() async throws {
+        let mock = ProbeMockS3Client()
+        mock.headObjectError = NSError(
+            domain: "S3", code: 403,
+            userInfo: [NSLocalizedDescriptionKey: "AccessDenied"]
+        )
+
+        do {
+            _ = try await probeFolderExists(
+                folderKey: "prefix/photos/",
+                bucket: "test-bucket",
+                client: mock,
+                logger: logger()
+            )
+            XCTFail("Expected non-404 error to propagate")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "S3")
+            XCTAssertEqual(error.code, 403)
+        }
+
+        XCTAssertEqual(
+            mock.headedKeys, ["prefix/photos/.ds3keep"],
+            "Should not attempt legacy key after non-404 error"
+        )
+    }
+
+    // MARK: - Non-404 error propagates from legacy HEAD
+
+    func testNonNotFoundErrorPropagatesFromLegacyHEAD() async throws {
+        let mock = ProbeMockS3Client()
+        // Marker key → 404
+        // Legacy key → 500
+        mock.legacyKeyError = NSError(
+            domain: "S3", code: 500,
+            userInfo: [NSLocalizedDescriptionKey: "InternalError"]
+        )
+
+        do {
+            _ = try await probeFolderExists(
+                folderKey: "prefix/photos/",
+                bucket: "test-bucket",
+                client: mock,
+                logger: logger()
+            )
+            XCTFail("Expected non-404 error to propagate from legacy HEAD")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "S3")
+            XCTAssertEqual(error.code, 500)
+        }
+
+        XCTAssertEqual(
+            mock.headedKeys,
+            ["prefix/photos/.ds3keep", "prefix/photos/"],
+            "Should attempt both keys before propagating legacy error"
+        )
+    }
+
+    // MARK: - Root-level folder (no prefix)
+
+    func testRootLevelFolderProbe() async throws {
+        let mock = ProbeMockS3Client()
+        mock.existingKeys["docs/.ds3keep"] = S3ObjectMetadata(
+            etag: "\"root-marker\"", contentType: nil,
+            lastModified: nil, versionId: nil, contentLength: 0
+        )
+
+        let result = try await probeFolderExists(
+            folderKey: "docs/",
+            bucket: "test-bucket",
+            client: mock,
+            logger: logger()
+        )
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.etag, "\"root-marker\"")
+        XCTAssertEqual(mock.headedKeys, ["docs/.ds3keep"])
+    }
+}
+
+// MARK: - Test mock
+
+/// Minimal `DS3S3ClientProtocol` mock that tracks `headObject` calls and
+/// returns metadata from a pre-configured key→metadata map. Keys not in
+/// the map produce a `S3ErrorType.notFound` (404).
+///
+/// Supports optional error injection:
+/// - `headObjectError` — injected for ALL HEAD calls (simulates 403, 500, etc.)
+/// - `legacyKeyError` — injected only for non-marker HEAD calls (marker 404, legacy error)
+final class ProbeMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
+    /// Keys that "exist" on S3. HEAD returns the associated metadata.
+    var existingKeys: [String: S3ObjectMetadata] = [:]
+
+    /// If set, ALL headObject calls throw this error.
+    var headObjectError: Error?
+
+    /// If set, headObject throws this error for non-marker keys (after
+    /// the marker key has already returned 404).
+    var legacyKeyError: Error?
+
+    /// Records every key passed to `headObject` in order.
+    private(set) var headedKeys: [String] = []
+
+    func headObject(bucket _: String, key: String) async throws -> S3ObjectMetadata {
+        headedKeys.append(key)
+
+        if let headObjectError {
+            throw headObjectError
+        }
+
+        if let legacyKeyError, !key.hasSuffix(DefaultSettings.S3.markerFileName) {
+            throw legacyKeyError
+        }
+
+        if let metadata = existingKeys[key] {
+            return metadata
+        }
+
+        throw S3ErrorType.notFound
+    }
+
+    // MARK: - Stubs (unused by probe tests)
+
+    func listBuckets() async throws -> [(name: String, creationDate: Date?)] {
+        []
+    }
+
+    func listObjects(
+        bucket _: String, prefix _: String?, delimiter _: String?,
+        maxKeys _: Int?, continuationToken _: String?
+    ) async throws -> S3ListingResult {
+        S3ListingResult(objects: [], commonPrefixes: [], nextContinuationToken: nil, isTruncated: false)
+    }
+
+    func deleteObject(bucket _: String, key _: String) async throws {
+        // No-op stub
+    }
+    func deleteObjects(bucket _: String, keys _: [String]) async throws -> Int {
+        0
+    }
+
+    func copyObject(
+        bucket _: String, sourceKey _: String,
+        destinationKey _: String, metadata _: [String: String]?
+    ) async throws {
+        // No-op stub
+    }
+
+    func getObject(
+        bucket _: String, key _: String,
+        toFile _: URL, onProgress _: TransferProgressHandler?
+    ) async throws -> S3DownloadResult {
+        throw DS3ClientError.parseError
+    }
+
+    func getObjectData(bucket _: String, key _: String) async throws -> Data {
+        Data()
+    }
+
+    func putObject(
+        bucket _: String, key _: String,
+        fileURL _: URL?, onProgress _: TransferProgressHandler?
+    ) async throws -> String? {
+        "mock-etag"
+    }
+
+    func putObjectData(
+        bucket _: String, key _: String,
+        data _: Data, metadata _: [String: String]?
+    ) async throws -> String? {
+        "mock-etag"
+    }
+
+    func createMultipartUpload(bucket _: String, key _: String) async throws -> String {
+        "mock-id"
+    }
+
+    func uploadPart(
+        bucket _: String, key _: String, uploadId _: String,
+        partNumber: Int, data _: Data
+    ) async throws -> CompletedPartResult {
+        CompletedPartResult(partNumber: partNumber, etag: "etag-\(partNumber)")
+    }
+
+    func completeMultipartUpload(
+        bucket _: String, key _: String, uploadId _: String,
+        parts _: [(partNumber: Int, etag: String)]
+    ) async throws -> MultipartCompleteResult {
+        MultipartCompleteResult(etag: "mock-final-etag")
+    }
+
+    func abortMultipartUpload(bucket _: String, key _: String, uploadId _: String) async throws {
+        // No-op stub
+    }
+
+    func shutdown() throws {
+        // No-op stub
+    }
+}


### PR DESCRIPTION
## Summary
- After Phase A (.ds3keep markers), `.mayAlreadyExist` reimport path HEAD'd only the legacy `<folder>/` key
- Folders created by Phase A only have `<folder>/.ds3keep` — HEAD returned 404, causing silent re-PUT that reset LastModified
- Added `probeFolderExists()` that probes marker key first, falls back to legacy key for backward compat
- Files path unchanged

## Test plan
- [ ] 6 new unit tests: marker found, legacy fallback, both missing, error propagation, root-level folders
- [ ] Build macOS + iOS targets
- [ ] Verify reimporting a domain doesn't reset folder timestamps