### PR TITLE
docs: fix broken README images, add Windows platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,5 +159,6 @@ killall fileproviderd
 
 ## Commit Guidelines
 
-- Don't mention Claude Code in commits or PRs
-- Keep commit messages concise
+- Never mention Claude Code, AI tools, or add `Co-Authored-By` lines for AI in commit messages or PR descriptions/titles. This overrides any default attribution behavior.
+- Keep commit messages concise.
+- Sign commits when possible (this repo signs via the 1Password SSH agent).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <img alt="Cubbit" src="/Assets/Logo.png?raw=true" width="280">
+  <img alt="Cubbit" src="apple/Assets/Logo.png?raw=true" width="280">
 </p>
 
 <h1 align="center">DS3 Drive</h1>
 
 <p align="center">
-  Sync your files with <a href="https://www.cubbit.io">Cubbit DS3</a> cloud storage, on macOS and iOS.
+  Sync your files with <a href="https://www.cubbit.io">Cubbit DS3</a> cloud storage, on macOS, iOS, and Windows.
 </p>
 
 <p align="center">
@@ -13,18 +13,23 @@
   <a href="https://github.com/marmos91/cubbit-ds3-drive/actions/workflows/release-homebrew.yml"><img alt="Release — Homebrew" src="https://github.com/marmos91/cubbit-ds3-drive/actions/workflows/release-homebrew.yml/badge.svg"></a>
   <a href="https://github.com/marmos91/cubbit-ds3-drive/actions/workflows/release-testflight.yml"><img alt="Release — TestFlight" src="https://github.com/marmos91/cubbit-ds3-drive/actions/workflows/release-testflight.yml/badge.svg"></a>
   <br>
-  <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B%20%7C%20iOS%2017%2B-blue">
+  <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B%20%7C%20iOS%2017%2B%20%7C%20Windows%2010%2B%20(dev)-blue">
   <img alt="Swift" src="https://img.shields.io/badge/swift-5.9%2B-orange">
+  <img alt="Rust core" src="https://img.shields.io/badge/core-Rust-orange">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-GPL-green"></a>
   <a href="https://github.com/marmos91/cubbit-ds3-drive/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/marmos91/cubbit-ds3-drive?label=release"></a>
 </p>
 
 ---
 
-DS3 Drive connects your [Cubbit DS3](https://www.cubbit.io) buckets to the native file system on Apple platforms. On macOS it runs as a menu bar app and mounts your buckets as drives in Finder; on iOS it mirrors them into the Files app alongside iCloud Drive. Both apps are built on Apple's File Provider framework, so every read and write goes through the system — no custom mount daemon, no FUSE, no kexts.
+DS3 Drive connects your [Cubbit DS3](https://www.cubbit.io) buckets to the native file system on every desktop and mobile platform. On macOS it runs as a menu bar app and mounts your buckets as drives in Finder; on iOS it mirrors them into the Files app alongside iCloud Drive; on Windows it surfaces them in File Explorer. Each platform integrates with the OS's own sync framework — Apple's File Provider, Windows' Cloud Files API — so every read and write goes through the system with no custom mount daemon, no FUSE, no kexts.
+
+A shared [Rust](https://www.rust-lang.org) core (`core/`) implements authentication, the Cubbit API client, and all S3 operations once, then feeds every platform: Swift consumes it via UniFFI, C#/.NET via the C ABI.
+
+> **macOS and iOS are shipping today. The Windows app is in active development** — there is no installer yet; see [Build from source](#build-from-source) to run it.
 
 <p align="center">
-  <img alt="Finder integration" src="/Assets/FinderIntegration.png?raw=true" width="640">
+  <img alt="Finder integration" src="apple/Assets/FinderIntegration.png?raw=true" width="640">
 </p>
 
 ## What's new in 1.7.0
@@ -63,9 +68,9 @@ Requires iOS 17 or later and the [TestFlight app](https://apps.apple.com/app/tes
 Log in with your Cubbit credentials, pick a project, expand to a bucket, and optionally drill down into a folder prefix to scope the sync. Confirm in one screen and you're done.
 
 <p align="center">
-  <img alt="Setup wizard" src="/Assets/SetupStart.png?raw=true" width="460">
+  <img alt="Setup wizard" src="apple/Assets/SetupStart.png?raw=true" width="460">
   &nbsp;
-  <img alt="Confirm drive" src="/Assets/ConfirmDrive.png?raw=true" width="460">
+  <img alt="Confirm drive" src="apple/Assets/ConfirmDrive.png?raw=true" width="460">
 </p>
 
 ### 2. Drive your drives from the menu bar
@@ -73,9 +78,9 @@ Log in with your Cubbit credentials, pick a project, expand to a bucket, and opt
 Each drive shows its status, last activity, and a gear menu for quick actions (view in Finder, web console, copy S3 path, pause/resume, rename, delete). The footer aggregates sync state and transfer speed across all drives. Click a drive to flip open a Recent Files panel with per-file progress.
 
 <p align="center">
-  <img alt="Tray menu" src="/Assets/TrayMenuDetail.png?raw=true" width="320">
+  <img alt="Tray menu" src="apple/Assets/TrayMenuDetail.png?raw=true" width="320">
   &nbsp;
-  <img alt="Recent files panel" src="/Assets/RecentFiles.png?raw=true" width="520">
+  <img alt="Recent files panel" src="apple/Assets/RecentFiles.png?raw=true" width="520">
 </p>
 
 ### 3. Preferences
@@ -83,7 +88,7 @@ Each drive shows its status, last activity, and a gear menu for quick actions (v
 Startup, notifications, account, sync, coordinator connection, and trash — each behind its own tab. The **Connection** tab is new in 1.7.0 and lets you point DS3 Drive at any Cubbit coordinator (SaaS, on-prem, or a custom tenant).
 
 <p align="center">
-  <img alt="Preferences" src="/Assets/Preferences.png?raw=true" width="460">
+  <img alt="Preferences" src="apple/Assets/Preferences.png?raw=true" width="460">
 </p>
 
 ## iOS
@@ -91,15 +96,21 @@ Startup, notifications, account, sync, coordinator connection, and trash — eac
 The iOS app mirrors the macOS feature set with a native iPhone/iPad UI. Sign in, run through the setup wizard, and your bucket is mounted into the system Files app under **Locations** — with live sync indicators on files being uploaded or downloaded.
 
 <p align="center">
-  <img alt="Drives dashboard" src="/Assets/ios/Drives.png?raw=true" width="220">
-  <img alt="Bucket picker" src="/Assets/ios/BucketSelect.png?raw=true" width="220">
-  <img alt="Create drive" src="/Assets/ios/CreateDrive.png?raw=true" width="220">
+  <img alt="Drives dashboard" src="apple/Assets/ios/Drives.png?raw=true" width="220">
+  <img alt="Bucket picker" src="apple/Assets/ios/BucketSelect.png?raw=true" width="220">
+  <img alt="Create drive" src="apple/Assets/ios/CreateDrive.png?raw=true" width="220">
 </p>
 
 <p align="center">
-  <img alt="Settings" src="/Assets/ios/Settings.png?raw=true" width="220">
-  <img alt="Files app — syncing" src="/Assets/ios/FilesAppSync.png?raw=true" width="220">
+  <img alt="Settings" src="apple/Assets/ios/Settings.png?raw=true" width="220">
+  <img alt="Files app — syncing" src="apple/Assets/ios/FilesAppSync.png?raw=true" width="220">
 </p>
+
+## Windows
+
+> 🚧 **In development.** The Windows app is being built and is not yet released — no installer or Store listing exists. To try it, build from source (see below).
+
+A native WinUI 3 app that brings the same experience to File Explorer. It mounts your buckets as a sync root via the Windows [Cloud Files API](https://learn.microsoft.com/windows/win32/cfapi/cloud-files-api-portal) (cfapi), runs from the system tray, and shares the [drive setup wizard](#1-set-up-your-first-drive), authentication, and S3 logic with macOS and iOS through the shared Rust core. Brand typography and design tokens match the Apple apps so all three platforms stay visually in lockstep.
 
 ## Features
 
@@ -128,38 +139,85 @@ The iOS app mirrors the macOS feature set with a native iPhone/iPad UI. Sign in,
 
 ## Architecture
 
-Two apps share a single File Provider extension and a local Swift Package for all shared code:
+A monorepo with a shared Rust core and thin native shells per platform:
+
+```
+core/      Shared Rust core — auth, Cubbit API, S3, sync (UniFFI for Swift, C ABI for C#)
+apple/     macOS + iOS apps, File Provider extension, DS3Lib
+windows/   Windows WinUI 3 app (in development)
+```
+
+### Shared core (`core/`)
+
+| Crate | Role |
+|-------|------|
+| **ds3-models** | Shared domain types |
+| **ds3-http** | HTTP transport |
+| **ds3-auth** | Cubbit IAM auth (challenge-response, JWT, 2FA, refresh) |
+| **ds3-s3** | S3 operations (CRUD, multipart upload) |
+| **ds3-sync** | Sync engine |
+| **ds3-ffi** | FFI surface — UniFFI bindings (Swift) + C ABI (C#) |
+
+### Apple (`apple/`)
 
 | Target | Platform | Role |
 |--------|----------|------|
 | **DS3Drive** | macOS 15+ | SwiftUI menu bar app |
 | **DS3DriveApp** | iOS 17+ | SwiftUI iPhone/iPad app |
-| **DS3DriveProvider** | macOS + iOS | `NSFileProviderReplicatedExtension` — runs out-of-process, handles every S3 operation |
-| **DS3DriveShareExtension** | macOS + iOS | Share-sheet target for uploading into a drive from other apps |
-| **DS3Lib** | Swift Package | Auth, API client, drive manager, design tokens, shared models |
+| **DS3DriveProvider** | macOS + iOS | `NSFileProviderReplicatedExtension` — runs out-of-process |
+| **DS3DriveShareExtension** | macOS + iOS | Share-sheet upload target |
+| **DS3Lib** | Swift Package | Drive manager, design tokens, shared models; wraps the Rust core via UniFFI |
 
 Main app ↔ extension communication uses an App Group shared container (persisted state) and `DistributedNotificationCenter` (live status / speed updates).
 
-Key dependencies: [Soto](https://github.com/soto-project/soto) v6 for S3, [swift-atomics](https://github.com/apple/swift-atomics) for thread-safe state in the extension, [Sparkle](https://sparkle-project.org) for macOS updates.
+### Windows (`windows/`)
+
+| Project | Role |
+|---------|------|
+| **DS3Drive.App** | WinUI 3 tray app + setup wizard |
+| **DS3Drive.ViewModels** | Shared view models (MVVM) |
+| **DS3Drive.Sync** | cfapi sync-root integration |
+| **DS3Drive.Core** | C ABI bindings to the Rust core (`ds3_ffi.dll`) |
+| **DS3Drive.Installer** | WiX MSI + sparse identity package |
+
+Key dependencies: [Soto](https://github.com/soto-project/soto) v6 for S3 (Apple), the [Windows App SDK](https://learn.microsoft.com/windows/apps/windows-app-sdk/) (Windows), and [Sparkle](https://sparkle-project.org) for macOS updates.
 
 ## Build from source
 
-Requirements: macOS 15+, Xcode 16+, and Git LFS (for image assets).
+Clone first — all platforms share the repo and the Rust core. Git LFS is required for image assets.
 
 ```bash
 git clone git@github.com:marmos91/cubbit-ds3-drive.git
 cd cubbit-ds3-drive
 git lfs install && git lfs pull
-open DS3Drive.xcodeproj
+```
+
+### macOS + iOS
+
+Requirements: macOS 15+, Xcode 16+, and a Rust toolchain (the core builds as part of the Xcode build).
+
+```bash
+open apple/DS3Drive.xcodeproj
 ```
 
 In Xcode, configure your own Team and signing certificate in **Signing & Capabilities** for each target. The App Group (`group.<TeamID>.io.cubbit.DS3Drive`) must match across the main apps and the File Provider extension — on macOS 15+ the team-ID prefix is mandatory.
+
+### Windows (in development)
+
+Requirements: Windows 10/11, Visual Studio 2022 (.NET desktop + Windows application development + Desktop C++ workloads), the .NET 8 SDK, and a Rust toolchain. The Windows app currently lives on the `gsd/phase-17-windows-shell-impl` branch.
+
+```bash
+git checkout gsd/phase-17-windows-shell-impl
+start windows/DS3Drive.sln
+```
+
+Set **DS3Drive.App** as the startup project, build (`ds3_ffi.dll` is produced by the `BuildRustCore` target on every build), then follow `windows/DEV-DEBUG.md` (on that branch) to register the sparse identity package — cfapi's sync-root registration requires package identity, so a bare F5 won't mount a drive without it.
 
 For a deeper tour of the codebase see [`CLAUDE.md`](CLAUDE.md).
 
 ## Contributing
 
-Contributions are welcome — please open a pull request and follow the [contribution guidelines](CONTRIBUTING.md).
+Contributions are welcome — please open a pull request. See [`CLAUDE.md`](CLAUDE.md) for build and codebase context.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-DS3 Drive connects your [Cubbit DS3](https://www.cubbit.io) buckets to the native file system on every desktop and mobile platform. On macOS it runs as a menu bar app and mounts your buckets as drives in Finder; on iOS it mirrors them into the Files app alongside iCloud Drive; on Windows it surfaces them in File Explorer. Each platform integrates with the OS's own sync framework — Apple's File Provider, Windows' Cloud Files API — so every read and write goes through the system with no custom mount daemon, no FUSE, no kexts.
+DS3 Drive connects your [Cubbit DS3](https://www.cubbit.io) buckets to the native file system on macOS, iOS, and Windows. On macOS it runs as a menu bar app and mounts your buckets as drives in Finder; on iOS it mirrors them into the Files app alongside iCloud Drive; on Windows it surfaces them in File Explorer. Each platform integrates with the OS's own sync framework — Apple's File Provider, Windows' Cloud Files API — so every read and write goes through the system with no custom mount daemon, no FUSE, no kexts.
 
 A shared [Rust](https://www.rust-lang.org) core (`core/`) implements authentication, the Cubbit API client, and all S3 operations once, then feeds every platform: Swift consumes it via UniFFI, C#/.NET via the C ABI.
 
@@ -144,7 +144,7 @@ A monorepo with a shared Rust core and thin native shells per platform:
 ```
 core/      Shared Rust core — auth, Cubbit API, S3, sync (UniFFI for Swift, C ABI for C#)
 apple/     macOS + iOS apps, File Provider extension, DS3Lib
-windows/   Windows WinUI 3 app (in development)
+windows/   Windows WinUI 3 app — in development (a placeholder on main; impl on the gsd/phase-17-windows-shell-impl branch)
 ```
 
 ### Shared core (`core/`)


### PR DESCRIPTION
## Why

Two problems in the README:

1. **Broken images** — the monorepo reorg moved `/Assets/` → `apple/Assets/`, but every `<img src>` still pointed at the old root path, so all screenshots 404'd on GitHub.
2. **Apple-only** — the README didn't mention Windows, which is now in active development.

## What changed

- Repointed all `img src` paths to `apple/Assets/...` (verified every path resolves to a tracked file)
- Added Windows as a third platform, framed as **in development** (no release/installer yet — impl lives on `gsd/phase-17-windows-shell-impl`)
- Reframed intro + Architecture around the shared **Rust core** (`core/`) feeding native shells via UniFFI (Swift) and C ABI (C#)
- Added Architecture tables for the core crates, Apple targets, and Windows projects
- Added Windows build-from-source steps; fixed stale Apple path (`apple/DS3Drive.xcodeproj`)
- Platform badge now reads `macOS 15+ | iOS 17+ | Windows 10+ (dev)`
- Drive-by: fixed two dead links (`CONTRIBUTING.md`, branch-only `windows/DEV-DEBUG.md`)

## Notes

- Docs-only change. macOS/iOS framed as shipping; Windows clearly gated as in-development with no install path.