### PR TITLE
fix(provider): folder rename moves .ds3keep marker correctly (closes #167)

### DIFF
--- a/DS3Drive.xcodeproj/project.pbxproj
+++ b/DS3Drive.xcodeproj/project.pbxproj
@@ -209,7 +209,7 @@
 		A1D5410101000000A1D54101 /* S3LibFolderMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */; };
 		A1D5410201000000A1D54102 /* S3LibFolderMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */; };
 		A1D5420101000000A1D54201 /* FolderMarkerCopyDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */; };
-		A1D5430101000000A1D54301 /* FolderMarkerProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5430001000000A1D54300 /* FolderMarkerProbeTests.swift */; };
+		A1D5430101000000A1D54301 /* FolderMarkerRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5430001000000A1D54300 /* FolderMarkerRenameTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -291,7 +291,7 @@
 		A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerEnumeratorTests.swift; sourceTree = "<group>"; };
 		A1D5410001000000A1D54100 /* S3LibFolderMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = S3LibFolderMarker.swift; sourceTree = "<group>"; };
 		A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerCopyDeleteTests.swift; sourceTree = "<group>"; };
-		A1D5430001000000A1D54300 /* FolderMarkerProbeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerProbeTests.swift; sourceTree = "<group>"; };
+		A1D5430001000000A1D54300 /* FolderMarkerRenameTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FolderMarkerRenameTests.swift; sourceTree = "<group>"; };
 		1823D7B17115B90E2FD9181D /* IOSSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSSettingsView.swift; sourceTree = "<group>"; };
 		2C71C4FFADB8DDE9EC58F5E2 /* SyncSetupViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncSetupViewModelTests.swift; sourceTree = "<group>"; };
 		39439872734512266C6F7F51 /* IOSMainTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IOSMainTabView.swift; sourceTree = "<group>"; };
@@ -697,7 +697,7 @@
 				A1D53EEE01000000A1D53EEE /* S3ItemWireKeyTests.swift */,
 				A1D5400001000000A1D54000 /* FolderMarkerEnumeratorTests.swift */,
 				A1D5420001000000A1D54200 /* FolderMarkerCopyDeleteTests.swift */,
-				A1D5430001000000A1D54300 /* FolderMarkerProbeTests.swift */,
+				A1D5430001000000A1D54300 /* FolderMarkerRenameTests.swift */,
 				A130601301000000A1306013 /* ThumbnailFetchLimiterTests.swift */,
 				A132010301000000A1320103 /* ThumbnailFallbackLimiterTests.swift */,
 				A141010301000000A1410103 /* ThumbnailUploadLimiterTests.swift */,
@@ -1428,7 +1428,7 @@
 				A1D53EEF01000000A1D53EEF /* S3ItemWireKeyTests.swift in Sources */,
 				A1D5400101000000A1D54001 /* FolderMarkerEnumeratorTests.swift in Sources */,
 				A1D5420101000000A1D54201 /* FolderMarkerCopyDeleteTests.swift in Sources */,
-				A1D5430101000000A1D54301 /* FolderMarkerProbeTests.swift in Sources */,
+				A1D5430101000000A1D54301 /* FolderMarkerRenameTests.swift in Sources */,
 				7FE55AB1B1E1D9BE5865060E /* TestFixtures.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DS3DriveProvider/S3Lib.swift
+++ b/DS3DriveProvider/S3Lib.swift
@@ -279,16 +279,10 @@ actor S3Lib {
         }
 
         // Explicitly delete the `.ds3keep` marker to close any race where it
-        // was PUT after the listing completed. S3 returns 204 for missing keys;
-        // guard against non-404 errors (permissions, network) so they don't
-        // abort an otherwise successful folder delete.
+        // was PUT after the listing completed. S3 returns 204 for missing keys.
         let markerKey = S3PathUtils.markerKey(forFolderKey: folderPrefix)
         self.logger.debug("Deleting folder marker \(markerKey, privacy: .public)")
-        do {
-            try await client.deleteObject(bucket: s3Item.drive.syncAnchor.bucket.name, key: markerKey)
-        } catch where DS3S3Client.isNotFoundError(error) {
-            self.logger.debug("Folder marker not found during delete (legacy folder) — \(markerKey, privacy: .public)")
-        }
+        try await client.deleteObject(bucket: s3Item.drive.syncAnchor.bucket.name, key: markerKey)
 
         self.logger.debug("Deleting enclosing folder \(folderPrefix, privacy: .public)")
         try await self.deleteS3Item(s3Item, withProgress: progress, force: true)

--- a/DS3DriveProvider/S3Lib.swift
+++ b/DS3DriveProvider/S3Lib.swift
@@ -278,14 +278,17 @@ actor S3Lib {
                 )
         }
 
-        // Phase A: explicitly delete the `.ds3keep` marker. The batch delete
-        // above covers it when the listing returns it, but an explicit delete
-        // closes any race / eventual-consistency gap where the marker was PUT
-        // after the listing completed (e.g. rapid create-then-rename on iOS).
-        // S3 returns 204 for non-existent keys, so this is always safe.
+        // Explicitly delete the `.ds3keep` marker to close any race where it
+        // was PUT after the listing completed. S3 returns 204 for missing keys;
+        // guard against non-404 errors (permissions, network) so they don't
+        // abort an otherwise successful folder delete.
         let markerKey = S3PathUtils.markerKey(forFolderKey: folderPrefix)
         self.logger.debug("Deleting folder marker \(markerKey, privacy: .public)")
-        try await client.deleteObject(bucket: s3Item.drive.syncAnchor.bucket.name, key: markerKey)
+        do {
+            try await client.deleteObject(bucket: s3Item.drive.syncAnchor.bucket.name, key: markerKey)
+        } catch where DS3S3Client.isNotFoundError(error) {
+            self.logger.debug("Folder marker not found during delete (legacy folder) — \(markerKey, privacy: .public)")
+        }
 
         self.logger.debug("Deleting enclosing folder \(folderPrefix, privacy: .public)")
         try await self.deleteS3Item(s3Item, withProgress: progress, force: true)
@@ -407,12 +410,8 @@ actor S3Lib {
             }
         } while continuationToken != nil
 
-        // Phase A: always ensure the destination has a `.ds3keep` marker.
-        // If the listing already copied it (copiedMarker == true), skip the
-        // duplicate work. Otherwise the marker was either not listed (race /
-        // eventual consistency) or the source is a legacy `<folder>/`
-        // placeholder — materializeEmptyFolderMarker handles both cases by
-        // trying a server-side copy first and falling back to a fresh PUT.
+        // Ensure the destination has a `.ds3keep` marker when the listing
+        // didn't already copy one (race / legacy `<folder>/` placeholder).
         if !copiedMarker {
             try await materializeEmptyFolderMarker(
                 sourcePrefix: sourcePrefix,

--- a/DS3DriveProvider/S3Lib.swift
+++ b/DS3DriveProvider/S3Lib.swift
@@ -278,6 +278,15 @@ actor S3Lib {
                 )
         }
 
+        // Phase A: explicitly delete the `.ds3keep` marker. The batch delete
+        // above covers it when the listing returns it, but an explicit delete
+        // closes any race / eventual-consistency gap where the marker was PUT
+        // after the listing completed (e.g. rapid create-then-rename on iOS).
+        // S3 returns 204 for non-existent keys, so this is always safe.
+        let markerKey = S3PathUtils.markerKey(forFolderKey: folderPrefix)
+        self.logger.debug("Deleting folder marker \(markerKey, privacy: .public)")
+        try await client.deleteObject(bucket: s3Item.drive.syncAnchor.bucket.name, key: markerKey)
+
         self.logger.debug("Deleting enclosing folder \(folderPrefix, privacy: .public)")
         try await self.deleteS3Item(s3Item, withProgress: progress, force: true)
     }
@@ -376,6 +385,7 @@ actor S3Lib {
         var continuationToken: String?
         var items = [S3Item]()
         let sourcePrefix = s3Item.itemIdentifier.rawValue
+        var copiedMarker = false
 
         repeat {
             (items, continuationToken) = try await self.listS3Items(
@@ -391,13 +401,19 @@ actor S3Lib {
                 let newKey = item.identifier.rawValue.replacingOccurrences(of: sourcePrefix, with: destinationPrefix)
                 self.logger.debug("Copying to \(newKey, privacy: .public)")
                 try await self.copyS3Item(item, toKey: newKey, withProgress: progress)
+                if S3PathUtils.isDS3KeepMarkerKey(item.identifier.rawValue) {
+                    copiedMarker = true
+                }
             }
         } while continuationToken != nil
 
-        if items.isEmpty {
-            // Phase A: an empty source folder has at most a `.ds3keep` marker.
-            // Copy it to the destination, or PUT a fresh marker if the source
-            // has none (legacy `<folder>/` placeholder or fresh-empty folder).
+        // Phase A: always ensure the destination has a `.ds3keep` marker.
+        // If the listing already copied it (copiedMarker == true), skip the
+        // duplicate work. Otherwise the marker was either not listed (race /
+        // eventual consistency) or the source is a legacy `<folder>/`
+        // placeholder — materializeEmptyFolderMarker handles both cases by
+        // trying a server-side copy first and falling back to a fresh PUT.
+        if !copiedMarker {
             try await materializeEmptyFolderMarker(
                 sourcePrefix: sourcePrefix,
                 destinationPrefix: destinationPrefix,

--- a/DS3DriveProvider/S3Lib.swift
+++ b/DS3DriveProvider/S3Lib.swift
@@ -279,10 +279,15 @@ actor S3Lib {
         }
 
         // Explicitly delete the `.ds3keep` marker to close any race where it
-        // was PUT after the listing completed. S3 returns 204 for missing keys.
+        // was PUT after the listing completed. Guard non-404 errors so they
+        // don't abort an otherwise successful folder delete.
         let markerKey = S3PathUtils.markerKey(forFolderKey: folderPrefix)
         self.logger.debug("Deleting folder marker \(markerKey, privacy: .public)")
-        try await client.deleteObject(bucket: s3Item.drive.syncAnchor.bucket.name, key: markerKey)
+        do {
+            try await client.deleteObject(bucket: s3Item.drive.syncAnchor.bucket.name, key: markerKey)
+        } catch where DS3S3Client.isNotFoundError(error) {
+            self.logger.debug("Folder marker not found during delete — \(markerKey, privacy: .public)")
+        }
 
         self.logger.debug("Deleting enclosing folder \(folderPrefix, privacy: .public)")
         try await self.deleteS3Item(s3Item, withProgress: progress, force: true)

--- a/DS3DriveProviderTests/FolderMarkerRenameTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerRenameTests.swift
@@ -7,20 +7,20 @@ import XCTest
 
 /// Issue #167: folder rename must move the `.ds3keep` marker from old to new
 /// location and explicitly delete the old marker so no ghost folder remains.
-///
-/// Tests exercise both the marker-copy path (`materializeEmptyFolderMarker`)
-/// and the marker-delete path (`S3PathUtils.markerKey` + `deleteObject`),
-/// simulating the scenarios that arise during a create-then-rename on iOS.
 final class FolderMarkerRenameTests: XCTestCase {
     private func logger() -> os.Logger {
         os.Logger(subsystem: "io.cubbit.DS3Drive.tests", category: "marker-rename")
     }
 
+    private func makeMock(withHeadKeys keys: [String] = []) -> RenameMockS3Client {
+        let mock = RenameMockS3Client()
+        mock.headKeys = Set(keys)
+        return mock
+    }
+
     // MARK: - Marker key computation for delete
 
     func testMarkerKeyForFolderPrefix() {
-        // deleteFolder explicitly deletes markerKey(forFolderKey: folderPrefix).
-        // Verify the computed key matches the `.ds3keep` convention.
         XCTAssertEqual(
             S3PathUtils.markerKey(forFolderKey: "prefix/Untitled folder/"),
             "prefix/Untitled folder/.ds3keep"
@@ -51,8 +51,6 @@ final class FolderMarkerRenameTests: XCTestCase {
     // MARK: - Rename copies marker to destination
 
     func testRenameMarkerCopiedViaLoop() {
-        // When the listing returns .ds3keep, copyFolder copies it in the loop.
-        // Verify the string replacement logic produces the correct destination key.
         let sourceKey = "prefix/Untitled folder/.ds3keep"
         let destKey = sourceKey.replacingOccurrences(
             of: "prefix/Untitled folder/",
@@ -62,21 +60,11 @@ final class FolderMarkerRenameTests: XCTestCase {
     }
 
     func testRenameMarkerDetectedByIsDS3KeepMarkerKey() {
-        // copyFolder uses isDS3KeepMarkerKey to track whether the marker was
-        // already copied in the listing loop, skipping the fallback
-        // materializeEmptyFolderMarker call when it was.
-        let markerKey = "prefix/Untitled folder/.ds3keep"
-        XCTAssertTrue(
-            S3PathUtils.isDS3KeepMarkerKey(markerKey),
-            "copyFolder must recognize .ds3keep items in the listing to set copiedMarker"
-        )
+        XCTAssertTrue(S3PathUtils.isDS3KeepMarkerKey("prefix/Untitled folder/.ds3keep"))
     }
 
     func testRenameMarkerMaterializedWhenListingEmpty() async throws {
-        // When the listing returns nothing (race / eventual consistency),
-        // materializeEmptyFolderMarker is called to ensure the destination
-        // has a marker.
-        let mock = RenameMockS3Client()
+        let mock = makeMock()
         try await materializeEmptyFolderMarker(
             sourcePrefix: "prefix/Untitled folder/",
             destinationPrefix: "prefix/NewName/",
@@ -84,16 +72,12 @@ final class FolderMarkerRenameTests: XCTestCase {
             client: mock,
             logger: logger()
         )
-        // Source marker doesn't exist (default mock behavior), so fallback PUT fires
         XCTAssertEqual(mock.putKey, "prefix/NewName/.ds3keep")
         XCTAssertNil(mock.putFileURL, "Marker PUT must be zero-byte")
     }
 
     func testRenameMarkerMaterializedWhenSourceExists() async throws {
-        // When materializeEmptyFolderMarker can copy the source marker,
-        // it does so instead of PUTting a fresh one.
-        let mock = RenameMockS3Client()
-        mock.headKeys.insert("prefix/Untitled folder/.ds3keep")
+        let mock = makeMock(withHeadKeys: ["prefix/Untitled folder/.ds3keep"])
         try await materializeEmptyFolderMarker(
             sourcePrefix: "prefix/Untitled folder/",
             destinationPrefix: "prefix/NewName/",
@@ -109,33 +93,26 @@ final class FolderMarkerRenameTests: XCTestCase {
     // MARK: - Delete side: explicit marker cleanup
 
     func testDeleteMarkerKeyMatchesCreatedMarker() {
-        // The explicit delete in deleteFolder uses markerKey(forFolderKey:).
-        // Verify it targets the same key that createItem PUTs via wireKey.
         let drive = ProviderTestFixtures.makeDrive()
         let folder = ProviderTestFixtures.makeItem(key: "prefix/Untitled folder/", drive: drive)
 
-        let wireKey = folder.wireKey
-        let deleteKey = S3PathUtils.markerKey(forFolderKey: folder.itemIdentifier.rawValue)
-
         XCTAssertEqual(
-            wireKey,
-            deleteKey,
+            folder.wireKey,
+            S3PathUtils.markerKey(forFolderKey: folder.itemIdentifier.rawValue),
             "deleteFolder must target the same key that createItem PUT via wireKey"
         )
     }
 
     func testDeleteMarkerKeyAfterRename() {
-        // After rename from "Untitled folder" to "NewName", the OLD marker
-        // must be deleted. Verify the key computation for the old folder.
-        let oldFolderKey = "prefix/Untitled folder/"
-        let markerToDelete = S3PathUtils.markerKey(forFolderKey: oldFolderKey)
-        XCTAssertEqual(markerToDelete, "prefix/Untitled folder/.ds3keep")
+        XCTAssertEqual(
+            S3PathUtils.markerKey(forFolderKey: "prefix/Untitled folder/"),
+            "prefix/Untitled folder/.ds3keep"
+        )
     }
 
     // MARK: - isDS3KeepMarkerKey detection
 
     func testIsDS3KeepMarkerKeyForRenameFlow() {
-        // copyFolder tracks copiedMarker by checking isDS3KeepMarkerKey.
         XCTAssertTrue(S3PathUtils.isDS3KeepMarkerKey("prefix/Untitled folder/.ds3keep"))
         XCTAssertTrue(S3PathUtils.isDS3KeepMarkerKey("prefix/NewName/.ds3keep"))
         XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/Untitled folder/"))
@@ -145,36 +122,19 @@ final class FolderMarkerRenameTests: XCTestCase {
     // MARK: - Folder rename key computation (renameS3Item path)
 
     func testRenameFolderKeyComputation() {
-        // renameS3Item computes the new key by replacing the last path component.
-        // Verify this works for folder keys (trailing delimiter).
-        let oldKey = "prefix/Untitled folder/"
-        let isFolder = oldKey.hasSuffix("/")
-        let trimmed = isFolder ? String(oldKey.dropLast()) : oldKey
-        let components = trimmed.split(separator: Character("/"))
-        let parentPath = components.dropLast().joined(separator: "/")
-        let newName = "NewName"
-        let newKey = parentPath + "/" + newName + (isFolder ? "/" : "")
+        let newKey = computeRenamedFolderKey("prefix/Untitled folder/", newName: "NewName")
         XCTAssertEqual(newKey, "prefix/NewName/")
     }
 
     func testRenameNestedFolderKeyComputation() {
-        let oldKey = "prefix/parent/Untitled folder/"
-        let isFolder = oldKey.hasSuffix("/")
-        let trimmed = isFolder ? String(oldKey.dropLast()) : oldKey
-        let components = trimmed.split(separator: Character("/"))
-        let parentPath = components.dropLast().joined(separator: "/")
-        let newName = "NewName"
-        let newKey = parentPath + "/" + newName + (isFolder ? "/" : "")
+        let newKey = computeRenamedFolderKey("prefix/parent/Untitled folder/", newName: "NewName")
         XCTAssertEqual(newKey, "prefix/parent/NewName/")
     }
 
     // MARK: - Edge cases
 
     func testMarkerCopyWithLocalizedUntitledFolder() async throws {
-        // iOS may use localized "Untitled folder" names with spaces/special chars.
-        // Verify marker logic handles them.
-        let mock = RenameMockS3Client()
-        mock.headKeys.insert("prefix/Cartella senza titolo/.ds3keep")
+        let mock = makeMock(withHeadKeys: ["prefix/Cartella senza titolo/.ds3keep"])
         try await materializeEmptyFolderMarker(
             sourcePrefix: "prefix/Cartella senza titolo/",
             destinationPrefix: "prefix/Nuova cartella/",
@@ -187,9 +147,7 @@ final class FolderMarkerRenameTests: XCTestCase {
     }
 
     func testMarkerCopyWithFolderContainingDots() async throws {
-        // Folder names can contain dots — ensure markerKey doesn't confuse them.
-        let mock = RenameMockS3Client()
-        mock.headKeys.insert("prefix/my.folder.v2/.ds3keep")
+        let mock = makeMock(withHeadKeys: ["prefix/my.folder.v2/.ds3keep"])
         try await materializeEmptyFolderMarker(
             sourcePrefix: "prefix/my.folder.v2/",
             destinationPrefix: "prefix/renamed/",
@@ -200,26 +158,33 @@ final class FolderMarkerRenameTests: XCTestCase {
         XCTAssertEqual(mock.copiedFrom, "prefix/my.folder.v2/.ds3keep")
         XCTAssertEqual(mock.copiedTo, "prefix/renamed/.ds3keep")
     }
+
+    // MARK: - Helpers
+
+    /// Mirrors the rename key computation from `renameS3Item`.
+    private func computeRenamedFolderKey(_ oldKey: String, newName: String) -> String {
+        let isFolder = oldKey.hasSuffix("/")
+        let trimmed = isFolder ? String(oldKey.dropLast()) : oldKey
+        let components = trimmed.split(separator: Character("/"))
+        let parentPath = components.dropLast().joined(separator: "/")
+        return parentPath + "/" + newName + (isFolder ? "/" : "")
+    }
 }
 
 // MARK: - Test mock
 
-/// Mock S3 client for folder rename tests. Records copy, put, and delete calls.
-/// Extends the pattern from `MarkerCopyMockS3Client` with support for
-/// configurable HEAD responses and delete tracking.
+/// Mock S3 client for folder rename tests. Records copy and put calls,
+/// with configurable HEAD responses to simulate marker presence.
 private final class RenameMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
     var copiedFrom: String?
     var copiedTo: String?
-    var copiedBucket: String?
     var copyObjectError: Error?
 
     var putKey: String?
     var putFileURL: URL?
     var putObjectError: Error?
 
-    var deletedKeys: [String] = []
-
-    /// Keys that HEAD succeeds for. All other HEAD calls throw NotFound.
+    /// Keys that HEAD and copyObject succeed for. All others throw NoSuchKey.
     var headKeys: Set<String> = []
 
     func listBuckets() async throws -> [(name: String, creationDate: Date?)] {
@@ -243,25 +208,22 @@ private final class RenameMockS3Client: DS3S3ClientProtocol, @unchecked Sendable
         )
     }
 
-    func deleteObject(bucket _: String, key: String) async throws {
-        deletedKeys.append(key)
+    func deleteObject(bucket _: String, key _: String) async throws {
+        // No-op
     }
 
-    func deleteObjects(bucket _: String, keys: [String]) async throws -> Int {
-        deletedKeys.append(contentsOf: keys)
-        return 0
+    func deleteObjects(bucket _: String, keys _: [String]) async throws -> Int {
+        0
     }
 
     func copyObject(
-        bucket: String, sourceKey: String,
+        bucket _: String, sourceKey: String,
         destinationKey: String, metadata _: [String: String]?
     ) async throws {
         if let copyObjectError { throw copyObjectError }
-        // Simulate S3 behavior: copy fails if source doesn't exist
         guard headKeys.contains(sourceKey) else {
             throw S3ErrorType.noSuchKey
         }
-        copiedBucket = bucket
         copiedFrom = sourceKey
         copiedTo = destinationKey
     }
@@ -313,10 +275,10 @@ private final class RenameMockS3Client: DS3S3ClientProtocol, @unchecked Sendable
     }
 
     func abortMultipartUpload(bucket _: String, key _: String, uploadId _: String) async throws {
-        // No-op stub
+        // No-op
     }
 
     func shutdown() throws {
-        // No-op stub
+        // No-op
     }
 }

--- a/DS3DriveProviderTests/FolderMarkerRenameTests.swift
+++ b/DS3DriveProviderTests/FolderMarkerRenameTests.swift
@@ -1,0 +1,322 @@
+@testable import DS3Lib
+import FileProvider
+import Foundation
+import os.log
+import SotoS3
+import XCTest
+
+/// Issue #167: folder rename must move the `.ds3keep` marker from old to new
+/// location and explicitly delete the old marker so no ghost folder remains.
+///
+/// Tests exercise both the marker-copy path (`materializeEmptyFolderMarker`)
+/// and the marker-delete path (`S3PathUtils.markerKey` + `deleteObject`),
+/// simulating the scenarios that arise during a create-then-rename on iOS.
+final class FolderMarkerRenameTests: XCTestCase {
+    private func logger() -> os.Logger {
+        os.Logger(subsystem: "io.cubbit.DS3Drive.tests", category: "marker-rename")
+    }
+
+    // MARK: - Marker key computation for delete
+
+    func testMarkerKeyForFolderPrefix() {
+        // deleteFolder explicitly deletes markerKey(forFolderKey: folderPrefix).
+        // Verify the computed key matches the `.ds3keep` convention.
+        XCTAssertEqual(
+            S3PathUtils.markerKey(forFolderKey: "prefix/Untitled folder/"),
+            "prefix/Untitled folder/.ds3keep"
+        )
+    }
+
+    func testMarkerKeyForFolderPrefixWithoutTrailingSlash() {
+        XCTAssertEqual(
+            S3PathUtils.markerKey(forFolderKey: "prefix/Untitled folder"),
+            "prefix/Untitled folder/.ds3keep"
+        )
+    }
+
+    func testMarkerKeyForNestedFolder() {
+        XCTAssertEqual(
+            S3PathUtils.markerKey(forFolderKey: "prefix/parent/child/"),
+            "prefix/parent/child/.ds3keep"
+        )
+    }
+
+    func testMarkerKeyForRootFolder() {
+        XCTAssertEqual(
+            S3PathUtils.markerKey(forFolderKey: "folder/"),
+            "folder/.ds3keep"
+        )
+    }
+
+    // MARK: - Rename copies marker to destination
+
+    func testRenameMarkerCopiedViaLoop() {
+        // When the listing returns .ds3keep, copyFolder copies it in the loop.
+        // Verify the string replacement logic produces the correct destination key.
+        let sourceKey = "prefix/Untitled folder/.ds3keep"
+        let destKey = sourceKey.replacingOccurrences(
+            of: "prefix/Untitled folder/",
+            with: "prefix/NewName/"
+        )
+        XCTAssertEqual(destKey, "prefix/NewName/.ds3keep")
+    }
+
+    func testRenameMarkerDetectedByIsDS3KeepMarkerKey() {
+        // copyFolder uses isDS3KeepMarkerKey to track whether the marker was
+        // already copied in the listing loop, skipping the fallback
+        // materializeEmptyFolderMarker call when it was.
+        let markerKey = "prefix/Untitled folder/.ds3keep"
+        XCTAssertTrue(
+            S3PathUtils.isDS3KeepMarkerKey(markerKey),
+            "copyFolder must recognize .ds3keep items in the listing to set copiedMarker"
+        )
+    }
+
+    func testRenameMarkerMaterializedWhenListingEmpty() async throws {
+        // When the listing returns nothing (race / eventual consistency),
+        // materializeEmptyFolderMarker is called to ensure the destination
+        // has a marker.
+        let mock = RenameMockS3Client()
+        try await materializeEmptyFolderMarker(
+            sourcePrefix: "prefix/Untitled folder/",
+            destinationPrefix: "prefix/NewName/",
+            bucket: "bucket",
+            client: mock,
+            logger: logger()
+        )
+        // Source marker doesn't exist (default mock behavior), so fallback PUT fires
+        XCTAssertEqual(mock.putKey, "prefix/NewName/.ds3keep")
+        XCTAssertNil(mock.putFileURL, "Marker PUT must be zero-byte")
+    }
+
+    func testRenameMarkerMaterializedWhenSourceExists() async throws {
+        // When materializeEmptyFolderMarker can copy the source marker,
+        // it does so instead of PUTting a fresh one.
+        let mock = RenameMockS3Client()
+        mock.headKeys.insert("prefix/Untitled folder/.ds3keep")
+        try await materializeEmptyFolderMarker(
+            sourcePrefix: "prefix/Untitled folder/",
+            destinationPrefix: "prefix/NewName/",
+            bucket: "bucket",
+            client: mock,
+            logger: logger()
+        )
+        XCTAssertEqual(mock.copiedFrom, "prefix/Untitled folder/.ds3keep")
+        XCTAssertEqual(mock.copiedTo, "prefix/NewName/.ds3keep")
+        XCTAssertNil(mock.putKey, "PUT must not be issued when copy succeeded")
+    }
+
+    // MARK: - Delete side: explicit marker cleanup
+
+    func testDeleteMarkerKeyMatchesCreatedMarker() {
+        // The explicit delete in deleteFolder uses markerKey(forFolderKey:).
+        // Verify it targets the same key that createItem PUTs via wireKey.
+        let drive = ProviderTestFixtures.makeDrive()
+        let folder = ProviderTestFixtures.makeItem(key: "prefix/Untitled folder/", drive: drive)
+
+        let wireKey = folder.wireKey
+        let deleteKey = S3PathUtils.markerKey(forFolderKey: folder.itemIdentifier.rawValue)
+
+        XCTAssertEqual(
+            wireKey,
+            deleteKey,
+            "deleteFolder must target the same key that createItem PUT via wireKey"
+        )
+    }
+
+    func testDeleteMarkerKeyAfterRename() {
+        // After rename from "Untitled folder" to "NewName", the OLD marker
+        // must be deleted. Verify the key computation for the old folder.
+        let oldFolderKey = "prefix/Untitled folder/"
+        let markerToDelete = S3PathUtils.markerKey(forFolderKey: oldFolderKey)
+        XCTAssertEqual(markerToDelete, "prefix/Untitled folder/.ds3keep")
+    }
+
+    // MARK: - isDS3KeepMarkerKey detection
+
+    func testIsDS3KeepMarkerKeyForRenameFlow() {
+        // copyFolder tracks copiedMarker by checking isDS3KeepMarkerKey.
+        XCTAssertTrue(S3PathUtils.isDS3KeepMarkerKey("prefix/Untitled folder/.ds3keep"))
+        XCTAssertTrue(S3PathUtils.isDS3KeepMarkerKey("prefix/NewName/.ds3keep"))
+        XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/Untitled folder/"))
+        XCTAssertFalse(S3PathUtils.isDS3KeepMarkerKey("prefix/photo.jpg"))
+    }
+
+    // MARK: - Folder rename key computation (renameS3Item path)
+
+    func testRenameFolderKeyComputation() {
+        // renameS3Item computes the new key by replacing the last path component.
+        // Verify this works for folder keys (trailing delimiter).
+        let oldKey = "prefix/Untitled folder/"
+        let isFolder = oldKey.hasSuffix("/")
+        let trimmed = isFolder ? String(oldKey.dropLast()) : oldKey
+        let components = trimmed.split(separator: Character("/"))
+        let parentPath = components.dropLast().joined(separator: "/")
+        let newName = "NewName"
+        let newKey = parentPath + "/" + newName + (isFolder ? "/" : "")
+        XCTAssertEqual(newKey, "prefix/NewName/")
+    }
+
+    func testRenameNestedFolderKeyComputation() {
+        let oldKey = "prefix/parent/Untitled folder/"
+        let isFolder = oldKey.hasSuffix("/")
+        let trimmed = isFolder ? String(oldKey.dropLast()) : oldKey
+        let components = trimmed.split(separator: Character("/"))
+        let parentPath = components.dropLast().joined(separator: "/")
+        let newName = "NewName"
+        let newKey = parentPath + "/" + newName + (isFolder ? "/" : "")
+        XCTAssertEqual(newKey, "prefix/parent/NewName/")
+    }
+
+    // MARK: - Edge cases
+
+    func testMarkerCopyWithLocalizedUntitledFolder() async throws {
+        // iOS may use localized "Untitled folder" names with spaces/special chars.
+        // Verify marker logic handles them.
+        let mock = RenameMockS3Client()
+        mock.headKeys.insert("prefix/Cartella senza titolo/.ds3keep")
+        try await materializeEmptyFolderMarker(
+            sourcePrefix: "prefix/Cartella senza titolo/",
+            destinationPrefix: "prefix/Nuova cartella/",
+            bucket: "bucket",
+            client: mock,
+            logger: logger()
+        )
+        XCTAssertEqual(mock.copiedFrom, "prefix/Cartella senza titolo/.ds3keep")
+        XCTAssertEqual(mock.copiedTo, "prefix/Nuova cartella/.ds3keep")
+    }
+
+    func testMarkerCopyWithFolderContainingDots() async throws {
+        // Folder names can contain dots — ensure markerKey doesn't confuse them.
+        let mock = RenameMockS3Client()
+        mock.headKeys.insert("prefix/my.folder.v2/.ds3keep")
+        try await materializeEmptyFolderMarker(
+            sourcePrefix: "prefix/my.folder.v2/",
+            destinationPrefix: "prefix/renamed/",
+            bucket: "bucket",
+            client: mock,
+            logger: logger()
+        )
+        XCTAssertEqual(mock.copiedFrom, "prefix/my.folder.v2/.ds3keep")
+        XCTAssertEqual(mock.copiedTo, "prefix/renamed/.ds3keep")
+    }
+}
+
+// MARK: - Test mock
+
+/// Mock S3 client for folder rename tests. Records copy, put, and delete calls.
+/// Extends the pattern from `MarkerCopyMockS3Client` with support for
+/// configurable HEAD responses and delete tracking.
+private final class RenameMockS3Client: DS3S3ClientProtocol, @unchecked Sendable {
+    var copiedFrom: String?
+    var copiedTo: String?
+    var copiedBucket: String?
+    var copyObjectError: Error?
+
+    var putKey: String?
+    var putFileURL: URL?
+    var putObjectError: Error?
+
+    var deletedKeys: [String] = []
+
+    /// Keys that HEAD succeeds for. All other HEAD calls throw NotFound.
+    var headKeys: Set<String> = []
+
+    func listBuckets() async throws -> [(name: String, creationDate: Date?)] {
+        []
+    }
+
+    func listObjects(
+        bucket _: String, prefix _: String?, delimiter _: String?,
+        maxKeys _: Int?, continuationToken _: String?
+    ) async throws -> S3ListingResult {
+        S3ListingResult(objects: [], commonPrefixes: [], nextContinuationToken: nil, isTruncated: false)
+    }
+
+    func headObject(bucket _: String, key: String) async throws -> S3ObjectMetadata {
+        guard headKeys.contains(key) else {
+            throw S3ErrorType.noSuchKey
+        }
+        return S3ObjectMetadata(
+            etag: "mock-etag", contentType: nil, lastModified: nil,
+            versionId: nil, contentLength: 0, metadata: nil
+        )
+    }
+
+    func deleteObject(bucket _: String, key: String) async throws {
+        deletedKeys.append(key)
+    }
+
+    func deleteObjects(bucket _: String, keys: [String]) async throws -> Int {
+        deletedKeys.append(contentsOf: keys)
+        return 0
+    }
+
+    func copyObject(
+        bucket: String, sourceKey: String,
+        destinationKey: String, metadata _: [String: String]?
+    ) async throws {
+        if let copyObjectError { throw copyObjectError }
+        // Simulate S3 behavior: copy fails if source doesn't exist
+        guard headKeys.contains(sourceKey) else {
+            throw S3ErrorType.noSuchKey
+        }
+        copiedBucket = bucket
+        copiedFrom = sourceKey
+        copiedTo = destinationKey
+    }
+
+    func getObject(
+        bucket _: String, key _: String,
+        toFile _: URL, onProgress _: TransferProgressHandler?
+    ) async throws -> S3DownloadResult {
+        throw DS3ClientError.parseError
+    }
+
+    func getObjectData(bucket _: String, key _: String) async throws -> Data {
+        Data()
+    }
+
+    func putObject(
+        bucket _: String, key: String,
+        fileURL: URL?, onProgress _: TransferProgressHandler?
+    ) async throws -> String? {
+        if let putObjectError { throw putObjectError }
+        putKey = key
+        putFileURL = fileURL
+        return "mock-etag"
+    }
+
+    func putObjectData(
+        bucket _: String, key _: String,
+        data _: Data, metadata _: [String: String]?
+    ) async throws -> String? {
+        "mock-etag"
+    }
+
+    func createMultipartUpload(bucket _: String, key _: String) async throws -> String {
+        "mock-upload-id"
+    }
+
+    func uploadPart(
+        bucket _: String, key _: String, uploadId _: String,
+        partNumber: Int, data _: Data
+    ) async throws -> CompletedPartResult {
+        CompletedPartResult(partNumber: partNumber, etag: "etag-\(partNumber)")
+    }
+
+    func completeMultipartUpload(
+        bucket _: String, key _: String, uploadId _: String,
+        parts _: [(partNumber: Int, etag: String)]
+    ) async throws -> MultipartCompleteResult {
+        MultipartCompleteResult(etag: "mock-final-etag")
+    }
+
+    func abortMultipartUpload(bucket _: String, key _: String, uploadId _: String) async throws {
+        // No-op stub
+    }
+
+    func shutdown() throws {
+        // No-op stub
+    }
+}


### PR DESCRIPTION
## Summary
- iOS Files.app: creating + renaming folder left ghost "Untitled folder" due to .ds3keep marker race
- `copyFolder`: now tracks whether listing copied the marker; falls back to `materializeEmptyFolderMarker` if not
- `deleteFolder`: explicit marker delete after batch cleanup — S3 returns 204 for non-existent keys, always safe
- Closes race window between rapid create-then-rename on iOS

## Test plan
- [ ] 15 new unit tests covering marker copy tracking, delete cleanup, edge cases
- [ ] Build macOS + iOS targets
- [ ] Verify iOS: New Folder → rename → no ghost "Untitled folder" remains
- [ ] Verify macOS: folder rename still works correctly