### PR TITLE
docs: v3.0 enterprise platform specification set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 DS3 Drive is a cross-platform app that syncs local files with Cubbit DS3 (S3-compatible) cloud storage on both **macOS** and **iOS**, with **Windows** support in development. It uses Apple's File Provider framework (`NSFileProviderReplicatedExtension`) to integrate with Finder on macOS and the Files app on iOS, presenting remote S3 buckets as native drive locations. A shared Rust core (under `core/`) provides S3 operations and authentication, consumed via UniFFI (Swift) and C ABI (C#).
 
+## Upcoming: v3.0 Enterprise Platform Pivot
+
+**Starts after the v2.0.0 Windows milestone wraps.** DS3 Drive becomes a Dropbox-class, server-mediated enterprise SaaS on Cubbit DS3 — not a thick direct-to-S3 client anymore. Full north-star design: `docs/superpowers/specs/2026-07-16-enterprise-platform-northstar-design.md`. Each area gets its own per-part spec; **Layer 0 (foundation) is first**. Locked directives:
+
+- **Sync server** = Rust + axum, **reusing `core/` crates** (no re-implementing S3/auth). API front door `api.ds3drive.com/v2`.
+- **Identity** = **Zitadel** (branded OIDC Auth-Code+PKCE at `auth.ds3drive.com`). **Never** hand end users raw DS3 keys, and **never** build a `/v2/login` password proxy (kills SSO/MFA). Keep it swappable to Keycloak via an `IdentityProvider` trait seam; key app data on our own Postgres IDs mapped to OIDC `sub`.
+- **Data plane** = **presigned URLs** (DS3-confirmed; no STS). Bytes go client↔DS3 direct. **No proxy tier in v1.** All access enforcement lives in the server's presign gate (DS3 has no bucket policies / no STS).
+- **Data tier** = **Postgres** (namespace source of truth: paths/perms/versions/audit) + **Redis from day 0** (WebSocket pub/sub, HA at petabyte scale). S3 = bytes + native versioning.
+- **Push** = WebSocket on :443 (no polling). **Conflicts** = optimistic concurrency at authorization. **Multi-tenancy** = bucket/project per org via DS3 APIs.
+- **Surfaces** = web dashboards in **Next.js/TS**, built super-admin → org-admin → user; **mobile dual** (FileProvider + in-app browser); **whitelabel = build-time**.
+
 ## Repository Layout
 
 This is a mono-repo with platform-specific directories:
@@ -151,6 +162,19 @@ killall fileproviderd
 ```
 
 **IMPORTANT:** Never use `xcodebuild` with `CODE_SIGN_IDENTITY="-"` (ad-hoc signing) — it strips App Group entitlements and poisons all caches.
+
+### Extension Loads But Drive Missing in Finder (three distinct failures)
+
+"Extension not starting" is usually one of three layers. Each has its own log signature — diagnose in order, don't guess. Extension subsystem logs (`io.cubbit.DS3Drive.provider`) being **empty** means the `.appex` never launched.
+
+**1. Stale domain → app log `cannot be used right now` + `DS3DriveManagerError error 0`.**
+`error 0` = `.driveNotFound`, thrown when `NSFileProviderManager.domains()` itself throws — the app can't self-heal. Cause: `~/Library/Application Support/FileProvider/io.cubbit.DS3Drive.provider/Provider.plist` references a **deleted DerivedData build path**. Check with `plutil -p`. Fix (app stopped): `killall fileproviderd` → `rm -rf` that provider dir → `killall fileproviderd` → relaunch.
+
+**2. Duplicate LaunchServices registrations → owner-app resolves to a dead copy** (same error persists after #1). Find: `lsregister -dump | grep "path:.*DS3Drive-.*Cubbit DS3 Drive.app"` (most point at deleted DerivedData). Fix: `lsregister -u` every stale path, then `lsregister -f` the live build only. (`lsregister` full path is in the recovery block above.)
+
+**3. ⚠️ THE TRAP — `pluginkit -u`/`-a` + `lsregister` churn silently flips the File Provider extension's approval toggle OFF** in System Settings → Login Items & Extensions. Then every `add(domain)` is born `Enabled => false` → `fileproviderd` errors `FP -2011 "Sync is not enabled"` (`NSFileProviderError.domainDisabled`); `fileproviderctl dump` shows `state:disabled` (iCloud/Dropbox stay `enabled`). **`pluginkit -m` still shows `+` — that's plugin match policy, NOT the FileProvider approval. Misleading.** No reliable CLI to re-enable: **manually toggle System Settings → General → Login Items & Extensions → Extensions → File Provider ⓘ → app ON.** Prevention: don't `pluginkit -u`/rebuild-thrash to fix extension issues — that churn is what flips the toggle; prefer `killall fileproviderd` + the provider-dir/LaunchServices reset, and re-check the toggle afterward.
+
+**4. After it loads: `Extension init failed ... credentials.json couldn't be opened` → invalidates.** Per-drive S3 API key missing from the App Group container. Auto-recovery only fires on a `.notAuthenticated` signal, but a missing file makes the extension invalidate instead. **Fix: re-login in the app** — regenerates the API key, writes `credentials.json`. Success signal: extension logs `enumerateItems: N visible items (N from S3)` + a `downloaded successfully`.
 
 ## Git Worktrees
 

--- a/docs/superpowers/specs/2026-07-16-crosscutting-whitelabel-vpn-design.md
+++ b/docs/superpowers/specs/2026-07-16-crosscutting-whitelabel-vpn-design.md
@@ -42,10 +42,15 @@ CI builds each reseller's artifacts with this injected:
 
 ---
 
-## C. Open items
+## C. Operations — monitoring & feature flags
+
+- **Observability (ship with the deployment):** server exposes **Prometheus** metrics (`/metrics`), structured logs → **Loki**, **Grafana** dashboards, **OpenTelemetry** tracing. Reuse the Rust `tracing` already in core. Underpins the Layer-0 benchmark targets.
+- **Feature flags — lazy:** reuse what exists — **per-org policy toggles in Postgres** (links on/off, self-serve signup) + **per-reseller build-time config**. Cover most needs. Add self-hosted **Unleash** *only if* runtime/gradual/targeted rollout is needed later. `ponytail:` don't add a flag platform for v1.
+
+## D. Open items
 - Rust core HTTP client: confirm **system-proxy + OS-trust-store** support (add config knob if missing).
 - Whitelabel: lock the exact brandable-token set with the first reseller (avoid gold-plating).
 - Mobile store logistics: per-reseller App Store/Play accounts + review process (reseller-owned) — operational, not code.
 
-## D. Next
+## E. Next
 All sections defined. Write the spec **index**, then `writing-plans` for the backend (Layer 0) when Windows wraps.

--- a/docs/superpowers/specs/2026-07-16-crosscutting-whitelabel-vpn-design.md
+++ b/docs/superpowers/specs/2026-07-16-crosscutting-whitelabel-vpn-design.md
@@ -1,0 +1,51 @@
+# DS3 Drive v3.0 — Cross-cutting: Whitelabel & VPN/Proxy (deep-dive spec)
+
+**Status:** Draft. Seventh per-part deep-dive. Cross-cutting; wire early, keep thin.
+**Date:** 2026-07-16
+
+---
+
+## A. Whitelabel (build-time)
+
+**Decision:** per-reseller branding baked at **build/config time** — one brand per instance. No runtime per-org theming.
+
+### What's brandable
+Product name · logo / favicon / app icon · color + type **tokens** · support/legal URLs · email-template branding · **branded login** (custom domain `auth.<reseller>` + Zitadel branding) · splash.
+
+### Mechanism — one branding source per reseller
+```
+branding/<reseller>/
+  tokens.css        # CSS variables (web theme)
+  assets/           # logos, favicon, app icons, splash
+  strings.json      # product name, support/legal URLs, per-locale copy
+  config.json       # domains, feature flags, App Store IDs
+```
+CI builds each reseller's artifacts with this injected:
+- **Web:** swap `tokens.css` + asset bundle at build → branded Next.js image.
+- **Mobile:** per-reseller **app target/config** → branded binary (bundle ID, name, icons) shipped under **the reseller's own App Store / Play / MDM account** ("sell through their own store profiles").
+- **Server/Zitadel:** branded email templates, product name in notifications, branded login at the reseller's `auth.` domain.
+
+`ponytail:` it's a token file + asset bundle + per-target config consumed by CI — **not** a plugin/theming engine. A few deploy-time values (support email, instance domain) can be env/config rather than a rebuild. Defer *additional* themes until a real second reseller exists.
+
+---
+
+## B. VPN / Proxy (super simple)
+
+**Decision:** rely on the enterprise's existing network; **no custom VPN client.**
+
+- **System proxy:** all clients honor the OS proxy settings (macOS/iOS/Windows native loaders do by default). Ensure the **Rust core HTTP client respects system proxy** (env/OS config) — the one thing to verify, since core does its own HTTP.
+- **Custom CA / TLS trust:** support a **corporate root CA** so TLS validates to a (possibly internal) sync-server / DS3 endpoint. Clients use the **OS trust store** (MDM-populated); the Rust core HTTP client uses the OS trust store or an optional configurable CA bundle.
+- **:443 WebSocket** already traverses corporate proxies/VPN — no extra work.
+- **Configurable endpoints:** clients point at the reseller's instance URL (may be internal, reached over the customer's VPN); super-admin sets the DS3 endpoint. Already in Layer 0.
+
+**Deferred (not v1):** mTLS client-certificate auth, if a reseller demands it. Note only.
+
+---
+
+## C. Open items
+- Rust core HTTP client: confirm **system-proxy + OS-trust-store** support (add config knob if missing).
+- Whitelabel: lock the exact brandable-token set with the first reseller (avoid gold-plating).
+- Mobile store logistics: per-reseller App Store/Play accounts + review process (reseller-owned) — operational, not code.
+
+## D. Next
+All sections defined. Write the spec **index**, then `writing-plans` for the backend (Layer 0) when Windows wraps.

--- a/docs/superpowers/specs/2026-07-16-enterprise-platform-northstar-design.md
+++ b/docs/superpowers/specs/2026-07-16-enterprise-platform-northstar-design.md
@@ -31,7 +31,7 @@ It is also **~12 subsystems = a multi-quarter roadmap**, not one spec. This docu
 | **Bus/cache** | **Redis from day 0** — WebSocket pub/sub fan-out + presence + token/rate cache. | Multi-instance HA is expected immediately at this scale (petabyte target); provisioning it up front avoids a later retrofit. Not a database — a message bus. |
 | **Change/sync** | Server authorizes every write → knows every change → **WebSocket :443 push**, no polling. | Kills polling latency; :443 sails through corporate proxies/VPN. |
 | **Conflicts** | Optimistic concurrency **at authorization time** — server checks expected version before minting a PUT URL. | Rejects stale writes up front; strictly better than today's after-the-fact ETag conflict copies. |
-| **Multi-tenancy** | **Bucket/project per org** via DS3 APIs on signup. | Hard data isolation between orgs, for free. |
+| **Deployment & tenancy** | **Two levels.** (1) Each **reseller** self-hosts a **branded instance** (Docker/K8s) — sync server + Zitadel + Postgres/Redis — connected to **a Cubbit DS3 instance** (Composer on-prem *or* Cubbit cloud — a deployment detail; super-admin configures endpoint + admin creds). (2) Within it, many **organizations** sign up; each org = **project/bucket** provisioned via DS3 management APIs, isolated. | Resellers ship DS3 Drive as their own Dropbox on Cubbit storage. Each instance is itself multi-tenant. Build-time whitelabel. Requires DS3 **management** APIs (project/bucket/IAM CRUD) at the configured endpoint — confirm. |
 
 ### Identity is swappable (not locked to Zitadel)
 Keycloak (or any OIDC IdP) must stay a few-days adapter away, not a rewrite. Honor three rules from day 1:

--- a/docs/superpowers/specs/2026-07-16-enterprise-platform-northstar-design.md
+++ b/docs/superpowers/specs/2026-07-16-enterprise-platform-northstar-design.md
@@ -9,7 +9,7 @@
 
 ## 1. What this is — and why it's a pivot, not a refactor
 
-Today DS3 Drive is a **thick sync client** with a deliberate constraint: *no custom backend — the client talks directly to Cubbit IAM/Composer + S3* (`PROJECT.md`). Every requirement in this effort breaks that constraint.
+Today DS3 Drive is a **thick sync client** with a deliberate constraint: *no custom backend — the client talks directly to Cubbit IAM/Composer + S3* (`.planning/PROJECT.md`). Every requirement in this effort breaks that constraint.
 
 What we're building is a **Dropbox-class enterprise SaaS platform built on Cubbit DS3**: server-mediated identity, sharing, permissions, versioning, web consoles, per-org provisioning, audit, whitelabel. This is a **company-level bet with a different cost structure and threat model** (we now run and secure a backend 24/7), not a client refactor. Naming that up front because it reframes scope for every downstream decision.
 
@@ -195,7 +195,7 @@ CROSS-CUTTING  (thin; wire early, build minimal)
 | 1 | **Sharing + links + permissions** | Web app **shows folders**; downloads issue **presigned URLs** (works for shared + public/anonymous — no proxy). Perms in Postgres, enforced at presign. Roles viewer/editor/owner per folder. Private-share URLs kept short-lived; public-link tokens map to presign-on-validate. |
 | 2 | **Versioning** | **Match incumbents (Dropbox / Google Drive / Nextcloud / Proton Drive):** full version history with preview + restore, time-based retention. S3-native versioning + Postgres version index. |
 | 3 | **Web dashboards** | **Next.js + TypeScript**, on the `/v2` API. Build **in order: super-admin → org-admin → end-user** (configure tenant/system first, then onboarding, then user surface). |
-| 4 | **Mobile in-app browser** | **Dual, like Dropbox** — keep FileProvider **and** add in-app browse/preview/download. Update `PROJECT.md`'s "Files-app-only" out-of-scope entry when Layer 2 starts. |
+| 4 | **Mobile in-app browser** | **Dual, like Dropbox** — keep FileProvider **and** add in-app browse/preview/download. Update `.planning/PROJECT.md`'s "Files-app-only" out-of-scope entry when Layer 2 starts. |
 | 5 | **Audit + force-disconnect** | **Queryable history** (no real-time streaming for v1). Partitioned Postgres audit table; per-user + org views. Force-disconnect = revoke Zitadel session + drop WebSocket (+ rotate org key nuclear option). |
 | 6 | **VPN / proxy** | **Super simple for v1** — honor system proxy + custom CA; :443 WebSocket covers the rest. No dedicated subsystem. |
 | 7 | **Whitelabel** | **Build-time** — per-customer branding baked at build (design tokens + asset bundle + branded Zitadel login). Wire branding-as-config from day 1 so it's not retrofitted. |
@@ -209,7 +209,7 @@ CROSS-CUTTING  (thin; wire early, build minimal)
 - **DS3 versioned deletes are irreversible** — versioning UX must account for this.
 - **Zitadel multi-tenant ops** — per-org config, custom domains, SCIM at scale is new operational surface; validate self-host vs cloud early.
 - **Permission model scale** — start Postgres table; SpiceDB is the escape hatch, not the starting point.
-- **Mobile reversal** — in-app browser contradicts the shipped "Files-app-only" decision; **resolved: dual** (FileProvider + in-app, like Dropbox). Update `PROJECT.md` when Layer 2 starts.
+- **Mobile reversal** — in-app browser contradicts the shipped "Files-app-only" decision; **resolved: dual** (FileProvider + in-app, like Dropbox). Update `.planning/PROJECT.md` when Layer 2 starts.
 - **Running a backend 24/7** — new on-call, security, and compliance burden the current architecture didn't have.
 
 ---

--- a/docs/superpowers/specs/2026-07-16-enterprise-platform-northstar-design.md
+++ b/docs/superpowers/specs/2026-07-16-enterprise-platform-northstar-design.md
@@ -1,0 +1,227 @@
+# DS3 Drive — Enterprise Platform (v3.0) North-Star Design
+
+**Status:** Draft / north-star. Foundation (Layer 0) **and** feature-layer directions locked; each area detailed in its own per-part spec.
+**Date:** 2026-07-16
+**Sequencing:** Execution starts **after** the v2.0.0 Windows milestone wraps (Phase 17.1 UAT + remainder). This spec is written ahead so it's ready.
+**Supersedes/extends:** builds on `2026-05-26-cross-platform-rewrite-design.md` (Rust core + native shells).
+
+---
+
+## 1. What this is — and why it's a pivot, not a refactor
+
+Today DS3 Drive is a **thick sync client** with a deliberate constraint: *no custom backend — the client talks directly to Cubbit IAM/Composer + S3* (`PROJECT.md`). Every requirement in this effort breaks that constraint.
+
+What we're building is a **Dropbox-class enterprise SaaS platform built on Cubbit DS3**: server-mediated identity, sharing, permissions, versioning, web consoles, per-org provisioning, audit, whitelabel. This is a **company-level bet with a different cost structure and threat model** (we now run and secure a backend 24/7), not a client refactor. Naming that up front because it reframes scope for every downstream decision.
+
+It is also **~12 subsystems = a multi-quarter roadmap**, not one spec. This document is the north-star: it locks the foundation and scopes each feature area. Each feature area then gets its **own** brainstorm → spec → plan cycle ("discuss per parts").
+
+---
+
+## 2. Locked foundation (Layer 0)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Data plane** | **Presigned URLs** (DS3-confirmed supported). Bytes go **client ↔ DS3 direct**. | Server never in the byte path → scales, keeps Cubbit's edge. Client holds **no** standing credential; each URL is one object, short-lived, minted only after a permission check. STS not needed (and DS3 has no STS yet). |
+| **Proxy tier** | **Not in v1.** Presigned URLs cover shared **and** public/anonymous downloads (server mints a presigned GET on link-token validation — no client credential, no proxy). | Deferred entirely; revisit only if a future feature needs the server in the byte path (server-side transforms/AV). Keeps v1 simple. |
+| **Identity** | **Zitadel** (self-host or cloud), fronted by our own domain (`auth.ds3drive.com`). | Orgs are first-class (maps to per-org model), native SAML/OIDC/SSO, lighter ops than Keycloak. Never build identity. |
+| **API front door** | **`api.ds3drive.com/v2/…`** (axum), Bearer-validated against Zitadel JWKS. | One control-plane surface for all app calls. Client authorizes from Postgres server-side. |
+| **Login flow** | **OIDC Authorization Code + PKCE** against branded Zitadel. **Not** a `/v2/login` password proxy. | A password proxy (ROPG) throws away SSO/MFA/federation — the whole reason for Zitadel. Web = BFF (httpOnly cookie); native = ASWebAuthenticationSession / AppAuth (token in Keychain/Credential Manager). Branded Zitadel = whitelabel login for free. |
+| **Server stack** | **Rust + axum, reusing `core/` crates** (`ds3-s3`, `ds3-auth`, `ds3-models`). | Zero re-implementation of S3/auth/presigning; one source of truth shared with the clients' FFI core; single language across core + server. |
+| **Primary DB** | **Postgres** = namespace source of truth (paths, versions, permissions, audit). S3 = bytes + native versions only. | Relational + transactional workload (optimistic concurrency, permission joins). Same class Dropbox/Nextcloud run on. Bytes in S3 → tiny rows, scale axis is row count (Postgres handles 100Ms with partitioning). |
+| **Bus/cache** | **Redis from day 0** — WebSocket pub/sub fan-out + presence + token/rate cache. | Multi-instance HA is expected immediately at this scale (petabyte target); provisioning it up front avoids a later retrofit. Not a database — a message bus. |
+| **Change/sync** | Server authorizes every write → knows every change → **WebSocket :443 push**, no polling. | Kills polling latency; :443 sails through corporate proxies/VPN. |
+| **Conflicts** | Optimistic concurrency **at authorization time** — server checks expected version before minting a PUT URL. | Rejects stale writes up front; strictly better than today's after-the-fact ETag conflict copies. |
+| **Multi-tenancy** | **Bucket/project per org** via DS3 APIs on signup. | Hard data isolation between orgs, for free. |
+
+### Identity is swappable (not locked to Zitadel)
+Keycloak (or any OIDC IdP) must stay a few-days adapter away, not a rewrite. Honor three rules from day 1:
+1. **Auth via standard OIDC only** — validate JWTs vs the IdP's JWKS + OIDC discovery. Fully portable; a swap is config (issuer/client/JWKS).
+2. **One seam:** isolate the vendor-specific *management* API (create org / invite user / assign roles) behind a Rust **`IdentityProvider` trait** — `ZitadelProvider` now, `KeycloakProvider` later. Do **not** abstract auth (already standard); **do** wrap management.
+3. **Own the ID mapping** — users/orgs keyed on *our* Postgres PKs, mapped to the OIDC `sub`. Never foreign-key on the IdP's internal IDs, so a swap re-links instead of breaking.
+
+Residual switch cost = user-record migration (password hashes/sessions don't port between IdPs) — inherent to any IdP change, softened by SCIM/federation. Cheap to honor now, expensive to retrofit.
+
+### Named upgrade paths (deferred behind real triggers — do NOT build day 1)
+- **SpiceDB (Zanzibar)** — if permissions get deeply nested / cross-org at scale. Start with a Postgres perms table.
+- **ClickHouse** — if audit write volume/analytics hurt. Start with a partitioned Postgres audit table.
+- **Meilisearch / Elasticsearch** — if file search becomes a feature. Start with Postgres FTS.
+
+---
+
+## 3. Architecture
+
+```
+                          ┌────────────────────────────┐
+   End users ──login───▶  │  Zitadel (OIDC/SAML/SSO)   │  auth.ds3drive.com
+   (mac/win/ios/web)      │  branded, our domain       │  (whitelabel login)
+                          └──────────────┬─────────────┘
+                                         │ OIDC token (PKCE)
+        ┌────────────────────────────────▼──────────────────────────┐
+        │        SYNC SERVER — control plane (Rust/axum)             │
+        │  api.ds3drive.com/v2                                       │
+        │  • validate Zitadel JWT     • Postgres = namespace SoT     │
+        │  • permissions/shares/versions/audit                       │
+        │  • WebSocket :443 push      • holds Cubbit DS3 org key      │
+        │  • mints presigned URLs     • provisions bucket/proj/org    │
+        │  • reuses core/ crates (ds3-s3, ds3-auth, ds3-models)      │
+        └───────┬──────────────────────────────────┬─────────────────┘
+                │ control (JSON / WS)               │ presigned URL
+                │                                   │ (1 object, short-lived)
+   ┌────────────▼────────────┐          ┌───────────▼────────────┐
+   │  Clients                │──bytes──▶│  Cubbit DS3 (S3)        │
+   │  mac/win FileProvider   │  direct  │  org-isolated buckets   │
+   │  ios/web in-app browser │◀─bytes───│  + native versioning    │
+   └─────────────────────────┘          └─────────────────────────┘
+     (no proxy tier in v1 — presigned GET covers shared + public/anonymous
+      downloads too; revisit only for future server-side transforms/AV)
+
+   Data tier:  Postgres (metadata/perms/versions/audit)  +  Redis (pub/sub/presence/cache)
+```
+
+---
+
+## 4. Key flows
+
+### 4.1 Org signup + provisioning
+```mermaid
+sequenceDiagram
+    participant Admin as Org Admin (web)
+    participant API as Sync Server (/v2)
+    participant Z as Zitadel
+    participant DS3 as Cubbit DS3 APIs
+    participant PG as Postgres
+    Admin->>Z: Sign up (OIDC, branded)
+    Z-->>Admin: token
+    Admin->>API: POST /v2/orgs (Bearer)
+    API->>Z: create Zitadel org + admin role
+    API->>DS3: create project + bucket (org-isolated) + enable versioning
+    API->>PG: persist org, bucket mapping, root namespace
+    API-->>Admin: org ready
+```
+
+### 4.2 Login (OIDC + PKCE, branded)
+```mermaid
+sequenceDiagram
+    participant C as Client (native/web)
+    participant Z as auth.ds3drive.com (Zitadel)
+    participant API as Sync Server
+    C->>Z: Authorization Code + PKCE (+ SSO/SAML if enterprise)
+    Z-->>C: code -> token (native: Keychain; web: httpOnly cookie via BFF)
+    C->>API: /v2/... (Bearer)
+    API->>API: validate JWT vs Zitadel JWKS + authorize from Postgres
+```
+
+### 4.3 Upload (presigned, bytes direct)
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant API as Sync Server
+    participant PG as Postgres
+    participant S3 as Cubbit DS3
+    participant WS as Other clients (WebSocket)
+    C->>API: POST /v2/files {path, size, expectedVersion}
+    API->>PG: permission check + optimistic version check
+    alt stale version
+        API-->>C: 409 conflict
+    else ok
+        API-->>C: presigned PUT URL(s) (multipart if large)
+        C->>S3: PUT bytes (direct)
+        C->>API: POST /v2/files/commit {etag, versionId}
+        API->>PG: record version, bump namespace
+        API->>WS: push change event
+    end
+```
+
+### 4.4 Share invite
+```mermaid
+sequenceDiagram
+    participant Owner
+    participant API as Sync Server
+    participant PG as Postgres
+    participant Email
+    participant Invitee
+    Owner->>API: POST /v2/shares {folder, email, role}
+    API->>PG: create share (role: viewer/editor)
+    API->>Email: invite link
+    Invitee->>API: accept (after OIDC login / or public-link token)
+    API->>PG: bind grant to identity
+    Note over API: enforced on every presign (perm check)
+```
+
+### 4.5 Version restore
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant API as Sync Server
+    participant PG as Postgres
+    participant S3 as Cubbit DS3
+    C->>API: GET /v2/files/{id}/versions
+    API->>PG: version index
+    API-->>C: list (versionId, ts, author)
+    C->>API: POST /v2/files/{id}/restore {versionId}
+    API->>S3: copy old version -> new current (S3-native)
+    API->>PG: record new version, push change
+```
+
+---
+
+## 5. Decomposition / roadmap
+
+```
+LAYER 0 — FOUNDATION  ◀ first deep-dive (MVP of the pivot)
+  Sync server (axum, reuse core/) · Zitadel + branded OIDC · client re-point
+  · Postgres + Redis · presigned data plane · WebSocket push · per-org provisioning
+  → Prove server-mediated model on ONE platform pair (e.g. web + macOS) end-to-end.
+
+LAYER 1 — ENTERPRISE FEATURES  (each own spec; all depend on L0)
+  Sharing + links + granular permissions · Versioning · Audit + force-disconnect
+
+LAYER 2 — SURFACES  (depend on L0, partly L1)
+  Web dashboards — Next.js/TS, built super-admin → org-admin → end-user
+  · Mobile in-app browser (dual with FileProvider, like Dropbox)
+
+CROSS-CUTTING  (thin; wire early, build minimal)
+  Whitelabel (branding-as-config) · VPN/proxy (system proxy + custom CA)
+```
+
+**MVP of the pivot = Layer 0 on one platform pair**, proving the server-mediated model before any enterprise feature. Nothing in Layer 1/2 is real until Layer 0 ships.
+
+---
+
+## 6. Feature areas — decisions (details in per-part specs)
+
+| # | Area | Decision |
+|---|---|---|
+| 1 | **Sharing + links + permissions** | Web app **shows folders**; downloads issue **presigned URLs** (works for shared + public/anonymous — no proxy). Perms in Postgres, enforced at presign. Roles viewer/editor/owner per folder. Private-share URLs kept short-lived; public-link tokens map to presign-on-validate. |
+| 2 | **Versioning** | **Match incumbents (Dropbox / Google Drive / Nextcloud / Proton Drive):** full version history with preview + restore, time-based retention. S3-native versioning + Postgres version index. |
+| 3 | **Web dashboards** | **Next.js + TypeScript**, on the `/v2` API. Build **in order: super-admin → org-admin → end-user** (configure tenant/system first, then onboarding, then user surface). |
+| 4 | **Mobile in-app browser** | **Dual, like Dropbox** — keep FileProvider **and** add in-app browse/preview/download. Update `PROJECT.md`'s "Files-app-only" out-of-scope entry when Layer 2 starts. |
+| 5 | **Audit + force-disconnect** | **Queryable history** (no real-time streaming for v1). Partitioned Postgres audit table; per-user + org views. Force-disconnect = revoke Zitadel session + drop WebSocket (+ rotate org key nuclear option). |
+| 6 | **VPN / proxy** | **Super simple for v1** — honor system proxy + custom CA; :443 WebSocket covers the rest. No dedicated subsystem. |
+| 7 | **Whitelabel** | **Build-time** — per-customer branding baked at build (design tokens + asset bundle + branded Zitadel login). Wire branding-as-config from day 1 so it's not retrofitted. |
+
+---
+
+## 7. Risks & assumptions
+
+- ✅ **RETIRED:** presigned-URL support (confirmed by Cubbit team). Was the #1 risk.
+- **DS3 access model = project-based + ACLs; no bucket policies, no STS.** So per-prefix scoping is *not* enforceable client-side via policy — enforcement lives in the **server (presign gate)**, never in a handed-out key. Design must never hand end users a raw DS3 key.
+- **DS3 versioned deletes are irreversible** — versioning UX must account for this.
+- **Zitadel multi-tenant ops** — per-org config, custom domains, SCIM at scale is new operational surface; validate self-host vs cloud early.
+- **Permission model scale** — start Postgres table; SpiceDB is the escape hatch, not the starting point.
+- **Mobile reversal** — in-app browser contradicts the shipped "Files-app-only" decision; **resolved: dual** (FileProvider + in-app, like Dropbox). Update `PROJECT.md` when Layer 2 starts.
+- **Running a backend 24/7** — new on-call, security, and compliance burden the current architecture didn't have.
+
+---
+
+## 8. Non-goals (this cycle)
+- Multi-cloud / generic S3 (Cubbit-native).
+- Real-time collaborative editing (S3 has no locking; sync, not co-edit).
+- Building identity (Zitadel does it).
+- GraphQL (REST + OpenAPI; add GraphQL only if a real integrator demands it).
+- A data-plane proxy tier (presigned covers all v1 downloads incl. public/anonymous; no proxy in v1).
+
+---
+
+## 9. Next step
+Take **Layer 0** into its own detailed deep-dive spec (`/gsd` or brainstorm → writing-plans): sync server + Zitadel + client re-point + provisioning, one platform pair end-to-end.

--- a/docs/superpowers/specs/2026-07-16-layer0-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer0-foundation-design.md
@@ -1,0 +1,131 @@
+# DS3 Drive v3.0 — Layer 0 Foundation (deep-dive spec)
+
+**Status:** Draft. First per-part deep-dive under the north-star (`2026-07-16-enterprise-platform-northstar-design.md`).
+**Date:** 2026-07-16
+**Scope discipline:** **Backend must be flawless (e2e-tested + benchmarked) before any client.** Sequence: **backend/API → web app → native clients**.
+
+---
+
+## 1. What Layer 0 is
+
+The server-mediated spine, proven end-to-end on the smallest surface: **web-only, greenfield** (new orgs; existing native clients keep running direct-to-S3, untouched). No sharing/versioning/audit UI yet — just enough to prove auth + provisioning + namespace + presigned data plane + push, as a **documented, benchmarked `/v2` API** plus a thin web client.
+
+### Locked decisions (from the deep-dive)
+| Topic | Decision |
+|---|---|
+| MVP surface | Web-only, greenfield. Backend-first. |
+| API | `/v2` REST + **OpenAPI**, a **first-class public product** (third-party integration), not just the web backend. |
+| Tenancy | Two-level: reseller **instance** (self-hosted, branded) → many **orgs**. Instance connects to a configured **Cubbit DS3 instance** (on-prem/cloud). |
+| Storage | **Presigned URLs**, bytes client↔DS3 direct. Server is **sole writer** to org buckets → Postgres is authoritative namespace. |
+| Identity | **Zitadel** = authN + per-org SSO (org ↔ Zitadel org 1:1). **Postgres owns orgs/groups/perms.** IdP behind an `IdentityProvider` trait (Keycloak-swappable). |
+| Permissions | **Folder-level, inherited + flat groups.** Roles: viewer / editor / owner. |
+| Provisioning | **Reseller (super-admin) creates orgs + first org-admin**; org-admin invites users. Self-serve org signup exists but **disabled by default**. |
+| Scale (per instance) | **Target: ~10k end-customer orgs (SMBs), each ~10TB docs (PDF/Word) / millions of files → tens of billions of objects; ~10k+ concurrent.** Reseller is large (e.g. a telco); its customers are SMBs. **v1 posture: partition-ready + org-scoped hot paths, prove at pilot volume, scale the DB tier later** (replicas → hash-partitioning → Citus/shard). "Scale later," not "build distributed now." |
+| Data tier | Postgres (SoT) + **Redis day 0** (pub/sub, presence, cache). |
+| Deploy | Docker / K8s, self-hosted, build-time whitelabel. |
+
+---
+
+## 2. Server structure (Rust/axum, reusing `core/`)
+
+```
+ds3-server (axum bin)   — routing, middleware (authn/z), handlers, OpenAPI
+├── ds3-domain (new)    — orgs, members, groups, namespace, folder-inherited perms (pure logic)
+├── ds3-db (new)        — Postgres via sqlx; migrations; partition-ready schema
+├── ds3-idp (new)       — IdentityProvider trait + ZitadelProvider impl (mgmt API)
+├── ds3-events (new)    — Redis pub/sub + WebSocket hub + resumable change feed
+├── ds3-provision (new) — DS3 management API client (project/bucket/IAM CRUD)
+├── ds3-s3 (reuse)      — S3 ops + presign (add presign helpers if missing)
+└── ds3-models (reuse)  — shared types
+```
+`ponytail:` reuse `ds3-s3`/`ds3-models`; the only genuinely new logic is domain + db + events + idp + provision. No new S3/signing code.
+
+---
+
+## 3. Domain model (Postgres sketch)
+
+All app tables carry `org_id` (partition-ready). Folder-inherited perms resolved via a **materialized path** on nodes (single indexed ancestor-prefix query — hits the <100ms folder-list / <10ms authz targets without recursive walks).
+
+```
+organization(id, zitadel_org_id, name, ds3_project_id, ds3_bucket, status, created_at)
+member(id, org_id, zitadel_user_id, email, role[admin|member], status, created_at)   -- v1: user ∈ one org
+group(id, org_id, name)
+group_member(group_id, member_id)
+node(id, org_id, parent_id, path, name, kind[file|folder], s3_key,
+     size, content_hash, etag, current_version_id, created_by, updated_at)            -- namespace; root per org
+permission(id, org_id, node_id, principal_type[member|group], principal_id,
+           role[viewer|editor|owner])                                                  -- on folders; inherited by path
+share_invite(id, org_id, node_id, email, role, token, status, expires_at)             -- pending email invites
+public_link(id, org_id, node_id, token, mode[view|download], expires_at, password_hash?) -- L1 detail, table stubbed
+file_version(id, node_id, s3_version_id, size, hash, author, created_at)              -- index over S3-native versions
+change_event(id, org_id, seq, node_id, type, actor, created_at)                        -- monotonic seq/org → push + resumable sync
+audit_event(id, org_id, actor, action, target, metadata, created_at)                   -- append-only, partition by created_at
+client_session(id, member_id, ws_conn_id, device, last_seen)                           -- presence + force-disconnect
+```
+`ponytail:` **every hot-path query is strictly org-scoped**, so latency stays independent of instance-wide object count. Indexes on `(org_id, parent_id)`, `(org_id, path)`, `(org_id, seq)`. **org_id hash-partitioning is the design basis**; enable it as data grows → read-replicas → **Citus** (distributed Postgres) toward the tens-of-billions target. Don't build distributed now — org-scoped keys make it addable without a schema rewrite. (If the top end proves too big even for Citus, a wide-column namespace store is the escape hatch — deferred.)
+
+---
+
+## 4. `/v2` API surface (OpenAPI-first)
+
+Grouped by audience. All authz enforced server-side before any DS3 access.
+
+- **Auth/session:** `POST /v2/session` (BFF token exchange, httpOnly cookie), `GET /v2/me`
+- **Super-admin (reseller):** `PUT /v2/admin/config` (DS3 endpoint/creds), `POST|GET|DELETE /v2/admin/orgs`, `GET /v2/admin/usage`, `GET /v2/admin/audit`, `GET|DELETE /v2/admin/sessions` (**force-disconnect**)
+- **Org-admin:** `…/orgs/{id}/members` (invite/CRUD), `…/groups`, `…/settings` (per-org SSO), `…/audit`
+- **Files/namespace:** `GET /v2/nodes/{id}/children`, `POST /v2/folders`, `POST /v2/files` (→ presigned PUT / multipart part URLs), `POST /v2/files/{id}/commit` (etag+versionId, optimistic-concurrency check), `GET /v2/files/{id}/content` (→ presigned GET), `POST /v2/nodes/{id}/{move|rename}`, `DELETE /v2/nodes/{id}`
+- **Sharing (L1 surface, stubbed in L0):** `…/nodes/{id}/permissions`, `POST /v2/shares`, `POST /v2/links`
+- **Push:** `GET /v2/events` (WebSocket, `?since={seq}` to resume)
+- **Third-party integration:** same `/v2`, authenticated via **Zitadel service users / OAuth client-credentials** (machine tokens).
+
+---
+
+## 5. Key flows
+
+**Provision org (super-admin):** create Zitadel org (via `IdentityProvider`) → create DS3 **project + bucket** (versioning on) via `ds3-provision` → insert `organization` + root `node` → assign first org-admin (Zitadel user + `member` role=admin). Target < a few seconds; idempotent + rollback on partial failure.
+
+**Login:** OIDC Auth-Code + PKCE against the org's Zitadel org (branded `auth.…`) → web gets httpOnly cookie (BFF), native gets token in secure store → `/v2` validates JWT vs Zitadel JWKS, resolves `member`/`org`/`role` from Postgres.
+
+**Upload:** `POST /v2/files {path,size,expectedVersion}` → authz (path-prefix perm) + optimistic version check → presigned PUT (multipart if large) → client PUTs bytes to DS3 direct → `commit` records `file_version`, bumps `node`, appends `change_event` → Redis fan-out → WebSocket push to other sessions.
+
+**Download:** authz → presigned GET → client fetches from DS3 direct.
+
+---
+
+## 6. Push (WebSocket + Redis)
+
+WebSocket on `:443`. On write, server appends a `change_event` (monotonic `seq` per org) and publishes to Redis; every server instance subscribes and forwards to its connected sessions for that org. Client tracks last `seq`; on reconnect, `GET /v2/events?since=seq` replays missed events from Postgres (durable, no lost changes). `ponytail:` no custom broker — Redis pub/sub + a Postgres change feed is the whole mechanism.
+
+---
+
+## 7. Non-functional gates — "flawless" is a checklist, not a vibe
+
+**Benchmark targets (measured at pilot volume with partitioning on, CI regression-gated):**
+- authz check p99 **< 10ms** · folder-list (1000 children) p99 **< 100ms** · presign issue p99 **< 50ms**
+- change → push delivered **< 1s** · org provisioning **< 5s** · **10k+** concurrent WebSocket connections/instance (target; prove at pilot, scale WS tier horizontally via Redis)
+- targets must **hold as instance object count grows** — validated against a DB seeded to pilot scale; hot paths are org-scoped so per-org latency ≠ f(total objects)
+- (byte throughput is DS3's, not ours — server never in the path; docs are small so multipart is rare)
+
+**e2e test strategy:**
+- Rust integration tests hitting the live axum server over HTTP, backed by **testcontainers** (Postgres, Redis, Zitadel).
+- **Contract tests** validated against the OpenAPI doc.
+- **Journey tests:** provision org → invite → login → create folder → upload → (share → download as invitee) → push received.
+- **Negative authz tests:** cross-org access denied, revoked grant denied, stale-version write rejected.
+- Load/benchmark harness (`oha`/`k6` or Rust) in CI with thresholds.
+
+**Definition of done (exit criteria before any client work):**
+1. Every `/v2` endpoint: happy + key error paths covered e2e. 2. All benchmark targets met in CI. 3. All negative-authz + optimistic-concurrency tests green. 4. OpenAPI published + contract-validated. 5. Provisioning idempotent + rollback-safe. 6. Runs from a single `docker compose up` (+ K8s manifests).
+
+---
+
+## 8. Namespace source-of-truth assumption
+The sync server is the **sole writer** to each org's bucket → Postgres is authoritative; **no S3↔DB reconciliation loop needed** in v1. If out-of-band bucket writes ever become a requirement, add a reconciler then. `ponytail:` don't build reconciliation for a bucket only we write to.
+
+## 9. Open items / risks (confirm before execution)
+- **DS3 management APIs** at the configured endpoint (project/bucket/IAM CRUD) — needed for provisioning. Confirm surface + on-prem parity.
+- **Presigned multipart** flow against the DS3 gateway — confirm part-URL signing works as with AWS.
+- **Zitadel org provisioning** via management API + per-org SSO config at scale — validate self-host ops.
+- Membership is **one-user-one-org** in v1; multi-org membership deferred (schema via `member` allows adding later).
+
+## 10. Next
+`superpowers:writing-plans` → phased implementation plan for Layer 0 (execution starts after Windows v2.0.0 wraps).

--- a/docs/superpowers/specs/2026-07-16-layer1-audit-forcedisconnect-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer1-audit-forcedisconnect-design.md
@@ -1,0 +1,64 @@
+# DS3 Drive v3.0 — Layer 1: Audit & Force-Disconnect (deep-dive spec)
+
+**Status:** Draft. Fourth per-part deep-dive. Extends Layer 0 + north-star. **Closes out the backend.**
+**Date:** 2026-07-16
+**Build order:** backend-first, before client UI.
+
+---
+
+## 1. Scope
+Append-only, tamper-evident audit with per-user + org + instance views, configurable retention, and export/SIEM pull. Queryable (no real-time streaming — decided). Plus **force-disconnect** of users/clients.
+
+### Locked decisions
+| Topic | Decision |
+|---|---|
+| Delivery | **Queryable** history (no streaming). |
+| Integrity | **Append-only + hash-chain** (tamper-evident). DB audit-writer role: INSERT/SELECT only. |
+| Retention | **Configurable per org**, default 365 days. |
+| Export | CSV/JSON export + cursor **pull endpoint** a SIEM can poll (`?since=seq`). |
+| Views | Per-user + org-wide (org-admin); instance-wide (super-admin). |
+
+---
+
+## 2. What's audited
+Auth (login, logout, failed login, force-disconnect), provisioning (org create/delete, member invite/remove/role change), file ops (upload, download, delete/trash, restore, move, rename, purge), sharing (grant, revoke, link create/revoke/**access**), settings (sharing policy, retention, SSO, DS3 endpoint config). Anonymous link access is captured with `actor_type=guest` + ip.
+
+## 3. Integrity & retention
+- **Append-only**; no UPDATE/DELETE code path; enforced by a dedicated DB role.
+- **Hash-chain:** each row stores `hash = H(prev_hash ‖ row)`. Verifiable, tamper-evident. `ponytail:` a hash column, not a blockchain.
+- **Retention:** prune > `retention_days` (default 365). Partition `audit_event` by month for cheap prune + query at scale.
+
+## 4. API additions (`/v2`)
+- Org-admin: `GET /v2/orgs/{id}/audit?actor=&action=&from=&to=&since=seq`, `GET /v2/orgs/{id}/audit/export?format=csv|json`
+- Super-admin: `GET /v2/admin/audit` (instance-wide, same filters)
+- Policy: `GET|PUT /v2/orgs/{id}/audit-policy` (retention_days)
+- Force-disconnect: `GET /v2/admin/sessions`, `DELETE /v2/admin/sessions/{id}` (instance); `…/orgs/{id}/sessions` (org-admin, own org)
+
+## 5. Force-disconnect mechanics
+Three layers, escalating:
+1. **Revoke Zitadel session/token** via the `IdentityProvider` port (management API: terminate session).
+2. **Redis revocation denylist** — `revoked:{session_id}` / `revoked_user:{member_id}` (TTL = max access-token lifetime). The Layer-0 auth middleware checks it on every request → **revoked token rejected immediately**, despite stateless JWT. *(Requires Layer-0: short access-token TTL, e.g. 5–15 min, + this denylist check — noted as a Layer-0 auth addendum.)*
+3. **Drop WebSocket(s)** — publish a `disconnect` command over Redis to whichever instance holds the connection (via the events hub); connection closed at once.
+- **Nuclear option:** rotate the org's DS3 credentials → invalidates any outstanding presigned URLs (confirm DS3 invalidates presigns on key rotation). Reserve for compromise scenarios.
+
+## 6. Schema (extends Layer-0)
+```
+audit_event(id, org_id, seq, actor_type[member|guest|system], actor_id,
+            action, target_type, target_id, metadata jsonb, prev_hash, hash, created_at)   -- partition by month
+audit_policy(org_id PK, retention_days default 365)
+-- revocation lives in Redis (denylist), not Postgres
+```
+
+## 7. Tests (e2e)
+- Each action type emits an event with correct actor/target/ip; hash-chain verifies; append-only (no mutate path).
+- Retention prune drops only > window; per-user/org/instance queries correctly scoped; export format valid.
+- **Force-disconnect:** revoked token rejected within one TTL window; WebSocket dropped across instances (Redis); denylist honored on every node.
+- Negative: org-admin can't read/force-disconnect **other** orgs.
+
+## 8. Open items
+- Zitadel **session-termination / token-revocation** API — confirm surface via management API.
+- DS3 presign **invalidation on key rotation** — confirm (drives the nuclear option).
+- Layer-0 auth addendum: short access-token TTL + Redis denylist check (fold into Layer-0 plan).
+
+## 9. Next
+**Backend fully defined** (Layer 0 + Sharing + Versioning + Audit). Next: client surfaces — **Web dashboards** (super-admin → org-admin → user), then Mobile, plus cross-cutting Whitelabel / VPN-proxy. Or `writing-plans` for the backend now.

--- a/docs/superpowers/specs/2026-07-16-layer1-sharing-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer1-sharing-design.md
@@ -1,0 +1,97 @@
+# DS3 Drive v3.0 — Layer 1: Sharing, Permissions & Links (deep-dive spec)
+
+**Status:** Draft. Second per-part deep-dive. Extends Layer 0 (`2026-07-16-layer0-foundation-design.md`) and the north-star.
+**Date:** 2026-07-16
+**Build order:** backend-first (extends the `/v2` API), e2e-tested + benchmarked, before dashboard/client UI.
+
+---
+
+## 1. Scope
+
+**v1:** internal sharing (within an org) + **admin-governed public/private links** for external collaborators. **No cross-org accounts.**
+**Deferred (own phase):** cross-org / external *named* sharing — via **guest identities + domain allowlists**, per the Google-visitor / Box-collaborator / Dropbox-approved-list pattern. Design leaves room; does not build it now.
+
+### Locked decisions
+| Topic | Decision |
+|---|---|
+| Boundary | Internal shares + public/private links. No cross-org account sharing (deferred). |
+| Grant model | Folder-level, **inherited** (via node materialized path); roles **viewer / editor / owner**; principals = **members + flat groups**. |
+| Resolution | Effective role = **most-permissive** across direct + group + inherited grants. |
+| Governance | **GDrive-style: org-admin sets policy/defaults; any member creates within it.** |
+| Links | Presigned-backed (no proxy). Scopes: **view / download / upload (file-request)**. Optional password + expiry, bounded by admin policy. |
+
+---
+
+## 2. Governance model (org sharing policy)
+
+Per-org policy, set by org-admin, enforced server-side on every share/link action:
+- `links_enabled` (bool) — kill switch for public links.
+- `default_link_expiry` / `max_link_expiry` — user picks within the cap.
+- `require_link_password` (off / optional / enforced).
+- `allowed_link_scopes` — subset of {view, download, upload}.
+- (deferred) `external_domain_allowlist` — for future named external sharing.
+
+**Within policy, any member can create shares/links** on nodes they hold editor/owner on. Changing folder-level *permissions* (adding/removing grants) requires **owner** on that folder (or org-admin). Policy is **forward-only** — tightening it doesn't retro-revoke existing links (matches GDrive/Dropbox); an audit view surfaces existing shares for manual cleanup.
+
+---
+
+## 3. Flows
+
+**Internal share:** member picks a folder + a member/group + role → `permission` row inserted → email notification. Invitee is already an org member (internal only), so no account provisioning.
+
+**Public/private link — create:** on a node, create a link with scope + optional password + expiry (within policy) → returns stable `token`. Stored in `public_link`.
+
+**Public link — anonymous access:** `GET /v2/l/{token}` → validate active + not expired + password (if set) → **mint a short-lived presigned GET** (download) or a preview response (view) → client fetches bytes **direct from DS3**. For **upload/file-request** links: mint a presigned **PUT** into the link's target folder. `ponytail:` the token is stable and revocable; the presigned URL is minted per-access and short-lived — no standing exposure, no proxy.
+
+**Revoke:** disable/delete the `public_link` row (immediate) or remove a `permission` row. Presigned URLs already handed out expire on their own short TTL.
+
+---
+
+## 4. API additions (`/v2`)
+
+- **Permissions:** `GET|POST /v2/nodes/{id}/permissions`, `DELETE /v2/nodes/{id}/permissions/{pid}`
+- **Internal share (notify):** `POST /v2/nodes/{id}/share` (member/group + role + optional message → grant + email)
+- **Links:** `POST /v2/links`, `GET|PATCH|DELETE /v2/links/{id}`
+- **Public resolve (unauthenticated):** `GET /v2/l/{token}` (metadata/preview), `POST /v2/l/{token}/content` (→ presigned GET), `POST /v2/l/{token}/upload` (→ presigned PUT)
+- **Org policy:** `GET|PUT /v2/orgs/{id}/sharing-policy`
+
+---
+
+## 5. Schema (extends Layer-0 stubs)
+
+```
+permission(id, org_id, node_id, principal_type[member|group], principal_id, role[viewer|editor|owner])
+public_link(id, org_id, node_id, token, scope[view|download|upload], password_hash?, expires_at, created_by, disabled, created_at)
+sharing_policy(org_id PK, links_enabled, default_link_expiry, max_link_expiry, require_link_password, allowed_link_scopes jsonb)
+-- share_invite(...) retained but unused in v1 (external named sharing deferred)
+```
+Authz check = one indexed ancestor-prefix query over `permission` by node `path` (folder-inherited) → holds the Layer-0 `<10ms` target.
+
+---
+
+## 6. Audit (feeds the Audit section)
+Log `share.grant`, `share.revoke`, `link.create`, `link.revoke`, `link.access` (with actor / target / ip) to `audit_event`. The **external-sharing view** (org-admin) lists all active links + external grants for policy cleanup.
+
+---
+
+## 7. Deferred: cross-org / external named sharing (own phase)
+When added, follow the competitor blueprint — **do not** open tenant buckets to each other:
+- **Guest identities:** external email → a *scoped guest* (Zitadel guest user) that sees only shared nodes (Google visitor / Box collaborator model), optional email/PIN verification.
+- **Domain allowlist** in org policy (Dropbox approved-list / Google trusted domains).
+- Server mints presigned URLs against the *owning* org's bucket for the guest, gated by the grant.
+- Forward-only policy + external-sharing audit view.
+
+---
+
+## 8. Tests (e2e, extends Layer-0 suite)
+- **Authz matrix:** viewer can't write; editor can't change perms; only owner/admin edits grants; most-permissive resolution correct.
+- **Isolation:** cross-org access denied everywhere.
+- **Links:** anonymous download works; expired/disabled/wrong-password denied; upload-link writes only into its target folder; revoke is immediate for new access.
+- **Governance:** link creation blocked when `links_enabled=false`; expiry clamped to `max_link_expiry`; enforced password required.
+
+## 9. Open items
+- Preview (view-scope) rendering: presigned GET + client-side render vs. a thumbnail service — decide in the dashboard phase.
+- File-request (upload link) quota/limits to prevent abuse — simple per-link size/count cap for v1.
+
+## 10. Next
+Continue section deep-dives (Versioning / Audit / Dashboards), or `writing-plans` once enough of Layer 1 is defined.

--- a/docs/superpowers/specs/2026-07-16-layer1-versioning-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer1-versioning-design.md
@@ -1,0 +1,66 @@
+# DS3 Drive v3.0 — Layer 1: Versioning & Trash (deep-dive spec)
+
+**Status:** Draft. Third per-part deep-dive. Extends Layer 0 + north-star.
+**Date:** 2026-07-16
+**Build order:** backend-first (extends `/v2`), before client UI.
+
+---
+
+## 1. Scope
+Full version history with preview + restore (match Dropbox/GDrive/Nextcloud/Proton), on **S3-native versioning** + a Postgres **version index**. Plus an app-level **trash**, because **DS3 versioned deletes are irreversible** — normal deletes must never hard-delete.
+
+### Locked decisions
+| Topic | Decision |
+|---|---|
+| Storage | S3-native bucket versioning (enabled at org provisioning) + Postgres `file_version` index. |
+| Retention | **Admin-configurable window, default 90 days.** Lifecycle prunes non-current versions older than the window. |
+| Delete | **Soft-delete (trash)** via Postgres flag — S3 object untouched. No irreversible S3 delete except explicit purge/prune. |
+| Restore | Previous version → S3 CopyObject(version-id)→new current. Trashed file → clear flag. Both push a change event. |
+
+---
+
+## 2. Delete / trash design (the careful bit)
+- **Delete** = set `node.deleted_at` + `trashed_by` in Postgres. Object stays at its S3 key, hidden from namespace listings. **No S3 DELETE issued** → no delete marker, nothing irreversible.
+- **Trash view** lists soft-deleted nodes; **restore** clears the flag (+ push). 
+- **Purge** (manual or after trash window) = the *only* place we issue an S3 delete. By then it's intentional and past the safety window.
+- `ponytail:` soft-delete is a Postgres flag, not an S3 move — no byte copy, no delete markers, cheap and reversible. The irreversible-delete footgun is simply never on the normal path.
+
+## 3. Version lifecycle
+- Every `commit` (Layer-0 upload flow) creates a new S3 version → append `file_version` row, flip `is_current`.
+- **Prune job** (per org, scheduled): delete non-current `file_version`s older than the org's retention window, and their S3 version-ids (`DELETE ?versionId=`). **Never touches the current version.**
+- **Prefer S3 lifecycle** (`NoncurrentVersionExpiration`) if DS3 supports it (offloads pruning to storage); else the app prune job. → open item.
+
+## 4. Restore semantics
+- **Restore a version:** `CopyObject` from the chosen `s3_version_id` to a new current version → update `node.current_version_id`, append `file_version`, append `change_event` → push. (Non-destructive: history preserved.)
+- **Restore from trash:** clear `deleted_at` → node reappears → push.
+
+## 5. API additions (`/v2`)
+- `GET /v2/files/{id}/versions` → `[{version_id, size, hash, author, created_at, is_current}]`
+- `GET /v2/files/{id}/versions/{vid}/content` → presigned GET of that version (preview/download old)
+- `POST /v2/files/{id}/restore {version_id}`
+- `DELETE /v2/nodes/{id}` → **soft-delete** (trash)
+- `GET /v2/trash` · `POST /v2/trash/{id}/restore` · `DELETE /v2/trash/{id}` (**permanent purge**)
+- `GET|PUT /v2/orgs/{id}/retention-policy` (window days)
+
+## 6. Schema (extends Layer-0)
+```
+file_version(id, node_id, s3_version_id, size, hash, author, created_at, is_current)   -- index; org-scoped via node
+node: + deleted_at, + trashed_by                                                        -- soft-delete
+retention_policy(org_id PK, version_window_days default 90, trash_window_days default 30)
+```
+`file_version` grows with edits — org-scoped + partition-ready like the rest. Prune keeps it bounded per the window.
+
+## 7. Tests (e2e)
+- version-list + version-content (presigned) correct; **restore** creates a new current, preserves history.
+- **soft-delete** hides node but keeps S3 object; **restore-from-trash** works; **purge** is the only S3 delete.
+- **prune** removes only non-current versions older than window; **never** the current version; per-org isolation.
+- negative: no cross-org version access/restore.
+- **Benchmark:** version-list p99 < 100ms (org-scoped index).
+
+## 8. Open items
+- DS3 **lifecycle rule** support (`NoncurrentVersionExpiration`) — prefer over app prune job; confirm.
+- Confirm **single-version DELETE** (`?versionId=`) works on DS3 for pruning.
+- Trash window vs retention window: independent knobs (trash default 30d, versions default 90d) — confirm resellers want both.
+
+## 9. Next
+Continue deep-dives (Audit + force-disconnect, then Dashboards), or `writing-plans` once Layer 1 backend is fully defined.

--- a/docs/superpowers/specs/2026-07-16-layer2-mobile-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer2-mobile-design.md
@@ -1,0 +1,46 @@
+# DS3 Drive v3.0 — Layer 2: Mobile In-App Browser (deep-dive spec)
+
+**Status:** Draft. Sixth per-part deep-dive. Consumes the backend; a *later* client (after web).
+**Date:** 2026-07-16
+**Reverses:** `PROJECT.md` "Files-app-only on iOS" — now **dual** (in-app browser + FileProvider), like Dropbox.
+
+---
+
+## 1. Scope & decisions
+| Topic | Decision |
+|---|---|
+| Platforms | iOS / iPadOS. (Desktop stays OS-integrated — Finder/Explorer — just re-pointed to the server.) |
+| Model | **Server-mediated, greenfield** (v3/new orgs). Existing direct-S3 iOS app keeps serving existing users. |
+| Surfaces | **Dual:** in-app file browser **+** re-pointed FileProvider (Files-app integration, open-in-other-apps). |
+| Access | **On-demand + native offline (v1).** FileProvider already materializes files locally and supports **"keep downloaded"** (offline) — shipped behavior. The in-app browser **coordinates with the FileProvider domain** (single local store) so offline is native, not a separate cache to build. On-demand hydration (presigned) for un-materialized items. |
+| Preview | **QuickLook** — native PDF / Office / image preview (richer than web, free). |
+| Reuse | Rust core (`ds3-models`, `ds3-s3`, UniFFI) already exists — re-point from direct-S3 to `/v2` + presigned. |
+
+## 2. Components
+- **Auth:** Zitadel OIDC + PKCE via `ASWebAuthenticationSession`; tokens in Keychain. (IdP-portable per Layer-0 seam.)
+- **`/v2` API client:** control plane (namespace, shares, versions, trash, account).
+- **In-app browser (SwiftUI):** folder list/grid, file/photo upload (picker + re-pointed Share Extension), download, QuickLook preview, share links (within org policy), shared-with-me, version history/restore, trash. Reuse iPad-adaptive patterns already shipped. **Backed by the FileProvider domain** (single local store) → materialized/"keep-downloaded" files are offline-available in the browser for free; no parallel cache.
+- **FileProvider extension:** re-pointed to hydrate via **presigned URLs** from the server (keep the existing 20MB streaming-I/O memory pattern).
+- **Push:** WebSocket (foreground) **+ APNs (background)** — see §3.
+
+## 3. ⚠️ Backend addition — APNs for background sync
+iOS can't hold a WebSocket in the background, so the server must send **APNs** notifications to wake the app for remote changes (WebSocket handles foreground live updates). **This is a new backend capability** (APNs sender + device-token registration) beyond the web's WebSocket-only push. Fold an APNs provider into the events service; register device tokens per `client_session`. (Android later → FCM, same shape.)
+
+## 4. Key concerns
+- **Background sync:** APNs wake + `BGTask`; on-demand hydration on access. No persistent background socket.
+- **Memory:** keep streaming I/O in the FileProvider extension (existing pattern).
+- **Upload:** presigned PUT / multipart from picker + Share Extension.
+- **Whitelabel = per-reseller app build** (build-time) → each reseller ships a branded binary under **their own App Store account / MDM** ("sell through their own store profiles"). Separate app targets/config per reseller. (Detailed in the whitelabel spec.)
+
+## 5. Testing
+- XCUITest for in-app journeys (login → browse → preview → upload → share → restore).
+- FileProvider integration (hydrate via presigned, push-driven refresh).
+- On-demand fetch + QuickLook; auth/session; APNs-triggered background sync.
+
+## 6. Open items
+- **APNs backend integration** + device-token lifecycle (and FCM for a future Android).
+- Existing direct-S3 app **coexistence / eventual migration** path for old users.
+- Confirm QuickLook covers the reseller's required doc types.
+
+## 7. Next
+Last section: cross-cutting **Whitelabel + VPN/proxy**. Then index + `writing-plans`.

--- a/docs/superpowers/specs/2026-07-16-layer2-mobile-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer2-mobile-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft. Sixth per-part deep-dive. Consumes the backend; a *later* client (after web).
 **Date:** 2026-07-16
-**Reverses:** `PROJECT.md` "Files-app-only on iOS" — now **dual** (in-app browser + FileProvider), like Dropbox.
+**Reverses:** `.planning/PROJECT.md` "Files-app-only on iOS" — now **dual** (in-app browser + FileProvider), like Dropbox.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-16-layer2-web-dashboards-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer2-web-dashboards-design.md
@@ -1,0 +1,50 @@
+# DS3 Drive v3.0 — Layer 2: Web Dashboards (deep-dive spec)
+
+**Status:** Draft. Fifth per-part deep-dive. Consumes the fully-defined backend (Layer 0 + Layer 1).
+**Date:** 2026-07-16
+**Note:** The **end-user dashboard is the primary v1 client** (web-only greenfield) — a real file manager, not a secondary surface.
+
+---
+
+## 1. Scope & decisions
+| Topic | Decision |
+|---|---|
+| App | **One Next.js (App Router) + TypeScript app**, role-gated (super-admin / org-admin / user areas). |
+| UI | **Tailwind + shadcn/ui** (Radix), themed via **CSS variables**. |
+| Whitelabel | **Build-time** — swap a token file + asset bundle (logo, colors, product name, support links) per reseller; one theme per instance build. |
+| Auth | BFF (httpOnly cookie, from Layer-0), calls `/v2`. |
+| Preview (v1) | PDF + image inline; Office = thumbnail + download. **Full GDocs-style editing = v2.** |
+| Build order | **super-admin → org-admin → end-user** (must configure + provision + invite before the user surface is usable). |
+| Multilanguage | **i18n first-class** — `next-intl` (frontend) + **per-user locale** + **localized backend emails/notifications** (invites, shares). Cross-cutting: also applies to mobile. |
+
+## 2. Per-persona scope
+**Super-admin (reseller operator):** first-run config (DS3 endpoint + creds, instance settings), **org lifecycle** (create / suspend / delete org, assign first org-admin), instance **usage/stats** (storage, orgs, users, activity), **instance-wide audit** + export, **force-disconnect** (sessions), health/license.
+
+**Org-admin (end-customer admin):** **members** (invite / remove / role), **groups** (CRUD + membership), **sharing policy**, retention/audit policy, **per-org audit** + export, **external-sharing view** (active links), org usage.
+
+**End-user (the product):** **file manager** — folder tree, list/grid, drag-drop upload, download, PDF/image preview, Office thumbnail+download; **sharing** (create links within policy, my-links, shared-with-me / by-me); **trash** (restore / purge); **version history** (list / preview / restore); **account** (profile, active sessions/devices, notifications).
+
+## 3. Architecture
+- Next.js App Router; RSC for data fetch, client components for interactivity (upload, drag-drop, live updates).
+- **Browser ↔ DS3 direct** via Layer-0 presigned URLs (PUT/multipart part URLs / GET). Server never in the byte path — *if CORS works* (see risk).
+- **WebSocket** (`/v2/events`) drives live updates (new files, sync status, trash, shares).
+- **i18n from day 1** (`next-intl`) — resellers localize (e.g. TIM → Italian).
+
+## 4. ⚠️ Key risk — browser presigned needs DS3 CORS
+Browser `fetch` PUT/GET to the DS3 gateway with a presigned URL requires the bucket to allow the dashboard origin via **CORS** (`PutBucketCors`). **Confirm DS3 supports bucket CORS.** If it does **not**, the *web* data plane must fall back to the **proxy tier** (server streams bytes for browser up/download) — reopening "no proxy in v1" **for the web client only** (native clients can still presign direct). This is the #1 thing to verify before building the file manager.
+
+## 5. Other open items
+- **Office/PDF thumbnails** need server-side rendering (LibreOffice-headless / pdfium) — a small thumbnail-render service or an extension of `DS3Thumbnails` (which today does images only).
+- **Large-upload UX** — presigned multipart + progress; docs are small so resumable is nice-to-have, not v1.
+- A few branding bits (support email, product name) — build-time per the whitelabel decision; confirm none need runtime per-org override.
+- **Backend i18n:** add `member.locale` (Layer-0 schema) + localized server-side email/notification templates; instance default locale set at build/config.
+
+## 6. Testing
+- **Playwright** e2e per persona journey (super-admin provisions org → org-admin invites → user uploads/previews/shares/restores).
+- Component tests; a11y baseline from Radix/shadcn; visual-regression on the themeable token layer.
+
+## 7. Design direction
+Visual/UX direction (layout, information density, brand-neutral base theme that whitelabels cleanly) to be developed via the **frontend-design** skill at implementation time — not during this spec. Requirements above are the contract it fills.
+
+## 8. Next
+Mobile in-app browser, then cross-cutting Whitelabel / VPN-proxy — or `writing-plans` for the backend + dashboards.

--- a/docs/superpowers/specs/2026-07-16-layer2-web-dashboards-design.md
+++ b/docs/superpowers/specs/2026-07-16-layer2-web-dashboards-design.md
@@ -15,7 +15,7 @@
 | Auth | BFF (httpOnly cookie, from Layer-0), calls `/v2`. |
 | Preview (v1) | PDF + image inline; Office = thumbnail + download. **Full GDocs-style editing = v2.** |
 | Build order | **super-admin → org-admin → end-user** (must configure + provision + invite before the user surface is usable). |
-| Multilanguage | **i18n first-class** — `next-intl` (frontend) + **per-user locale** + **localized backend emails/notifications** (invites, shares). Cross-cutting: also applies to mobile. |
+| Multilingual | **i18n first-class** — `next-intl` (frontend) + **per-user locale** + **localized backend emails/notifications** (invites, shares). Cross-cutting: also applies to mobile. |
 
 ## 2. Per-persona scope
 **Super-admin (reseller operator):** first-run config (DS3 endpoint + creds, instance settings), **org lifecycle** (create / suspend / delete org, assign first org-admin), instance **usage/stats** (storage, orgs, users, activity), **instance-wide audit** + export, **force-disconnect** (sessions), health/license.

--- a/docs/superpowers/specs/2026-07-16-v3-enterprise-INDEX.md
+++ b/docs/superpowers/specs/2026-07-16-v3-enterprise-INDEX.md
@@ -16,7 +16,7 @@ Brainstormed 2026-07-16. Turns the direct-to-S3 sync client into a **server-medi
 - **Data plane:** presigned URLs, bytes client↔DS3 direct, no proxy in v1. **Identity:** Zitadel (authN + per-org SSO), Keycloak-swappable seam. **Server:** Rust/axum reusing `core/`. **Data:** Postgres (SoT) + Redis (day 0). **Push:** WebSocket :443 (+ APNs for mobile background).
 - **Tenancy:** two-level — reseller self-hosts a **branded instance** → many SMB **orgs** (each = DS3 project/bucket). Target ~10k orgs × ~10 users × ~10TB → design-to-scale, deploy small.
 - **Perms:** folder-level inherited + flat groups. **Sharing:** internal + admin-governed links (GDrive-style); cross-org deferred. **Versioning:** S3-native + trash. **Audit:** immutable + exportable.
-- **Surfaces:** web dashboards (primary v1 client) → mobile dual. **Whitelabel:** build-time. **i18n + multilanguage:** first-class.
+- **Surfaces:** web dashboards (primary v1 client) → mobile dual. **Whitelabel:** build-time. **i18n + multilingual:** first-class.
 - **Order:** backend (e2e-tested + benchmarked, *flawless*) → web → native.
 
 ## ⚠️ Confirm before execution (DS3 / Zitadel team)

--- a/docs/superpowers/specs/2026-07-16-v3-enterprise-INDEX.md
+++ b/docs/superpowers/specs/2026-07-16-v3-enterprise-INDEX.md
@@ -1,0 +1,37 @@
+# DS3 Drive v3.0 — Enterprise Platform Spec Set (index)
+
+Brainstormed 2026-07-16. Turns the direct-to-S3 sync client into a **server-mediated, multi-tenant, self-hosted enterprise SaaS** on Cubbit DS3. Execution starts **after v2.0.0 Windows wraps**. Branch: `feat/enterprise-platform-v3`.
+
+## Read in this order
+1. **[north-star](2026-07-16-enterprise-platform-northstar-design.md)** — the map + locked foundation.
+2. **[Layer 0 — Foundation](2026-07-16-layer0-foundation-design.md)** — server, `/v2` API, auth, provisioning, presigned data plane, push, schema, benchmark/test gates. *(build first; backend flawless before clients)*
+3. **[Layer 1 — Sharing](2026-07-16-layer1-sharing-design.md)** — grants, GDrive-style governance, links, deferred external blueprint.
+4. **[Layer 1 — Versioning & Trash](2026-07-16-layer1-versioning-design.md)** — S3 versions + index, 90-day retention, irreversible-delete-safe trash.
+5. **[Layer 1 — Audit & Force-Disconnect](2026-07-16-layer1-audit-forcedisconnect-design.md)** — tamper-evident audit, export/SIEM, revoke+drop.
+6. **[Layer 2 — Web Dashboards](2026-07-16-layer2-web-dashboards-design.md)** — 3 personas, Next.js/shadcn, i18n, the primary v1 client.
+7. **[Layer 2 — Mobile](2026-07-16-layer2-mobile-design.md)** — dual in-app browser + re-pointed FileProvider, offline-native.
+8. **[Cross-cutting — Whitelabel & VPN/Proxy](2026-07-16-crosscutting-whitelabel-vpn-design.md)** — build-time branding, system proxy + custom CA.
+
+## Decision summary (the load-bearing calls)
+- **Data plane:** presigned URLs, bytes client↔DS3 direct, no proxy in v1. **Identity:** Zitadel (authN + per-org SSO), Keycloak-swappable seam. **Server:** Rust/axum reusing `core/`. **Data:** Postgres (SoT) + Redis (day 0). **Push:** WebSocket :443 (+ APNs for mobile background).
+- **Tenancy:** two-level — reseller self-hosts a **branded instance** → many SMB **orgs** (each = DS3 project/bucket). Target ~10k orgs × ~10 users × ~10TB → design-to-scale, deploy small.
+- **Perms:** folder-level inherited + flat groups. **Sharing:** internal + admin-governed links (GDrive-style); cross-org deferred. **Versioning:** S3-native + trash. **Audit:** immutable + exportable.
+- **Surfaces:** web dashboards (primary v1 client) → mobile dual. **Whitelabel:** build-time. **i18n + multilanguage:** first-class.
+- **Order:** backend (e2e-tested + benchmarked, *flawless*) → web → native.
+
+## ⚠️ Confirm before execution (DS3 / Zitadel team)
+| # | Item | Impact if unavailable |
+|---|---|---|
+| 1 | Presigned URLs | ✅ **confirmed** |
+| 2 | DS3 **management APIs** (project/bucket/IAM CRUD) at endpoint | blocks per-org provisioning |
+| 3 | DS3 **presigned multipart** part-URL signing | large-upload path |
+| 4 | DS3 **bucket CORS** (`PutBucketCors`) | **web** browser must proxy uploads/downloads (reopens proxy for web only) |
+| 5 | DS3 **lifecycle** (`NoncurrentVersionExpiration`) | fall back to app prune job |
+| 6 | DS3 **single-version DELETE** (`?versionId=`) | version pruning mechanism |
+| 7 | DS3 **presign invalidation on key rotation** | force-disconnect nuclear option |
+| 8 | **Zitadel** at ~100k users/~10k orgs, per-org SSO, session-termination + org-provisioning APIs | identity core |
+| 9 | Rust core HTTP: **system-proxy + OS-trust-store** | VPN/proxy + custom CA |
+| — | STS | ✅ confirmed **not** supported — design accounts for it |
+
+## Next
+`superpowers:writing-plans` → phased implementation plan for **Layer 0**, once Windows v2.0.0 is done.

--- a/docs/superpowers/specs/2026-07-16-v3-enterprise-INDEX.md
+++ b/docs/superpowers/specs/2026-07-16-v3-enterprise-INDEX.md
@@ -33,5 +33,8 @@ Brainstormed 2026-07-16. Turns the direct-to-S3 sync client into a **server-medi
 | 9 | Rust core HTTP: **system-proxy + OS-trust-store** | VPN/proxy + custom CA |
 | — | STS | ✅ confirmed **not** supported — design accounts for it |
 
+## Human-readable spec (for collaborators)
+**[2026-07-16-v3-enterprise-platform-SPEC.md](2026-07-16-v3-enterprise-platform-SPEC.md)** — a single narrative document consolidating the whole set (also exported to a Google Doc). Includes **operations** (Prometheus/Loki/Grafana + feature flags) and a **future-directions** section (v2 in-browser editing + billing + migration + SCIM; zero-knowledge folders; ransomware rollback + compliance/WORM; LAN/delta sync; v4 AI-over-files; OCR; collaboration & mobile polish).
+
 ## Next
 `superpowers:writing-plans` → phased implementation plan for **Layer 0**, once Windows v2.0.0 is done.

--- a/docs/superpowers/specs/2026-07-16-v3-enterprise-platform-SPEC.md
+++ b/docs/superpowers/specs/2026-07-16-v3-enterprise-platform-SPEC.md
@@ -1,0 +1,265 @@
+# DS3 Drive 3.0 — Enterprise Platform Specification
+
+*Version 1.0 · 16 July 2026 · Status: Draft for review*
+
+---
+
+## 1. Executive summary
+
+DS3 Drive today is a **desktop and mobile sync client**: it logs a user into Cubbit, then talks directly to Cubbit DS3 (S3-compatible) storage to sync files, showing them as a native drive in Finder, the iOS Files app, and Windows Explorer.
+
+This specification describes **DS3 Drive 3.0**, a transformation of that client into a **complete, self-hosted, white-labeled enterprise file platform** — a "Dropbox for Cubbit" that a large enterprise (for example, a telecommunications operator) can run on its own infrastructure and resell to its own business customers under its own brand.
+
+The change is significant: we move from a client that talks straight to storage, to a **server-mediated platform** with its own identity layer, sharing and permissions, versioning, audit, web dashboards, and mobile apps. Crucially, we do this **without turning our server into a bottleneck** — file bytes continue to travel directly between the user's device and Cubbit storage, while our server governs *who is allowed to do what*.
+
+This document is the north star for that effort. It is organized so that the foundation (the server and its API) is defined first and built first — "the backend must be flawless before we add the clients" — followed by the enterprise features and the user-facing applications.
+
+---
+
+## 2. Where DS3 Drive is today
+
+- **Clients:** native apps for macOS, iOS/iPadOS, and (in progress) Windows, built on a shared Rust core for storage and authentication.
+- **How it works:** each client authenticates to Cubbit and receives storage credentials, then reads and writes files directly against Cubbit DS3.
+- **Deliberate limitation:** there is **no backend of our own**. This kept the product simple, but it means every user effectively holds storage credentials, and there is no central place to manage users, share folders, enforce permissions, or serve a web experience.
+
+Every capability requested for 3.0 — a managed identity layer, sharing, permissions, a web console, per-organization provisioning, audit — requires a backend. So 3.0 is, at its heart, the introduction of that backend and the re-shaping of the product around it.
+
+---
+
+## 3. What we are building
+
+DS3 Drive 3.0 introduces a **Sync Server** — a control plane — and re-points the applications to it. The platform will provide:
+
+1. **A managed identity layer** so end users never see raw storage credentials, with support for enterprise single sign-on (SAML/OIDC) and per-organization identity.
+2. **A sync backend** that authenticates users, pushes changes to clients in real time (instead of polling), and holds the authoritative picture of every organization's files.
+3. **Sharing, permissions, and links** — invite colleagues to folders, create public or password-protected links, with granular, admin-governed control.
+4. **Versioning and trash** — full file history with restore, and a safe recycle bin.
+5. **Web dashboards** for three audiences: the platform operator, the organization administrator, and the end user.
+6. **Refreshed mobile apps** that browse files inside the app (like Dropbox), not only through the system Files integration.
+7. **Audit logs and remote disconnect** for compliance and security.
+8. **White-labeling** so each reseller ships the product under its own brand.
+9. **Per-organization data isolation**, with a dedicated storage bucket/project created automatically for each customer.
+
+---
+
+## 4. Product model and the people who use it
+
+The defining characteristic of 3.0 is a **two-level model**.
+
+**Level 1 — the reseller.** A large enterprise self-hosts its own branded instance of DS3 Drive (via Docker/Kubernetes) connected to a Cubbit DS3 instance. This is *their* product, sold under *their* name to *their* customers. One reseller = one deployment = one brand.
+
+**Level 2 — the reseller's customers.** Within a single reseller's instance, **many organizations** (typically small and medium businesses) sign up. Each organization has its own users, groups, permissions, and shared folders, and its own isolated storage. So each instance is itself multi-tenant.
+
+This yields three distinct roles, each with its own dashboard:
+
+| Role | Who they are | What they do |
+|---|---|---|
+| **Platform operator** (super-admin) | The reseller running the instance | Connect the instance to Cubbit storage, create and manage customer organizations, see usage and audit across the whole instance, disconnect users |
+| **Organization administrator** | An admin at a customer business | Invite and manage users, create groups, set sharing policy, review their organization's audit log |
+| **End user** | A member of a customer organization | Browse, upload, download, preview, share, and restore their files |
+
+Organizations are created by the reseller (who assigns each one its first administrator); that administrator then invites the rest of the team. Fully self-service sign-up is supported but **switched off by default**, so resellers control who joins.
+
+---
+
+## 5. System architecture
+
+### 5.1 The core idea: separate control from data
+
+The platform cleanly separates two responsibilities:
+
+- **The control plane (our Sync Server)** decides *who may do what*: it authenticates users, stores the file directory structure, enforces permissions, records history and audit, and notifies clients of changes. It handles only small messages, never file contents.
+- **The data plane** carries the actual file bytes, and it flows **directly between the user's device and Cubbit storage** — never through our server.
+
+We connect the two using **pre-signed URLs**. When a user wants to upload or download a file, the client asks the server; the server checks the user's permission, then issues a short-lived, single-file URL that the client uses to talk to Cubbit storage directly. The user never holds a lasting credential, every action is permission-checked, and our server never becomes a bandwidth bottleneck. This is the same principle Dropbox and Google Drive use (a dedicated data path separate from the control path), adapted to Cubbit.
+
+### 5.2 Components
+
+```
+   Users (web / desktop / mobile)
+        │  sign in
+        ▼
+   Identity provider (Zitadel) — branded login, SSO per organization
+        │  token
+        ▼
+   SYNC SERVER  (control plane, Rust)
+     • verifies identity            • authoritative file directory (PostgreSQL)
+     • permissions / sharing        • real-time change notifications (WebSocket)
+     • versioning / audit           • issues pre-signed URLs
+     • provisions a bucket per org  • holds the Cubbit storage credentials
+        │                                    │
+        │ small control messages             │ short-lived pre-signed URL
+        ▼                                    ▼
+   Client apps  ───────── file bytes (direct) ─────────►  Cubbit DS3 storage
+                ◄──────── file bytes (direct) ──────────  (one bucket per org)
+```
+
+Supporting pieces: **PostgreSQL** holds the authoritative directory, permissions, versions, and audit; **Redis** carries real-time notifications between server instances and enables horizontal scaling. Both run inside the reseller's deployment.
+
+### 5.3 Technology choices at a glance
+
+- **Sync Server:** Rust (axum web framework), reusing the existing DS3 Rust core so storage and authentication logic is not rewritten.
+- **Identity:** Zitadel, self-hosted — chosen because organizations are a first-class concept in it and it supports SAML/OIDC single sign-on out of the box. The design keeps identity swappable (e.g., to Keycloak) behind a small internal interface.
+- **Database:** PostgreSQL for all metadata; Redis for messaging and caching.
+- **Web dashboards:** Next.js + TypeScript, styled with Tailwind and shadcn/ui so branding is a matter of swapping design tokens.
+- **Storage:** Cubbit DS3, one bucket/project per organization, with native versioning enabled.
+- **Operations:** Prometheus metrics, Loki logs, Grafana dashboards, and OpenTelemetry tracing — the standard self-hosted observability stack, shipped with the deployment.
+
+---
+
+## 6. Key decisions and why
+
+| Decision | Rationale |
+|---|---|
+| **File bytes go directly to storage via pre-signed URLs; our server is control-plane only** | Keeps Cubbit's distributed storage advantage, avoids a bandwidth bottleneck, and means users never hold lasting storage credentials. Confirmed viable — Cubbit DS3 supports pre-signed URLs. |
+| **Buy identity (Zitadel), don't build it** | Identity, single sign-on, and multi-factor authentication are solved problems; building them is a costly distraction. Zitadel's organization model fits our two-level design. |
+| **PostgreSQL is the source of truth for the file directory; storage holds only bytes** | Sharing, permissions, versioning, and audit need a real transactional database. Because our server authorizes every change, it always knows the current state — no guessing or reconciliation. |
+| **Real-time updates over a persistent connection, not polling** | Faster, lighter, and a better experience; the connection runs over the standard HTTPS port so it passes through corporate networks and VPNs. |
+| **One bucket/project per organization** | Clean, automatic data isolation between customers. |
+| **Backend first, fully tested and benchmarked, before any client** | The platform's correctness and performance are foundational; clients are built on a proven, stable API. |
+| **White-labeling at build time** | Each reseller gets a branded build; a single instance carries a single brand, which matches the self-hosted reseller model. |
+
+---
+
+## 7. How it works — core user journeys
+
+**Creating a customer organization.** The reseller's operator creates an organization from the platform dashboard. Behind the scenes the server creates a matching organization in the identity provider, provisions a dedicated storage bucket (with versioning enabled), records the organization in the database, and assigns its first administrator. This completes in seconds and is safe to retry.
+
+**Signing in.** A user signs in through the branded login page. Enterprise customers can connect their own single sign-on. The application receives a secure token, which it presents to the server on every request; the server verifies it and looks up the user's organization and role.
+
+**Uploading a file.** The client tells the server it wants to save a file. The server checks the user's permission and that the file hasn't changed underneath them, then returns a short-lived upload URL. The client sends the bytes straight to Cubbit storage, then confirms completion. The server records the new version and instantly notifies the user's other devices and collaborators.
+
+**Downloading or previewing.** The server checks permission and returns a short-lived download URL; the client fetches the bytes directly from storage. In the web app, PDFs and images preview inline; on mobile, the system previewer also handles Office documents.
+
+**Sharing a folder.** A user invites a colleague (by choosing them within the organization) or creates a link. Links can be view-only, download, or upload ("file request"), and can carry a password and an expiry — all within limits the organization's administrator has set. For a public link, when someone opens it the server validates the link and mints a one-time download URL; there is no lasting exposure.
+
+**Restoring a previous version.** The user opens a file's history, previews an earlier version, and restores it. Restoring brings the old version back as the new current version without erasing history.
+
+---
+
+## 8. Feature areas in detail
+
+### 8.1 Foundation (built first)
+
+The foundation is the Sync Server and its public API, proven end-to-end on a **web-only** experience for **new** organizations, while today's existing clients keep working unchanged. It includes: identity integration and branded login; automatic per-organization provisioning; the authoritative file directory; the pre-signed upload/download flow with conflict detection; and real-time change notifications.
+
+The server exposes a **documented, versioned API** (`/v2`) that is a first-class product in its own right — enterprises can integrate it with their own systems. Every endpoint is covered by automated end-to-end tests, and performance targets are enforced continuously. The foundation is considered complete only when the API is fully tested, meets its benchmarks, passes strict security checks (for example, no user can ever reach another organization's data), and runs from a single command.
+
+### 8.2 Sharing, permissions, and links
+
+Permissions are set on folders and inherited by their contents, with three roles — **viewer, editor, owner** — and can be granted to individuals or to **groups**. Sharing is **internal** (within an organization) plus **public/private links** for outside collaborators; cross-organization account sharing is intentionally deferred to a later phase, following the "guest account" pattern established by Google, Box, and Dropbox.
+
+Governance follows the Google Drive model: the **organization administrator sets the policy and defaults** (whether links are allowed, maximum expiry, whether passwords are required), and **within those limits any member can share**. Administrators get a view of all active external links for periodic clean-up.
+
+### 8.3 Versioning and trash
+
+Every change creates a new version, backed by Cubbit's native storage versioning, with a fast history index for the user interface. **Retention is configurable, defaulting to 90 days**, after which older versions are pruned to control storage cost.
+
+Deleting a file moves it to a **trash** (a soft delete) rather than removing it immediately — an important safety measure, because permanently deleting a specific version in storage cannot be undone. Files can be restored from trash, and only an explicit purge removes them for good.
+
+### 8.4 Audit and remote disconnect
+
+The platform keeps an **append-only, tamper-evident audit log** of significant actions (sign-ins, sharing, file operations, administrative changes), with configurable retention (default one year), per-user and organization-wide views, and export for compliance and security tooling.
+
+Administrators can **force-disconnect** a user or device: the server revokes the identity session, immediately drops the live connection, and — in the most serious cases — can rotate the organization's storage credentials to invalidate any outstanding access.
+
+### 8.5 Web dashboards
+
+A single Next.js application serves all three roles, gated by permission. Because the foundation ships web-first, the **end-user dashboard is the primary application for version 1** — a genuine file manager with folder navigation, drag-and-drop upload, download, sharing, version history, and trash. For version 1, PDFs and images preview inline and Office documents show a thumbnail with download-to-open; **full in-browser document editing is planned for version 2**. The dashboards are built in the order operator → administrator → end user, and are **multilingual** from the outset.
+
+### 8.6 Mobile apps
+
+The iOS/iPadOS apps gain an **in-app file browser** (browse, preview, upload, download, share, restore) alongside the existing system Files integration — a "dual" model like Dropbox. Files already downloaded remain **available offline** through the existing system integration, so offline works without building a separate cache. Because mobile devices cannot hold a live connection in the background, the server will send **push notifications** to wake the app when files change. Desktop apps keep their native Finder/Explorer integration, re-pointed to the new server.
+
+### 8.7 White-labeling and networking
+
+**White-labeling** is applied at build time: each reseller supplies a branding bundle (logo, colors, product name, support links), and the build produces a branded web app, branded mobile apps (published under the reseller's own store accounts), and a branded login page. It is a configuration bundle, not a complex theming engine.
+
+**Networking** is kept deliberately simple: the apps honor the operating system's proxy settings and corporate certificate authorities, so they work inside enterprise networks and VPNs with no special client. Real-time updates run over the standard HTTPS port, which corporate networks already allow.
+
+### 8.8 Operations: monitoring and feature flags
+
+Because each reseller self-hosts the platform, it ships with a standard, self-hosted **observability stack**: the Sync Server exposes **Prometheus** metrics, emits structured logs collected by **Loki**, provides **Grafana** dashboards, and supports **OpenTelemetry** tracing across requests. Operators get health, performance, and capacity visibility out of the box, and this underpins the performance targets in Section 9.
+
+**Feature management** starts deliberately lightweight. The platform already carries per-organization policy switches in its database (for example, whether public links are allowed, or whether self-service sign-up is enabled) and per-reseller options in the build-time branding bundle; together these cover most needs. A dedicated feature-flag service (such as a self-hosted **Unleash**) can be added later if the platform needs runtime, gradual, or targeted rollouts — noted as an upgrade path, not built for version 1.
+
+---
+
+## 9. Scale and performance
+
+A single reseller instance is designed to serve on the order of **10,000 organizations, roughly 10 users each (~100,000 users), each storing about 10 TB of documents** — tens of billions of files in total. The architecture is designed to scale from day one (every operation is scoped to a single organization, the server is stateless, and the real-time layer scales horizontally), while the intention is to **deploy modestly at first and scale the database tier as volume grows** rather than build for maximum scale immediately.
+
+Performance is treated as a contract, with continuously enforced targets — for example, permission checks under ~10 ms, folder listings under ~100 ms, and change notifications delivered in under a second — validated against realistically-sized data.
+
+---
+
+## 10. Delivery roadmap
+
+Work proceeds in layers, backend-first:
+
+1. **Foundation** — Sync Server, identity, provisioning, pre-signed data plane, real-time updates, fully tested and benchmarked. *(This is the "make it flawless" phase.)*
+2. **Enterprise features** — sharing/permissions/links, versioning/trash, audit/force-disconnect (extensions of the backend).
+3. **Surfaces** — web dashboards (operator → administrator → end user), then the mobile in-app browser.
+4. **Cross-cutting** — white-labeling and networking, wired in early and kept thin.
+
+Execution begins after the current Windows milestone is completed. The end-user experience is the ultimate goal, but it is built last because it depends on the operator and administrator capabilities existing first.
+
+### Beyond version 1 — future directions
+
+The following are out of scope for the first release but recorded as intended directions. Each will get its own specification when its time comes; they are captured here so the foundation does not preclude them.
+
+**Near-term (version 2):**
+
+- **Full in-browser document editing** — a Google-Docs-style experience for viewing and co-editing Office documents in the web app, with comments and activity, going beyond version 1's preview-and-download.
+- **Per-organization billing and metering** — usage metering and plans so resellers can bill their own customers. Close to a requirement for the reseller business model rather than a nice-to-have.
+- **Migration tools** — one-click import from Dropbox, Google Drive, OneDrive, and Box. The strongest lever for winning customers away from incumbents.
+- **SCIM and directory sync** — automatic user provisioning from a customer's Azure AD / Okta. Table stakes for large enterprise deals.
+
+**Differentiators that lean on Cubbit's strengths:**
+
+- **Zero-knowledge / end-to-end encrypted folders** — client-side encryption so not even the reseller can read protected folders. A strong trust and sovereignty proposition for regulated customers.
+- **Ransomware detection and one-click mass restore** — detect abnormal bulk changes and roll an organization back. Builds directly on versioning and is a compelling data-protection story.
+- **Compliance suite** — legal hold, immutable retention (WORM / object-lock), data-loss-prevention and sensitive-data (PII) detection, eDiscovery export, and data-residency reporting that leverages Cubbit's geo-distributed storage.
+- **LAN / peer sync and block-level delta sync** — transfer only changed blocks, and directly between devices on the same office network. Bandwidth-efficient and aligned with Cubbit's distributed model.
+
+**AI and content intelligence (version 4):**
+
+- **AI over your files** — generating embeddings of document contents so users can ask natural-language questions about their own data (retrieval-augmented search and Q&A), semantic search, automatic summaries, and automatic classification of sensitive content (which doubles as a compliance feature). This fits the existing stack — vector search can reuse PostgreSQL (pgvector) and an ingestion step can hook into the existing upload flow to extract and embed text — but it is a future undertaking.
+- **Optical character recognition (OCR)** for scanned documents, making everything full-text searchable.
+
+**Collaboration and mobile polish:**
+
+- Real-time co-editing, comments, @mentions, and an activity feed.
+- Mobile camera upload / auto-backup and document scanning (scan-to-PDF).
+
+These are directional notes, not commitments.
+
+---
+
+## 11. Open questions to confirm before build
+
+A small number of storage- and identity-platform capabilities need confirmation with the Cubbit DS3 and Zitadel teams. Each has a clear fallback, so none blocks the design.
+
+| Item | Why it matters | If unavailable |
+|---|---|---|
+| Pre-signed URLs | The whole direct-data-path model | **Confirmed available** |
+| Temporary (STS) credentials | An alternative credential model | **Confirmed not available** — design already avoids relying on it |
+| Storage management APIs (create bucket/project/user) | Automatic per-organization provisioning | Provisioning would need a manual or alternative path |
+| Browser cross-origin (CORS) support on storage | Lets the **web** app upload/download directly to storage | The web app would route file bytes through a small proxy service (a known fallback) |
+| Storage lifecycle rules | Automatic pruning of old versions | The server prunes on a schedule instead |
+| Invalidating a pre-signed URL by rotating credentials | The strongest form of "force disconnect" | Rely on short URL lifetimes and session revocation |
+| Zitadel at ~100k users, per-organization SSO, session revocation | The identity core | Validate deployment model early; identity is swappable if needed |
+
+---
+
+## 12. Glossary
+
+- **Control plane / data plane** — the separation between deciding *who may do what* (our server) and moving *the actual file bytes* (device ↔ storage).
+- **Pre-signed URL** — a short-lived, single-file link that lets a client read or write one object in storage directly, without holding lasting credentials.
+- **Reseller / organization** — the two tenancy levels: the enterprise running a branded instance, and each of its customer businesses within that instance.
+- **Sync Server** — the new backend (control plane) introduced in 3.0.
+- **White-labeling** — shipping the product under a reseller's own brand.
+
+---
+
+*Prepared for review. Feedback welcome on any section before we turn the foundation into a detailed implementation plan.*


### PR DESCRIPTION
Design/spec-only PR (no code). Captures the v3.0 pivot from a direct-to-S3 sync client to a self-hosted, white-labeled, multi-tenant enterprise platform on Cubbit DS3. Execution starts after the Windows v2.0.0 milestone.

## Contents (`docs/superpowers/specs/`)
- **`…-v3-enterprise-INDEX.md`** — read order + pre-execution "confirm with DS3/Zitadel" checklist
- **`…-v3-enterprise-platform-SPEC.md`** — consolidated, human-readable spec (also exported to a Google Doc)
- **north-star** + per-part deep-dives: Layer 0 foundation · Layer 1 sharing / versioning / audit · Layer 2 web dashboards / mobile · cross-cutting whitelabel / VPN / observability
- `CLAUDE.md` — v3.0 directives block

## Load-bearing decisions
- Server = control plane only; file bytes stay client↔DS3 direct via **pre-signed URLs** (confirmed supported; no STS)
- Identity = **Zitadel** (per-org SSO), Keycloak-swappable behind an interface
- Server = **Rust/axum reusing `core/`**; **PostgreSQL** source of truth + **Redis** day 0
- Two-level tenancy: reseller-branded self-hosted instance → many SMB orgs (bucket/project each)
- Backend first — e2e-tested + benchmarked before any client

## Not in this PR
Implementation. Next step is a phased plan for Layer 0 once Windows wraps.