### PR TITLE
fix(core): build Rust xcframework under Xcode + fix S3 endpoint stack overflow

### DIFF
--- a/core/ds3-ffi/src/c_exports.rs
+++ b/core/ds3-ffi/src/c_exports.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 use crate::cancellation::CancellationHandle;
-use crate::handles::runtime;
+use crate::handles::block_on;
 use crate::log_bridge::{self, DS3LogCallbackFn};
 use crate::panic_guard::ffi_guard;
 use crate::progress::DS3ProgressCallbackFn;
@@ -165,7 +165,7 @@ pub unsafe extern "C" fn ds3_authenticate(
         let tenant = unsafe { ffi_opt_str(tenant_id, tenant_id_len)? };
         let coordinator = unsafe { ffi_opt_str(coordinator_url, coordinator_url_len)? };
 
-        let session = runtime().block_on(DS3Session::authenticate(
+        let session = block_on(DS3Session::authenticate(
             email,
             password,
             tenant,
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn ds3_authenticate_2fa(
         let tenant = unsafe { ffi_opt_str(tenant_id, tenant_id_len)? };
         let coordinator = unsafe { ffi_opt_str(coordinator_url, coordinator_url_len)? };
 
-        let session = runtime().block_on(DS3Session::authenticate_with_2fa(
+        let session = block_on(DS3Session::authenticate_with_2fa(
             email,
             password,
             tfa,
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn ds3_session_restore(
         let coordinator = unsafe { ffi_opt_str(coordinator_url, coordinator_url_len)? };
 
         let session =
-            runtime().block_on(DS3Session::restore_from_refresh_token(refresh, coordinator))?;
+            block_on(DS3Session::restore_from_refresh_token(refresh, coordinator))?;
 
         unsafe { *out_handle = Box::into_raw(Box::new(session)) };
         Ok::<i32, DS3Error>(0)
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn ds3_refresh_token(handle: *const DS3Session, out_error:
             return Err(DS3Error::LoggedOut);
         }
         let session = unsafe { &*handle };
-        runtime().block_on(session.refresh_if_needed())?;
+        block_on(session.refresh_if_needed())?;
         Ok(0)
     })
 }
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn ds3_forge_iam_token(
         }
         let session = unsafe { &*handle };
         let user_id = unsafe { ffi_str(user_id, user_id_len)? };
-        let token = runtime().block_on(session.forge_iam_token(user_id))?;
+        let token = block_on(session.forge_iam_token(user_id))?;
         let json = serde_json::to_string(&token)?;
         unsafe { write_ffi_string(&json, out_json, out_json_len) };
         Ok(0)
@@ -326,13 +326,12 @@ pub unsafe extern "C" fn ds3_get_projects(
             return Err(DS3Error::LoggedOut);
         }
         let session = unsafe { &*handle };
-        runtime().block_on(session.refresh_if_needed())?;
-        let token = runtime()
-            .block_on(session.session.lock())
+        block_on(session.refresh_if_needed())?;
+        let token = block_on(session.session.lock())
             .token
             .token
             .clone();
-        let projects = runtime().block_on(ds3_http::projects::get_projects(
+        let projects = block_on(ds3_http::projects::get_projects(
             &session.http,
             &session.urls,
             &token,
@@ -362,7 +361,7 @@ pub unsafe extern "C" fn ds3_load_api_keys(
         let session = unsafe { &*handle };
         let user_id = unsafe { ffi_str(user_id, user_id_len)? };
         let iam_token = unsafe { ffi_str(iam_token, iam_token_len)? };
-        let keys = runtime().block_on(ds3_http::keys::load_api_keys(
+        let keys = block_on(ds3_http::keys::load_api_keys(
             &session.http,
             &session.urls,
             iam_token,
@@ -396,7 +395,7 @@ pub unsafe extern "C" fn ds3_create_api_key(
         let user_id = unsafe { ffi_str(user_id, user_id_len)? };
         let key_name = unsafe { ffi_str(key_name, key_name_len)? };
         let iam_token = unsafe { ffi_str(iam_token, iam_token_len)? };
-        let key = runtime().block_on(ds3_http::keys::create_api_key(
+        let key = block_on(ds3_http::keys::create_api_key(
             &session.http,
             &session.urls,
             iam_token,
@@ -429,7 +428,7 @@ pub unsafe extern "C" fn ds3_delete_api_key(
         let user_id = unsafe { ffi_str(user_id, user_id_len)? };
         let api_key_id = unsafe { ffi_str(api_key_id, api_key_id_len)? };
         let iam_token = unsafe { ffi_str(iam_token, iam_token_len)? };
-        runtime().block_on(ds3_http::keys::delete_api_key(
+        block_on(ds3_http::keys::delete_api_key(
             &session.http,
             &session.urls,
             iam_token,
@@ -531,7 +530,7 @@ pub unsafe extern "C" fn ds3_list_objects(
         let max_keys_opt = if max_keys > 0 { Some(max_keys) } else { None };
         let cont_token = unsafe { ffi_opt_str(continuation_token, continuation_token_len)? };
 
-        let result = runtime().block_on(client.list_objects(
+        let result = block_on(client.list_objects(
             bucket,
             prefix,
             delimiter,
@@ -557,7 +556,7 @@ pub unsafe extern "C" fn ds3_list_buckets(
             return Err(DS3Error::LoggedOut);
         }
         let client = unsafe { &*s3_handle };
-        let buckets = runtime().block_on(client.list_buckets())?;
+        let buckets = block_on(client.list_buckets())?;
         let bucket_objects: Vec<serde_json::Value> = buckets
             .into_iter()
             .map(|(name, creation_date)| {
@@ -589,7 +588,7 @@ pub unsafe extern "C" fn ds3_head_object(
         let client = unsafe { &*s3_handle };
         let bucket = unsafe { ffi_str(bucket, bucket_len)? };
         let key = unsafe { ffi_str(key, key_len)? };
-        let metadata = runtime().block_on(client.head_object(bucket, key))?;
+        let metadata = block_on(client.head_object(bucket, key))?;
         let json = serde_json::to_string(&metadata)?;
         unsafe { write_ffi_string(&json, out_json, out_json_len) };
         Ok(0)
@@ -625,7 +624,7 @@ pub unsafe extern "C" fn ds3_download_object(
         let callback = wrap_c_progress_callback(progress_cb, progress_ctx);
 
         let result =
-            runtime().block_on(client.download_object(bucket, key, path, callback.as_deref()))?;
+            block_on(client.download_object(bucket, key, path, callback.as_deref()))?;
         let json = serde_json::to_string(&result)?;
         unsafe { write_ffi_string(&json, out_json, out_json_len) };
         Ok(0)
@@ -660,7 +659,7 @@ pub unsafe extern "C" fn ds3_upload_object(
 
         let callback = wrap_c_progress_callback(progress_cb, progress_ctx);
 
-        let etag = runtime().block_on(client.upload_object(
+        let etag = block_on(client.upload_object(
             bucket,
             key,
             path,
@@ -697,7 +696,7 @@ pub unsafe extern "C" fn ds3_delete_object(
         let client = unsafe { &*s3_handle };
         let bucket = unsafe { ffi_str(bucket, bucket_len)? };
         let key = unsafe { ffi_str(key, key_len)? };
-        runtime().block_on(client.delete_object(bucket, key))?;
+        block_on(client.delete_object(bucket, key))?;
         Ok(0)
     })
 }
@@ -722,7 +721,7 @@ pub unsafe extern "C" fn ds3_copy_object(
         let bucket = unsafe { ffi_str(bucket, bucket_len)? };
         let source = unsafe { ffi_str(source_key, source_key_len)? };
         let dest = unsafe { ffi_str(dest_key, dest_key_len)? };
-        runtime().block_on(client.copy_object(bucket, source, dest, None))?;
+        block_on(client.copy_object(bucket, source, dest, None))?;
         Ok(0)
     })
 }
@@ -745,7 +744,7 @@ pub unsafe extern "C" fn ds3_probe_folder_exists(
         let client = unsafe { &*s3_handle };
         let bucket = unsafe { ffi_str(bucket, bucket_len)? };
         let folder_key = unsafe { ffi_str(folder_key, folder_key_len)? };
-        let exists = runtime().block_on(client.probe_folder_exists(bucket, folder_key))?;
+        let exists = block_on(client.probe_folder_exists(bucket, folder_key))?;
         unsafe { *out_result = if exists { 1 } else { 0 } };
         Ok(0)
     })
@@ -768,7 +767,7 @@ pub unsafe extern "C" fn ds3_create_folder_marker(
         let client = unsafe { &*s3_handle };
         let bucket = unsafe { ffi_str(bucket, bucket_len)? };
         let folder_key = unsafe { ffi_str(folder_key, folder_key_len)? };
-        runtime().block_on(client.create_folder_marker(bucket, folder_key))?;
+        block_on(client.create_folder_marker(bucket, folder_key))?;
         Ok(0)
     })
 }
@@ -888,7 +887,7 @@ pub unsafe extern "C" fn ds3_get_challenge(
             None => ds3_http::urls::CubbitAPIURLs::default_coordinator(),
         };
         let http = ds3_http::client::SharedHttpClient::new()?;
-        let challenge = runtime().block_on(ds3_auth::challenge::get_challenge(
+        let challenge = block_on(ds3_auth::challenge::get_challenge(
             &http, &urls, email, tenant,
         ))?;
 
@@ -918,7 +917,7 @@ pub unsafe extern "C" fn ds3_current_session(
             return Err(DS3Error::LoggedOut);
         }
         let session = unsafe { &*handle };
-        let snapshot = runtime().block_on(session.current_session());
+        let snapshot = block_on(session.current_session());
         let json = serde_json::to_string(&snapshot)?;
         unsafe { write_ffi_string(&json, out_session_json, out_session_json_len) };
         Ok(0)
@@ -956,7 +955,7 @@ pub unsafe extern "C" fn ds3_download_to_memory(
         let bucket = unsafe { ffi_str(bucket, bucket_len)? };
         let key = unsafe { ffi_str(key, key_len)? };
 
-        let bytes = runtime().block_on(client.download_to_memory(bucket, key))?;
+        let bytes = block_on(client.download_to_memory(bucket, key))?;
         unsafe { write_ffi_bytes(bytes, out_buf, out_len) };
         Ok(0)
     })
@@ -1010,7 +1009,7 @@ pub unsafe extern "C" fn ds3_upload_from_memory(
             metadata.insert("content-type".to_string(), ct.to_string());
         }
 
-        let etag = runtime().block_on(client.upload_from_memory(bucket, key, data, metadata))?;
+        let etag = block_on(client.upload_from_memory(bucket, key, data, metadata))?;
 
         if let Some(etag_str) = etag {
             unsafe { write_ffi_string(&etag_str, out_etag, out_etag_len) };
@@ -1051,7 +1050,7 @@ pub unsafe extern "C" fn ds3_presign_get(
         let bucket = unsafe { ffi_str(bucket, bucket_len)? };
         let key = unsafe { ffi_str(key, key_len)? };
 
-        let url = runtime().block_on(client.presign_get(bucket, key, ttl_seconds))?;
+        let url = block_on(client.presign_get(bucket, key, ttl_seconds))?;
         unsafe { write_ffi_string(&url, out_url, out_url_len) };
         Ok(0)
     })
@@ -1088,7 +1087,7 @@ pub unsafe extern "C" fn ds3_presign_upload_part(
         let key = unsafe { ffi_str(key, key_len)? };
         let upload_id = unsafe { ffi_str(upload_id, upload_id_len)? };
 
-        let url = runtime().block_on(client.presign_upload_part(
+        let url = block_on(client.presign_upload_part(
             bucket,
             key,
             upload_id,
@@ -1125,7 +1124,7 @@ pub unsafe extern "C" fn ds3_delete_objects(
         let keys_str = unsafe { ffi_str(keys_json, keys_json_len)? };
         let keys: Vec<String> = serde_json::from_str(keys_str)?;
 
-        let deleted = runtime().block_on(client.delete_objects(bucket, &keys))?;
+        let deleted = block_on(client.delete_objects(bucket, &keys))?;
         if !out_deleted_count.is_null() {
             unsafe { *out_deleted_count = deleted as i32 };
         }

--- a/core/ds3-ffi/src/c_exports.rs
+++ b/core/ds3-ffi/src/c_exports.rs
@@ -451,7 +451,7 @@ pub unsafe extern "C" fn ds3_delete_api_key(
 /// which supplies no region.
 ///
 /// The constructor performs NO network I/O (it only builds the AWS SDK client
-/// config), so there is no `runtime().block_on`; the only fallible step is the
+/// config), so there is no `block_on` call; the only fallible step is the
 /// UTF-8 decode of the input buffers.
 ///
 /// Returns 0 on success (handle written to `*out_handle`), -1 on error (code in

--- a/core/ds3-ffi/src/c_exports.rs
+++ b/core/ds3-ffi/src/c_exports.rs
@@ -232,8 +232,7 @@ pub unsafe extern "C" fn ds3_session_restore(
         let refresh = unsafe { ffi_str(refresh_token, refresh_token_len)? };
         let coordinator = unsafe { ffi_opt_str(coordinator_url, coordinator_url_len)? };
 
-        let session =
-            block_on(DS3Session::restore_from_refresh_token(refresh, coordinator))?;
+        let session = block_on(DS3Session::restore_from_refresh_token(refresh, coordinator))?;
 
         unsafe { *out_handle = Box::into_raw(Box::new(session)) };
         Ok::<i32, DS3Error>(0)
@@ -327,10 +326,7 @@ pub unsafe extern "C" fn ds3_get_projects(
         }
         let session = unsafe { &*handle };
         block_on(session.refresh_if_needed())?;
-        let token = block_on(session.session.lock())
-            .token
-            .token
-            .clone();
+        let token = block_on(session.session.lock()).token.token.clone();
         let projects = block_on(ds3_http::projects::get_projects(
             &session.http,
             &session.urls,
@@ -530,13 +526,8 @@ pub unsafe extern "C" fn ds3_list_objects(
         let max_keys_opt = if max_keys > 0 { Some(max_keys) } else { None };
         let cont_token = unsafe { ffi_opt_str(continuation_token, continuation_token_len)? };
 
-        let result = block_on(client.list_objects(
-            bucket,
-            prefix,
-            delimiter,
-            max_keys_opt,
-            cont_token,
-        ))?;
+        let result =
+            block_on(client.list_objects(bucket, prefix, delimiter, max_keys_opt, cont_token))?;
         let json = serde_json::to_string(&result)?;
         unsafe { write_ffi_string(&json, out_json, out_json_len) };
         Ok(0)
@@ -623,8 +614,7 @@ pub unsafe extern "C" fn ds3_download_object(
 
         let callback = wrap_c_progress_callback(progress_cb, progress_ctx);
 
-        let result =
-            block_on(client.download_object(bucket, key, path, callback.as_deref()))?;
+        let result = block_on(client.download_object(bucket, key, path, callback.as_deref()))?;
         let json = serde_json::to_string(&result)?;
         unsafe { write_ffi_string(&json, out_json, out_json_len) };
         Ok(0)
@@ -659,13 +649,7 @@ pub unsafe extern "C" fn ds3_upload_object(
 
         let callback = wrap_c_progress_callback(progress_cb, progress_ctx);
 
-        let etag = block_on(client.upload_object(
-            bucket,
-            key,
-            path,
-            callback.as_deref(),
-            None,
-        ))?;
+        let etag = block_on(client.upload_object(bucket, key, path, callback.as_deref(), None))?;
 
         if let Some(etag_str) = etag {
             unsafe { write_ffi_string(&etag_str, out_etag, out_etag_len) };
@@ -1087,13 +1071,8 @@ pub unsafe extern "C" fn ds3_presign_upload_part(
         let key = unsafe { ffi_str(key, key_len)? };
         let upload_id = unsafe { ffi_str(upload_id, upload_id_len)? };
 
-        let url = block_on(client.presign_upload_part(
-            bucket,
-            key,
-            upload_id,
-            part_number,
-            ttl_seconds,
-        ))?;
+        let url =
+            block_on(client.presign_upload_part(bucket, key, upload_id, part_number, ttl_seconds))?;
         unsafe { write_ffi_string(&url, out_url, out_url_len) };
         Ok(0)
     })

--- a/core/ds3-ffi/src/handles.rs
+++ b/core/ds3-ffi/src/handles.rs
@@ -4,9 +4,11 @@
 //! on a shared `tokio::runtime::Runtime` managed via `OnceLock`. This
 //! avoids the overhead of constructing a new runtime per FFI call.
 //!
-//! **Constraint:** FFI callers must NOT call from a tokio thread, or
-//! `block_on` will panic. Platform callers (Swift main thread, C# .NET
-//! thread) are always safe.
+//! FFI functions bridge to async via [`block_on`], which drives the future on
+//! a dedicated worker thread — so it is safe to call from any platform thread
+//! (Swift main thread, C# .NET thread, or Apple's GCD pools). Only a *direct*
+//! `runtime().block_on(...)` (as in this module's tests) would panic if invoked
+//! from within a tokio worker thread.
 
 use std::future::Future;
 use std::sync::OnceLock;
@@ -50,7 +52,7 @@ pub fn runtime() -> &'static Runtime {
 /// locals (the S3 client, session, …) without requiring `'static`, and the
 /// owned thread is never a tokio worker, so `block_on` cannot panic on it.
 ///
-/// ponytail: one short-lived OS thread per FFI call. These calls are network
+/// Tradeoff: one short-lived OS thread per FFI call. These calls are network
 /// round-trips (ms+), so the ~µs spawn cost is noise. If call volume ever makes
 /// it matter, replace with a single long-lived big-stack driver thread fed via
 /// a channel.
@@ -89,11 +91,15 @@ mod tests {
 
     #[test]
     fn test_block_on_drives_to_completion_and_borrows_locals() {
-        // The future borrows a local (`&name`) — proving `block_on` works
-        // without a `'static` bound, which is why FFI call sites can pass
-        // futures that borrow the S3 client / session.
+        // The future captures a borrow of a local (`&name`), so it is not
+        // `'static` — proving `block_on` accepts futures that borrow caller
+        // state, which is why FFI call sites can pass futures borrowing the S3
+        // client / session. `name` remaining usable afterwards confirms the
+        // borrow was scoped to the call, not moved away.
         let name = String::from("ds3");
-        let out = block_on(async { format!("{}-{}", name, 40 + 2) });
+        let borrowed = &name;
+        let out = block_on(async move { format!("{}-{}", borrowed, 40 + 2) });
         assert_eq!(out, "ds3-42");
+        assert_eq!(name, "ds3");
     }
 }

--- a/core/ds3-ffi/src/handles.rs
+++ b/core/ds3-ffi/src/handles.rs
@@ -8,8 +8,19 @@
 //! `block_on` will panic. Platform callers (Swift main thread, C# .NET
 //! thread) are always safe.
 
+use std::future::Future;
 use std::sync::OnceLock;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
+
+/// Stack size for the runtime's worker threads and the `block_on` driver
+/// thread.
+///
+/// tokio's default worker stack is 2 MiB. The aws-smithy S3 endpoint-resolution
+/// and orchestrator chain is extremely deep and monomorphizes into large stack
+/// frames — in debug builds it overflows a 2 MiB stack and faults
+/// (`EXC_BAD_ACCESS` inside `resolve_endpoint`). 8 MiB matches the platform
+/// main-thread default and gives ample headroom; harmless in release.
+const WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
 
 /// Returns a reference to the shared tokio runtime.
 ///
@@ -18,7 +29,45 @@ use tokio::runtime::Runtime;
 /// execute async Rust code.
 pub fn runtime() -> &'static Runtime {
     static RT: OnceLock<Runtime> = OnceLock::new();
-    RT.get_or_init(|| Runtime::new().expect("Failed to create tokio runtime"))
+    RT.get_or_init(|| {
+        Builder::new_multi_thread()
+            .enable_all()
+            .thread_stack_size(WORKER_STACK_SIZE)
+            .build()
+            .expect("Failed to create tokio runtime")
+    })
+}
+
+/// Drives `future` to completion, blocking the caller, and returns its output.
+///
+/// FFI callers reach us from Apple's GCD / Swift-concurrency cooperative thread
+/// pool (`com.apple.root.*.cooperative`), whose threads have small (~512 KiB)
+/// stacks. `Runtime::block_on` polls the root future on the *calling* thread,
+/// and the aws-smithy S3 endpoint-resolution chain is deep enough (especially
+/// in debug builds) to overflow that stack — faulting with `EXC_BAD_ACCESS`
+/// inside `resolve_endpoint`. We drive the future on an owned thread with a
+/// large stack instead. `std::thread::scope` lets the future borrow caller
+/// locals (the S3 client, session, …) without requiring `'static`, and the
+/// owned thread is never a tokio worker, so `block_on` cannot panic on it.
+///
+/// ponytail: one short-lived OS thread per FFI call. These calls are network
+/// round-trips (ms+), so the ~µs spawn cost is noise. If call volume ever makes
+/// it matter, replace with a single long-lived big-stack driver thread fed via
+/// a channel.
+pub fn block_on<F>(future: F) -> F::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .name("ds3-block-on".into())
+            .stack_size(WORKER_STACK_SIZE)
+            .spawn_scoped(scope, move || runtime().block_on(future))
+            .expect("failed to spawn block_on driver thread")
+            .join()
+            .expect("block_on driver thread panicked")
+    })
 }
 
 #[cfg(test)]
@@ -36,5 +85,15 @@ mod tests {
     fn test_runtime_can_block_on() {
         let result = runtime().block_on(async { 42 });
         assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn test_block_on_drives_to_completion_and_borrows_locals() {
+        // The future borrows a local (`&name`) — proving `block_on` works
+        // without a `'static` bound, which is why FFI call sites can pass
+        // futures that borrow the S3 client / session.
+        let name = String::from("ds3");
+        let out = block_on(async { format!("{}-{}", name, 40 + 2) });
+        assert_eq!(out, "ds3-42");
     }
 }

--- a/core/ds3-ffi/src/uniffi_exports.rs
+++ b/core/ds3-ffi/src/uniffi_exports.rs
@@ -1,8 +1,8 @@
 //! UniFFI exported functions for Swift bindings.
 //!
 //! `DS3SessionHandle` is an opaque UniFFI Object that wraps the authenticated
-//! `DS3Session`. All methods use the shared tokio runtime via `handles::runtime()`
-//! to bridge async Rust code to blocking FFI calls.
+//! `DS3Session`. All methods bridge async Rust to blocking FFI calls via
+//! `handles::block_on()`.
 //!
 //! Function groups:
 //! - Auth (9): authenticate, verify_2fa, refresh_token, forge_iam_token,

--- a/core/ds3-ffi/src/uniffi_exports.rs
+++ b/core/ds3-ffi/src/uniffi_exports.rs
@@ -27,7 +27,7 @@ use ds3_models::{
 use ds3_s3::DS3S3Client;
 
 use crate::cancellation::CancellationHandle;
-use crate::handles::runtime;
+use crate::handles::block_on;
 use crate::progress::ProgressCallback;
 
 /// Opaque session handle exposed to Swift via UniFFI.
@@ -62,7 +62,7 @@ impl DS3SessionHandle {
         tenant_id: Option<String>,
         coordinator_url: Option<String>,
     ) -> Result<Arc<Self>, DS3Error> {
-        let session = runtime().block_on(DS3Session::authenticate(
+        let session = block_on(DS3Session::authenticate(
             &email,
             &password,
             tenant_id.as_deref(),
@@ -83,7 +83,7 @@ impl DS3SessionHandle {
         tenant_id: Option<String>,
         coordinator_url: Option<String>,
     ) -> Result<Arc<Self>, DS3Error> {
-        let session = runtime().block_on(DS3Session::authenticate_with_2fa(
+        let session = block_on(DS3Session::authenticate_with_2fa(
             &email,
             &password,
             &tfa_code,
@@ -122,13 +122,13 @@ impl DS3SessionHandle {
     /// Refreshes the access token if expired.
     pub fn refresh_token(&self) -> Result<(), DS3Error> {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
-        runtime().block_on(session.refresh_if_needed())
+        block_on(session.refresh_if_needed())
     }
 
     /// Forges an IAM-scoped token for the specified user ID.
     pub fn forge_iam_token(&self, user_id: String) -> Result<Token, DS3Error> {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
-        runtime().block_on(session.forge_iam_token(&user_id))
+        block_on(session.forge_iam_token(&user_id))
     }
 
     /// Returns the authenticated account information.
@@ -144,7 +144,7 @@ impl DS3SessionHandle {
     /// Persistence Boundary", D-04/D-06).
     pub fn current_session(&self) -> Result<AccountSession, DS3Error> {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
-        Ok(runtime().block_on(session.current_session()))
+        Ok(block_on(session.current_session()))
     }
 
     /// Initializes the S3 client for this session with the given credentials.
@@ -178,7 +178,7 @@ impl DS3SessionHandle {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
         self.refresh_token()?;
         let token = self.current_token()?;
-        runtime().block_on(ds3_http::projects::get_projects(
+        block_on(ds3_http::projects::get_projects(
             &session.http,
             &session.urls,
             &token,
@@ -192,7 +192,7 @@ impl DS3SessionHandle {
         iam_token: String,
     ) -> Result<Vec<DS3ApiKey>, DS3Error> {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
-        runtime().block_on(ds3_http::keys::load_api_keys(
+        block_on(ds3_http::keys::load_api_keys(
             &session.http,
             &session.urls,
             &iam_token,
@@ -208,7 +208,7 @@ impl DS3SessionHandle {
         iam_token: String,
     ) -> Result<DS3ApiKey, DS3Error> {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
-        runtime().block_on(ds3_http::keys::create_api_key(
+        block_on(ds3_http::keys::create_api_key(
             &session.http,
             &session.urls,
             &iam_token,
@@ -225,7 +225,7 @@ impl DS3SessionHandle {
         iam_token: String,
     ) -> Result<(), DS3Error> {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
-        runtime().block_on(ds3_http::keys::delete_api_key(
+        block_on(ds3_http::keys::delete_api_key(
             &session.http,
             &session.urls,
             &iam_token,
@@ -250,7 +250,7 @@ impl DS3SessionHandle {
         continuation_token: Option<String>,
     ) -> Result<S3ListingResult, DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.list_objects(
+        block_on(client.list_objects(
             &bucket,
             prefix.as_deref(),
             delimiter.as_deref(),
@@ -262,7 +262,7 @@ impl DS3SessionHandle {
     /// Lists all buckets accessible with the current S3 credentials.
     pub fn list_buckets(&self) -> Result<Vec<BucketInfo>, DS3Error> {
         let client = self.require_s3()?;
-        let raw = runtime().block_on(client.list_buckets())?;
+        let raw = block_on(client.list_buckets())?;
         Ok(raw
             .into_iter()
             .map(|(name, creation_date)| BucketInfo {
@@ -275,7 +275,7 @@ impl DS3SessionHandle {
     /// Returns metadata for a single S3 object (HeadObject).
     pub fn head_object(&self, bucket: String, key: String) -> Result<S3ObjectMetadata, DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.head_object(&bucket, &key))
+        block_on(client.head_object(&bucket, &key))
     }
 
     /// Downloads an S3 object to a local file path.
@@ -295,7 +295,7 @@ impl DS3SessionHandle {
         let path = Path::new(&file_path);
         let callback = wrap_progress_callback(progress);
 
-        runtime().block_on(client.download_object(&bucket, &key, path, callback.as_deref()))
+        block_on(client.download_object(&bucket, &key, path, callback.as_deref()))
     }
 
     /// Uploads a local file to S3. Returns the ETag on success (if provided by S3).
@@ -317,19 +317,19 @@ impl DS3SessionHandle {
         let token: Option<Arc<dyn ds3_s3::CancelToken>> =
             cancel_token.map(|h| h as Arc<dyn ds3_s3::CancelToken>);
 
-        runtime().block_on(client.upload_object(&bucket, &key, path, callback.as_deref(), token))
+        block_on(client.upload_object(&bucket, &key, path, callback.as_deref(), token))
     }
 
     /// Deletes a single S3 object.
     pub fn delete_object(&self, bucket: String, key: String) -> Result<(), DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.delete_object(&bucket, &key))
+        block_on(client.delete_object(&bucket, &key))
     }
 
     /// Deletes multiple S3 objects. Returns the count of successfully deleted objects.
     pub fn delete_objects(&self, bucket: String, keys: Vec<String>) -> Result<i32, DS3Error> {
         let client = self.require_s3()?;
-        let count = runtime().block_on(client.delete_objects(&bucket, &keys))?;
+        let count = block_on(client.delete_objects(&bucket, &keys))?;
         Ok(count as i32)
     }
 
@@ -346,7 +346,7 @@ impl DS3SessionHandle {
         metadata: Option<HashMap<String, String>>,
     ) -> Result<(), DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.copy_object(&bucket, &source_key, &dest_key, metadata.as_ref()))
+        block_on(client.copy_object(&bucket, &source_key, &dest_key, metadata.as_ref()))
     }
 
     /// Downloads an S3 object directly to an in-memory `Vec<u8>`.
@@ -355,7 +355,7 @@ impl DS3SessionHandle {
     /// For large files, use `download_object` which streams to a file path.
     pub fn download_to_memory(&self, bucket: String, key: String) -> Result<Vec<u8>, DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.download_to_memory(&bucket, &key))
+        block_on(client.download_to_memory(&bucket, &key))
     }
 
     /// Uploads an in-memory `Vec<u8>` to S3 with optional custom metadata.
@@ -370,7 +370,7 @@ impl DS3SessionHandle {
         metadata: HashMap<String, String>,
     ) -> Result<Option<String>, DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.upload_from_memory(&bucket, &key, data, metadata))
+        block_on(client.upload_from_memory(&bucket, &key, data, metadata))
     }
 
     /// Generates a presigned GET URL for an S3 object.
@@ -385,7 +385,7 @@ impl DS3SessionHandle {
         expires_in_seconds: i64,
     ) -> Result<String, DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.presign_get(&bucket, &key, expires_in_seconds))
+        block_on(client.presign_get(&bucket, &key, expires_in_seconds))
     }
 
     /// Generates a presigned PUT URL for a multipart upload part.
@@ -402,7 +402,7 @@ impl DS3SessionHandle {
         expires_in_seconds: i64,
     ) -> Result<String, DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.presign_upload_part(
+        block_on(client.presign_upload_part(
             &bucket,
             &key,
             &upload_id,
@@ -418,13 +418,13 @@ impl DS3SessionHandle {
         folder_key: String,
     ) -> Result<bool, DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.probe_folder_exists(&bucket, &folder_key))
+        block_on(client.probe_folder_exists(&bucket, &folder_key))
     }
 
     /// Creates a .ds3keep folder marker for the given folder key.
     pub fn create_folder_marker(&self, bucket: String, folder_key: String) -> Result<(), DS3Error> {
         let client = self.require_s3()?;
-        runtime().block_on(client.create_folder_marker(&bucket, &folder_key))
+        block_on(client.create_folder_marker(&bucket, &folder_key))
     }
 }
 
@@ -448,7 +448,7 @@ pub fn get_challenge(
         None => CubbitAPIURLs::default_coordinator(),
     };
     let http = SharedHttpClient::new()?;
-    runtime().block_on(auth_get_challenge(
+    block_on(auth_get_challenge(
         &http,
         &urls,
         &email,
@@ -576,7 +576,7 @@ impl DS3SessionHandle {
     /// Returns the current access token string.
     fn current_token(&self) -> Result<String, DS3Error> {
         let session = self.session.as_ref().ok_or(DS3Error::LoggedOut)?;
-        let inner = runtime().block_on(session.session.lock());
+        let inner = block_on(session.session.lock());
         Ok(inner.token.token.clone())
     }
 

--- a/core/scripts/build-xcframework.sh
+++ b/core/scripts/build-xcframework.sh
@@ -21,6 +21,55 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Locate the Rust toolchain.
+# Xcode's Run Script Phase runs with a sanitized PATH that omits wherever cargo
+# was installed. Probe the common locations — rustup (~/.cargo/bin), Nix
+# profiles, and Homebrew — so the build works regardless of how Rust was set up,
+# on developer machines and in CI alike.
+# ---------------------------------------------------------------------------
+if ! command -v cargo >/dev/null 2>&1; then
+    for dir in \
+        "$HOME/.cargo/bin" \
+        "$HOME/.nix-profile/bin" \
+        "/etc/profiles/per-user/${USER:-$(id -un)}/bin" \
+        "/run/current-system/sw/bin" \
+        "/nix/var/nix/profiles/default/bin" \
+        "/opt/homebrew/bin" \
+        "/usr/local/bin"; do
+        [ -x "$dir/cargo" ] && PATH="$dir:$PATH"
+    done
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "error: cargo not found. Install Rust (https://rustup.rs) or add it to PATH." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Normalize the compiler/SDK environment for cross-compilation.
+#
+# Inside an Xcode Run Script Phase, Xcode injects vars (SDKROOT, CFLAGS, …)
+# pinned to the host app's single platform. Left alone they contaminate every
+# cargo target's C builds (ring, aws-lc-sys): an `-isysroot <wrong-sdk>` breaks
+# the compile outright.
+#
+#   * Clear the flag vars — a leaked `-isysroot` in CFLAGS would override the
+#     SDKROOT we set below.
+#   * Pin SDKROOT to the macOS SDK as the default. cc-rs needs a sysroot to find
+#     system headers (<stdio.h>, <TargetConditionals.h>); this covers the macOS
+#     target build AND the host `uniffi-bindgen` tooling build (a plain
+#     `cargo run`, no --target) further down. iOS target builds override this to
+#     *no* SDKROOT per command in the loop, because aws-lc-sys' cmake builder
+#     derives the iOS SDK itself and a forced SDKROOT breaks it.
+#
+# No effect when run from a clean shell beyond making the macOS SDK explicit
+# (e.g. CI), which is harmless.
+# ---------------------------------------------------------------------------
+unset CC CXX CFLAGS CXXFLAGS CPPFLAGS LDFLAGS \
+      CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH \
+      MACOSX_DEPLOYMENT_TARGET IPHONEOS_DEPLOYMENT_TARGET 2>/dev/null || true
+export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+
+# ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 CRATE_NAME="ds3_ffi"
@@ -58,25 +107,24 @@ echo "==> Building ds3-ffi for ${#TARGETS[@]} targets (${BUILD_PROFILE})..."
 # ---------------------------------------------------------------------------
 for target in "${TARGETS[@]}"; do
     echo "    Building for ${target}..."
-    # Set deployment targets for iOS/simulator to avoid __chkstk_darwin
-    # linker errors from aws-lc-sys (macOS-only symbol).
-    # aws-lc-sys requires cmake builder for iOS cross-compilation.
-    # The default build uses macOS-only __chkstk_darwin symbol.
+    # iOS/simulator need a deployment target + the aws-lc-sys cmake builder to
+    # avoid the macOS-only __chkstk_darwin symbol. The cmake builder derives the
+    # iOS SDK itself, so we run its cargo build with NO SDKROOT (CARGO_ENV_PREFIX
+    # = `env -u SDKROOT`) — a forced/leaked SDKROOT breaks it. The macOS target
+    # inherits the macOS SDKROOT set above (cc_builder needs the sysroot).
+    CARGO_ENV_PREFIX=""
     case "${target}" in
-        aarch64-apple-ios)
+        aarch64-apple-ios|aarch64-apple-ios-sim|x86_64-apple-ios)
             export IPHONEOS_DEPLOYMENT_TARGET="17.0"
             export AWS_LC_SYS_CMAKE_BUILDER=1
-            ;;
-        aarch64-apple-ios-sim|x86_64-apple-ios)
-            export IPHONEOS_DEPLOYMENT_TARGET="17.0"
-            export AWS_LC_SYS_CMAKE_BUILDER=1
+            CARGO_ENV_PREFIX="env -u SDKROOT"
             ;;
         aarch64-apple-darwin)
             export MACOSX_DEPLOYMENT_TARGET="15.0"
             unset AWS_LC_SYS_CMAKE_BUILDER 2>/dev/null || true
             ;;
     esac
-    cargo build --manifest-path "${CARGO_MANIFEST}" \
+    ${CARGO_ENV_PREFIX} cargo build --manifest-path "${CARGO_MANIFEST}" \
         --package ds3-ffi \
         ${CARGO_PROFILE_FLAG} \
         --target "${target}"

--- a/core/scripts/build-xcframework.sh
+++ b/core/scripts/build-xcframework.sh
@@ -36,7 +36,14 @@ if ! command -v cargo >/dev/null 2>&1; then
         "/nix/var/nix/profiles/default/bin" \
         "/opt/homebrew/bin" \
         "/usr/local/bin"; do
-        [ -x "$dir/cargo" ] && PATH="$dir:$PATH"
+        # Stop at the first match so the probe order = priority order (rustup
+        # first). Without break, the LAST match would be prepended last and win,
+        # inverting priority and possibly selecting a cargo that lacks the iOS
+        # `rustup target add` targets.
+        if [ -x "$dir/cargo" ]; then
+            PATH="$dir:$PATH"
+            break
+        fi
     done
 fi
 if ! command -v cargo >/dev/null 2>&1; then


### PR DESCRIPTION
Fresh macOS Xcode builds of DS3 Drive failed to build the Rust core, and once building, the app crashed while browsing buckets. Three distinct root causes, all fixed in shared `core/` so they hold on developer machines and in CI.

## Fixes

**1. `cargo: command not found` in the Run Script Phase**
Xcode's script phase gets a sanitized PATH. The script assumed `~/.cargo/bin`, but cargo may live elsewhere (Nix, Homebrew). `build-xcframework.sh` now probes rustup/Nix/Homebrew locations and stops at the first match (priority order = rustup first), with a clear error if cargo is truly absent.

**2. `ring` / `aws-lc-sys` fail to build (`'TargetConditionals.h' file not found`)**
Xcode leaks a single-platform `SDKROOT` into every cargo target's C build. Fix:
- Default `SDKROOT` to the **macOS SDK** for the whole script — needed by the macOS target's cc_builder *and* the host `uniffi-bindgen` build (`cargo run`, no `--target`), both of which need a sysroot for system headers.
- Strip `SDKROOT` (`env -u SDKROOT`) only for the **iOS cmake builds** — aws-lc-sys's cmake builder derives its own SDK, and a forced/leaked `SDKROOT` breaks it.

**3. `EXC_BAD_ACCESS` (stack overflow) navigating buckets**
FFI calls arrive on Apple's GCD/Swift-concurrency cooperative pool (~512 KiB stacks). `runtime().block_on` drives the deep aws-smithy S3 endpoint resolver on that calling thread, overflowing it (`code=2` guard-page fault in `resolve_endpoint`). New `handles::block_on()` drives futures on an owned 8 MiB-stack thread via `std::thread::scope` (lets futures borrow non-`'static` locals); all 52 FFI call sites route through it. Runtime worker stack also bumped to 8 MiB.

## Verification
- `cargo check -p ds3-ffi` clean; new `block_on` unit test (borrowed-local future) passes.
- Cold build via real `xcodebuild -scheme DS3Drive` (Xcode's actual Run Script env, all C deps cleaned first): **BUILD SUCCEEDED**, all 4 targets + host, app + File Provider extension signed.
- Manually verified on device: build runs and bucket navigation no longer crashes.

## Notes
- No `pbxproj` changes — the fix lives entirely in the shared build script.
- Generated artifacts (Swift glue, C# bindings) intentionally not included.